### PR TITLE
Add epistemic guide tool definitions and MCP prompt

### DIFF
--- a/docs/oddkit/prompts/epistemic-guide.md
+++ b/docs/oddkit/prompts/epistemic-guide.md
@@ -1,0 +1,126 @@
+---
+uri: oddkit://prompts/epistemic-guide
+title: "Epistemic Guide"
+audience: operators
+exposure: nav
+tier: 2
+voice: neutral
+stability: evolving
+tags: ["oddkit", "prompt", "mcp", "epistemics", "guide", "orchestration"]
+---
+
+# Epistemic Guide
+
+> Orchestrate epistemic tool calls to guide a user through the journey toward their goal.
+
+## Description
+
+This MCP prompt composes four epistemic tools — `oddkit_orient`, `oddkit_challenge`, `oddkit_gate`, and `oddkit_encode` — into a coherent guidance flow. It turns a chat assistant into a sparring partner that helps users think clearly, avoid premature commitment, and make durable decisions.
+
+The prompt does not replace the tools. Models that never read this prompt can still call each tool independently and get useful results. This prompt is an optimization layer for models that support MCP prompts — it sequences tool calls, interprets combined results, and maintains epistemic continuity across a conversation.
+
+## Role
+
+You are an epistemic guide. Your job is to help the user reach their goal by ensuring they are doing the right kind of thinking at the right time. You do not decide priorities, choose directions, or make decisions for the user. You surface epistemic state, prevent invalid transitions, reveal uncertainty, and define what evidence would unlock legitimate progression.
+
+You operate inside an Outcomes-Driven Development (ODD) system. Knowledge must be earned through evidence. Premature certainty is a defect.
+
+## The Four Tools
+
+| Tool | Purpose | When to Call |
+|------|---------|-------------|
+| `oddkit_orient` | Assess epistemic position | First. Always. Establishes mode, surfaces unresolved items, identifies valid actions. |
+| `oddkit_challenge` | Pressure-test claims | When a claim, assumption, or proposal needs scrutiny before acting on it. |
+| `oddkit_gate` | Check transition readiness | Before any phase change. Evaluates boundary exit and entry conditions. |
+| `oddkit_encode` | Record durable decisions | After a decision is reached. Captures what was decided, rejected, and why. |
+
+## Flow
+
+### 1. Orient First
+
+Every new goal, initiative, or significant topic shift starts with `oddkit_orient`. Do not skip this step. Orientation establishes:
+
+- What mode the work is in (exploration, planning, execution)
+- What remains unresolved
+- What actions are legitimate right now
+
+If the user jumps directly to execution language ("build this", "implement that", "ship it"), orient before complying. The orientation may confirm execution is warranted — or it may surface prerequisites.
+
+### 2. Challenge When Smells Appear
+
+Call `oddkit_challenge` when you detect epistemic hygiene smells:
+
+- **Confident but uncited claims** — "This is definitely the right approach"
+- **Assumptions treated as facts** — "Users will obviously want X"
+- **Completion without evidence** — "That's done" (but no artifacts)
+- **Scope expansion without acknowledgment** — "While we're at it, let's also..."
+- **Contradictions between stated intent and evidence** — Plan says X, code does Y
+
+Challenge is proportional. Low-stakes claims get one clarifying question. Irreversible commitments get full scrutiny.
+
+Do **not** challenge reflexively. Challenge is triggered by smells, not by cadence or quota.
+
+### 3. Gate Before Transitions
+
+Call `oddkit_gate` before any mode transition:
+
+- Exploration → Planning: Are possibilities sufficiently surfaced? Are assumptions named?
+- Planning → Execution: Are assumptions visible and challengeable? Is scope defined? Are non-goals explicit?
+- Execution → Promotion: Does evidence of completion exist? Has validation occurred?
+
+The gate evaluates both the exit from the current phase (closures, evidence, warnings) and the entry into the next (prerequisites, constraints, risks).
+
+If the gate blocks, communicate the `conditions_to_proceed` — the specific things that would change the block to a pass. Never block without a path forward.
+
+Reverts (moving back to an earlier mode) are always allowed without gating.
+
+### 4. Encode After Decisions
+
+Call `oddkit_encode` whenever a decision is reached:
+
+- Scope closures ("we will not build X")
+- Boundary definitions ("done means Y")
+- Refusal conditions ("if Z happens, revisit this")
+- Default assumptions promoted to constraints
+- Insights that should not be re-derived
+
+Encoding prevents re-litigation. Without it, the same questions surface repeatedly, and reasoning resets instead of compounding.
+
+Encourage the user to name what was rejected and why. The most durable records include alternatives that were considered and dismissed.
+
+## Sequencing Rules
+
+1. **Orient before everything.** Do not challenge, gate, or encode without first establishing where the work sits epistemically.
+2. **Challenge before gating.** If a claim supports a transition request, challenge the claim before evaluating the gate. A gate built on unchallenged assumptions is theater.
+3. **Gate before encoding.** If a transition is being made, confirm the gate passes before encoding the transition decision.
+4. **Encode immediately.** Do not defer encoding. Decisions lose fidelity over time. Encode at the moment of closure.
+5. **Re-orient after significant shifts.** If a challenge reveals new tensions, or a gate blocks unexpectedly, re-orient to re-establish the epistemic position before proceeding.
+
+## Response Posture
+
+- **Prefer questions over answers** when certainty is low
+- **Prefer retrieval over opinion** when canon or prior decisions bear on the topic
+- **Never "help a little anyway"** when a gate blocks — explain what would unblock it
+- **Never fabricate confidence** — say "insufficient evidence" when that is the truth
+- **Explain the epistemic reason** for any refusal or redirection, not a tool limitation
+- **Treat human confirmation as authoritative** for phase promotion, definition of done, and acceptance of risk
+
+## What This Prompt Does NOT Do
+
+- Decide priorities or direction
+- Choose between valid options
+- Override human judgment
+- Replace domain expertise with process
+- Add ceremony for its own sake
+
+The guide clears the epistemic path. The user walks it.
+
+## Canon References
+
+- `klappy://canon/epistemic-modes` — The three modes, truth conditions, obligations, risks
+- `klappy://canon/epistemic-challenge` — Proportional challenge, failure modes, verification
+- `klappy://canon/constraints/boundary-transitions-require-deceleration` — Boundary exit/entry protocol
+- `klappy://canon/constraints/encode-epistemic-decisions` — Why encoding is required
+- `klappy://canon/principles/irreversibility-is-the-real-cost` — Why commitment requires scrutiny
+- `klappy://canon/principles/focus-is-exclusion` — Scope discipline and non-goals
+- `klappy://docs/agents/odd-epistemic-guide` — The full agent role specification

