### PR TITLE
Fix ATTEMPT_KICKOFF.md to point to HISTORY.md not hardcoded attempt

### DIFF
--- a/products/odd-teaser/prompts/ATTEMPT_KICKOFF.md
+++ b/products/odd-teaser/prompts/ATTEMPT_KICKOFF.md
@@ -2,7 +2,7 @@
 
 ## Step 1: Load Prior Learnings
 
-Read: `products/odd-teaser/attempts/v1.1/attempt-001/ATTEMPT.md`
+Read: `products/odd-teaser/HISTORY.md`
 
 This gives you process learnings — what failed, what to avoid.
 


### PR DESCRIPTION
Learnings must be reusable across attempts.

https://claude.ai/code/session_01EvEaDZQiERbpaEmpszUs7o

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk doc-only change that updates an internal prompt reference; no runtime code or data flow is affected.
> 
> **Overview**
> Updates `products/odd-teaser/prompts/ATTEMPT_KICKOFF.md` to load prior learnings from the reusable `products/odd-teaser/HISTORY.md` instead of a hardcoded attempt-specific `ATTEMPT.md` path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d2e11fccb2d48e81f84f54b8193a822bbd48cb43. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->