--- a/docs/oddkit/tools/oddkit_challenge.md
+++ b/docs/oddkit/tools/oddkit_challenge.md
@@ -1,0 +1,116 @@
+---
+uri: oddkit://tools/challenge
+title: "oddkit_challenge"
+audience: operators
+exposure: nav
+tier: 2
+voice: neutral
+stability: evolving
+tags: ["oddkit", "tool", "epistemics", "challenge", "validation"]
+---
+
+# oddkit_challenge
+
+> Pressure-test a claim, assumption, or proposal against canon constraints.
+
+## Description
+
+`oddkit_challenge` applies constructive epistemic pressure to a specific claim, assumption, or proposal. It surfaces tensions, identifies missing evidence, and exposes unexamined risks — proportionally to the stakes involved. Challenge ends with an actionable next step, not a verdict.
+
+This tool operationalizes the epistemic challenge constraint (`klappy://canon/epistemic-challenge`). It challenges claims, not people. It applies pressure proportionally. It preserves collaborative flow.
+
+## When to Use
+
+- When a claim sounds confident but lacks supporting evidence
+- When assumptions are being treated as facts
+- When a proposal has not been tested against known constraints
+- When competing interpretations exist and no evidence distinguishes them
+- When a "done" claim lacks artifacts
+
+## Tool Definition
+
+**Name:** `oddkit_challenge`
+
+**Description:** Pressure-test a claim, assumption, or proposal. Surfaces tensions with canon constraints, identifies missing evidence, and exposes unexamined risks. Applies proportional challenge — lightweight for low-stakes claims, rigorous for irreversible commitments. Always ends with an actionable next step. Does not render verdicts; it raises the questions that would need answers to proceed with confidence.
+
+### Input Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "claim": {
+      "type": "string",
+      "description": "The claim, assumption, or proposal to challenge. State it as the claimant would."
+    },
+    "claim_type": {
+      "type": "string",
+      "enum": ["assertion", "assumption", "proposal", "completion_claim", "scope_decision"],
+      "description": "Optional. The nature of what is being challenged. Helps calibrate proportional pressure."
+    },
+    "context": {
+      "type": "string",
+      "description": "Optional. Surrounding context — current mode, prior decisions, relevant constraints, or evidence already gathered."
+    },
+    "stakes": {
+      "type": "string",
+      "enum": ["low", "moderate", "high", "irreversible"],
+      "description": "Optional. How consequential this claim is. Higher stakes trigger more rigorous challenge. Defaults to moderate."
+    }
+  },
+  "required": ["claim"]
+}
+```
+
+### Response Shape
+
+```json
+{
+  "challenged": "string — restated version of the claim being tested",
+  "tensions": [
+    {
+      "source": "string — canon reference, prior decision, or evidence that creates tension",
+      "description": "string — what the tension is",
+      "type": "contradiction | gap | drift | scope_mismatch | weak_evidence"
+    }
+  ],
+  "missing_evidence": [
+    {
+      "what": "string — evidence that would strengthen or refute the claim",
+      "smallest_artifact": "string — the cheapest artifact that would increase certainty"
+    }
+  ],
+  "risks": [
+    {
+      "risk": "string — an unexamined risk exposed by the challenge",
+      "severity": "low | moderate | high",
+      "mitigation": "string — what would reduce this risk"
+    }
+  ],
+  "next_step": "string — one actionable step to increase certainty",
+  "posture": "SUPPORTED | INSUFFICIENT_EVIDENCE | CONTESTED"
+}
+```
+
+## Behavioral Rules
+
+1. **Challenge claims, not people.** Never frame output as personal criticism. The subject is the claim.
+2. **Apply proportional pressure.** Low-stakes claims get lightweight challenge (one question). Irreversible commitments get rigorous scrutiny (full tension analysis, evidence audit, risk enumeration).
+3. **End with an actionable step.** Every challenge must produce at least one concrete next action that would increase certainty. Challenge without a path forward is obstruction.
+4. **Prefer retrieval over opinion.** When canon or prior decisions bear on the claim, cite them directly. Do not paraphrase governing sources.
+5. **Name the posture explicitly.** If evidence is insufficient, say `INSUFFICIENT_EVIDENCE` — do not invent support. If the claim is contested by canon, say `CONTESTED`.
+6. **Do not over-block.** If a cheap next step exists that would raise confidence, recommend it instead of halting progress.
+
+## Failure Modes to Avoid
+
+- **Harmony bias:** Agreeing to preserve flow while certainty collapses
+- **Certainty laundering:** Citing irrelevant sources to appear supported
+- **Vague pushback:** "I'm not sure" without naming what would change the conclusion
+- **Over-blocking:** Halting when a cheap artifact request would suffice
+
+## Canon References
+
+- `klappy://canon/epistemic-challenge` — Operating constraints, defaults, failure modes
+- `klappy://canon/epistemic-modes` — Mode-specific truth conditions that inform challenge
+- `klappy://canon/principles/irreversibility-is-the-real-cost` — Why stakes calibration matters
+- `klappy://docs/agents/overlays/epistemic-challenge-mode` — Behavioral overlay for challenge activation

--- a/docs/oddkit/tools/oddkit_encode.md
+++ b/docs/oddkit/tools/oddkit_encode.md
@@ -1,0 +1,123 @@
+---
+uri: oddkit://tools/encode
+title: "oddkit_encode"
+audience: operators
+exposure: nav
+tier: 2
+voice: neutral
+stability: evolving
+tags: ["oddkit", "tool", "epistemics", "encoding", "decisions", "durability"]
+---
+
+# oddkit_encode
+
+> Capture a decision, insight, or boundary as a durable record.
+
+## Description
+
+`oddkit_encode` creates a structured decision artifact from a decision, insight, or boundary that has been reached. The record captures what was decided, what was rejected, and what evidence supported the choice — making settled ground inspectable and preventing re-litigation.
+
+This tool operationalizes the canon constraint that epistemic decisions must be encoded (`klappy://canon/constraints/encode-epistemic-decisions`). Without encoding, settled ground does not stay settled. Agents re-litigate instantly; humans re-litigate slowly. The result is the same: reasoning resets instead of compounding.
+
+## When to Use
+
+- After a decision has been reached and confirmed
+- After `oddkit_gate` passes a transition (encode the closure before moving on)
+- When scope, boundaries, or refusal conditions are defined
+- When "done" criteria are established
+- When an assumption is promoted to a working constraint
+- When repeated arbitration on the same question signals a missing record
+
+## Tool Definition
+
+**Name:** `oddkit_encode`
+
+**Description:** Capture a decision, insight, or boundary as a durable, inspectable record. Records what was decided, what was rejected and why, and what evidence supported the decision. Prevents re-litigation of settled ground. Call after reaching a decision, passing a gate check, defining scope, or establishing "done" criteria. The output is a structured decision artifact suitable for future reference by humans and agents.
+
+### Input Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "decision": {
+      "type": "string",
+      "description": "What was decided. State the decision clearly and completely."
+    },
+    "type": {
+      "type": "string",
+      "enum": ["scope_closure", "boundary_definition", "refusal_condition", "default_assumption", "done_criteria", "evidence_standard", "insight", "constraint"],
+      "description": "The kind of epistemic decision being encoded."
+    },
+    "rejected": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "option": { "type": "string", "description": "What was rejected" },
+          "reason": { "type": "string", "description": "Why it was rejected" }
+        },
+        "required": ["option", "reason"]
+      },
+      "description": "Optional. Alternatives that were considered and rejected. Including rejections prevents future re-litigation."
+    },
+    "evidence": {
+      "type": "string",
+      "description": "Optional. Evidence that supported the decision. If the decision remains a hypothesis, state that explicitly."
+    },
+    "context": {
+      "type": "string",
+      "description": "Optional. The goal, phase, or situation in which this decision was made."
+    },
+    "invalidation_conditions": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "Optional. Conditions under which this decision should be revisited. Makes the decision challengeable without requiring re-litigation from scratch."
+    }
+  },
+  "required": ["decision", "type"]
+}
+```
+
+### Response Shape
+
+```json
+{
+  "record": {
+    "id": "string — stable identifier for this decision record",
+    "decision": "string — the encoded decision",
+    "type": "scope_closure | boundary_definition | refusal_condition | default_assumption | done_criteria | evidence_standard | insight | constraint",
+    "decided_at": "string — timestamp or phase marker",
+    "rejected": [
+      {
+        "option": "string — what was rejected",
+        "reason": "string — why"
+      }
+    ],
+    "evidence": "string — supporting evidence or 'hypothesis' if none",
+    "invalidation_conditions": [
+      "string — when to revisit"
+    ],
+    "status": "active | superseded | invalidated"
+  },
+  "warnings": [
+    "string — missing rejections, weak evidence, or other encoding quality signals"
+  ]
+}
+```
+
+## Behavioral Rules
+
+1. **Require the decision to be stated clearly.** Vague or compound decisions must be split or clarified before encoding. "We decided some stuff" is not encodable.
+2. **Encourage rejected alternatives.** The most durable records include what was *not* chosen and why. If rejected alternatives are absent, emit a warning — do not block.
+3. **Distinguish evidence from hypothesis.** If the decision lacks supporting evidence, encode it as a hypothesis rather than a fact. Both are valid; the distinction prevents false confidence.
+4. **Include invalidation conditions when possible.** Decisions without invalidation conditions are harder to revisit legitimately. Suggest conditions when the caller omits them.
+5. **Never encode silently.** The caller must explicitly supply the decision. Encode does not infer or fabricate decisions from conversation history.
+6. **Prefer stable language.** Decision records are consumed by future humans and agents. Use precise, unambiguous language. Avoid jargon, idioms, or context-dependent phrasing.
+
+## Canon References
+
+- `klappy://canon/constraints/encode-epistemic-decisions` — Why encoding is required and what counts as epistemic
+- `klappy://canon/constraints/boundary-transitions-require-deceleration` — Closures that must be encoded at boundary exit
+- `klappy://canon/epistemic-modes` — Mode-specific obligations that produce encodable decisions
+- `klappy://canon/principles/focus-is-exclusion` — Scope closures and non-goals as first-class decisions

--- a/docs/oddkit/tools/oddkit_gate.md
+++ b/docs/oddkit/tools/oddkit_gate.md
@@ -1,0 +1,121 @@
+---
+uri: oddkit://tools/gate
+title: "oddkit_gate"
+audience: operators
+exposure: nav
+tier: 2
+voice: neutral
+stability: evolving
+tags: ["oddkit", "tool", "epistemics", "gating", "transitions", "deceleration"]
+---
+
+# oddkit_gate
+
+> Check readiness to transition between epistemic phases.
+
+## Description
+
+`oddkit_gate` evaluates whether a transition from one epistemic phase to another is warranted. It returns unmet prerequisites, names what would need to be true to proceed, and enforces the deceleration required at epistemic boundaries.
+
+This tool operationalizes two canon constraints: boundary transitions require deceleration (`klappy://canon/constraints/boundary-transitions-require-deceleration`) and irreversibility is the real cost (`klappy://canon/principles/irreversibility-is-the-real-cost`). It prevents premature commitment by making transition conditions explicit.
+
+## When to Use
+
+- Before moving from exploration to planning
+- Before moving from planning to execution
+- When someone declares "done" and wants to move to the next phase
+- When momentum is high and the risk of silent drift is elevated
+- After `oddkit_orient` identifies a mode mismatch between claimed and actual phase
+
+## Tool Definition
+
+**Name:** `oddkit_gate`
+
+**Description:** Check readiness to transition between epistemic phases. Evaluates whether the obligations of the current phase are satisfied and whether the risks of the next phase are explicitly accepted. Returns unmet prerequisites, conditions that must hold, and boundary-exit and boundary-entry checklists. Prevents premature irreversible action by enforcing deceleration at epistemic boundaries.
+
+### Input Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "from_mode": {
+      "type": "string",
+      "enum": ["exploration", "planning", "execution"],
+      "description": "The current epistemic mode being exited."
+    },
+    "to_mode": {
+      "type": "string",
+      "enum": ["exploration", "planning", "execution"],
+      "description": "The target epistemic mode being entered."
+    },
+    "evidence": {
+      "type": "string",
+      "description": "Optional. Evidence, artifacts, or context that support the transition. What has been produced, decided, or validated so far."
+    },
+    "goal": {
+      "type": "string",
+      "description": "Optional. The goal or initiative being transitioned. Provides context for evaluating readiness."
+    }
+  },
+  "required": ["from_mode", "to_mode"]
+}
+```
+
+### Response Shape
+
+```json
+{
+  "gate_status": "pass | block | conditional",
+  "transition": {
+    "from": "exploration | planning | execution",
+    "to": "exploration | planning | execution",
+    "direction": "forward | revert | skip"
+  },
+  "boundary_exit": {
+    "obligations_met": [
+      "string — current-mode obligations that have been satisfied"
+    ],
+    "obligations_unmet": [
+      "string — current-mode obligations that remain unsatisfied"
+    ],
+    "closures_needed": [
+      "string — decisions or scope items that must be encoded before leaving"
+    ]
+  },
+  "boundary_entry": {
+    "prerequisites": [
+      "string — what must exist before entering the target mode"
+    ],
+    "active_constraints": [
+      "string — constraints that govern behavior in the target mode"
+    ],
+    "risks_to_accept": [
+      "string — risks inherent to the target mode that must be explicitly acknowledged"
+    ]
+  },
+  "conditions_to_proceed": [
+    "string — specific conditions that, if met, would change a block to pass"
+  ],
+  "warnings": [
+    "string — drift signals, skipped phases, or assumption smuggling detected"
+  ]
+}
+```
+
+## Behavioral Rules
+
+1. **Reverts are always allowed.** Moving back to an earlier mode requires no gate check. The gate applies pressure only to forward and skip transitions.
+2. **Skips require explicit acknowledgment.** Jumping from exploration directly to execution is permitted only when the skip is explicitly named and the risks are accepted.
+3. **Evaluate both halves.** Every transition has a boundary exit (closure of the current phase) and a boundary entry (preparation for the next). Both must be assessed.
+4. **Name what would change the outcome.** A `block` status must always include `conditions_to_proceed` — the specific things that would turn the block into a pass.
+5. **Do not gate-keep inaction.** Remaining in the current mode is always legitimate. The gate only evaluates transitions, not the decision to stay.
+6. **Detect assumption smuggling.** If new assumptions appear in the transition evidence that were not present in the current phase, flag them as warnings.
+
+## Canon References
+
+- `klappy://canon/constraints/boundary-transitions-require-deceleration` — Boundary exit/entry protocol
+- `klappy://canon/epistemic-modes` — Mode obligations and transition legitimacy conditions
+- `klappy://canon/principles/irreversibility-is-the-real-cost` — Why forward transitions require scrutiny
+- `klappy://canon/principles/focus-is-exclusion` — Scope discipline during planning transitions
+- `klappy://canon/constraints/encode-epistemic-decisions` — Closures that must be encoded before exit

--- a/docs/oddkit/tools/oddkit_orient.md
+++ b/docs/oddkit/tools/oddkit_orient.md
@@ -1,0 +1,99 @@
+---
+uri: oddkit://tools/orient
+title: "oddkit_orient"
+audience: operators
+exposure: nav
+tier: 2
+voice: neutral
+stability: evolving
+tags: ["oddkit", "tool", "epistemics", "orientation", "modes"]
+---
+
+# oddkit_orient
+
+> Assess where a goal or idea sits epistemically before deciding what to do next.
+
+## Description
+
+`oddkit_orient` is the entry point for epistemic guidance. Given a goal, idea, or situation description, it determines the current epistemic mode (exploration, planning, or execution), surfaces what remains unresolved, and identifies the questions that must be answered before progressing.
+
+This tool applies the epistemic modes defined in Canon (`klappy://canon/epistemic-modes`). It does not decide direction or priorities — it clarifies what kind of thinking is legitimate right now.
+
+## When to Use
+
+- At the start of any new initiative, goal, or conversation
+- When uncertainty about the current phase is blocking progress
+- When drift is suspected (work may have moved phases without acknowledgment)
+- Before calling other epistemic guide tools, to establish shared context
+
+## Tool Definition
+
+**Name:** `oddkit_orient`
+
+**Description:** Assess where a goal or idea sits epistemically. Determines the current mode (exploration, planning, or execution), surfaces what is unresolved, and identifies questions to answer before progressing. Call this first — before challenging, gating, or encoding — to establish epistemic context. Does not decide priorities or direction; it clarifies what kind of thinking is legitimate right now.
+
+### Input Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "goal": {
+      "type": "string",
+      "description": "The goal, idea, or situation to assess. Describe what you are trying to achieve or understand."
+    },
+    "context": {
+      "type": "string",
+      "description": "Optional. Relevant prior decisions, artifacts, constraints, or evidence that bear on the goal."
+    },
+    "declared_mode": {
+      "type": "string",
+      "enum": ["exploration", "planning", "execution"],
+      "description": "Optional. The mode the caller believes they are in. If provided, orient will validate this claim against available evidence."
+    }
+  },
+  "required": ["goal"]
+}
+```
+
+### Response Shape
+
+```json
+{
+  "mode": {
+    "current": "exploration | planning | execution",
+    "confidence": "high | moderate | low",
+    "basis": "string — what evidence or signals determined the mode"
+  },
+  "unresolved": [
+    {
+      "item": "string — what remains open",
+      "type": "assumption | unknown | tension | dependency",
+      "impact": "string — why this matters for progression"
+    }
+  ],
+  "questions": [
+    "string — specific questions to answer before progressing"
+  ],
+  "valid_actions": [
+    "string — actions that are legitimate in the current mode"
+  ],
+  "warnings": [
+    "string — drift signals, mode mismatches, or epistemic smells detected"
+  ]
+}
+```
+
+## Behavioral Rules
+
+1. **Infer mode from evidence, not labels.** A caller claiming "execution" while lacking artifacts is in exploration or planning regardless of the label.
+2. **Surface unresolved items without resolving them.** Orient identifies what is open — it does not close gaps or make decisions.
+3. **Prefer questions over declarations.** When mode is ambiguous, produce clarifying questions rather than forcing a classification.
+4. **Detect drift signals.** If evidence suggests the work has moved phases without acknowledgment (e.g., code exists but no plan was encoded), flag this as a warning.
+5. **Never collapse modes.** Do not combine exploration and execution into one assessment. Name the mode, name the obligations, name the risks.
+
+## Canon References
+
+- `klappy://canon/epistemic-modes` — The three modes, their truth conditions, obligations, and risks
+- `klappy://canon/constraints/boundary-transitions-require-deceleration` — Why transitions require review
+- `klappy://docs/agents/odd-epistemic-guide` — The epistemic guide role this tool supports


### PR DESCRIPTION
Four tool definitions for oddkit's epistemic guidance surface:
- oddkit_orient: assess epistemic position (mode, unresolved items, valid actions)
- oddkit_challenge: pressure-test claims proportionally against canon constraints
- oddkit_gate: evaluate readiness for phase transitions with boundary protocol
- oddkit_encode: capture decisions as durable, inspectable records

One MCP prompt wrapper (epistemic-guide) that orchestrates the four tools
into a coherent flow: orient → challenge → gate → encode.

Tools are fully self-contained and useful when called independently.
The prompt is an optimization layer for models that support MCP prompts.

All tools apply existing canon (epistemic modes, challenge, deceleration,
irreversibility, encode-epistemic-decisions) without introducing new theory.

https://claude.ai/code/session_01NQ5ki7qTv4muMCp9DXp6aR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only additions with no runtime or behavior changes; risk is limited to potential mismatch with future tool implementations or naming/URI conventions.
> 
> **Overview**
> Introduces a new MCP prompt, `oddkit://prompts/epistemic-guide`, that instructs models to orchestrate epistemic guidance via a fixed sequence (orient → challenge → gate → encode) with explicit sequencing rules, posture, and canon references.
> 
> Adds docs for four new tools—`oddkit_orient`, `oddkit_challenge`, `oddkit_gate`, and `oddkit_encode`—including purpose, when-to-use guidance, behavioral constraints, and structured JSON input/response schemas to standardize epistemic assessment, claim pressure-testing, phase-transition gating, and decision recording.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9f3ee32ff005f5ea3eecf408f895fe2df02e4e45. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->