### PR TITLE
Add ODD Compared guide and clarify positioning in README

### DIFF
--- a/canon/resonance/README.md
+++ b/canon/resonance/README.md
@@ -112,3 +112,4 @@ Each resonance page follows a consistent structure:
 - [ODD Manifesto](/odd/manifesto.md)
 - [Canon Index](/canon/README.md)
 - [Three-Tier Hierarchy](/odd/decisions/D0001-three-tier-conceptual-hierarchy.md)
+- [ODD Compared](/odd/odd-compared.md) — How ODD relates to contemporary methodologies, governance frameworks, and agentic tooling. The practitioner-facing counterpart to this index.

--- a/odd/README.md
+++ b/odd/README.md
@@ -15,13 +15,29 @@ start_here_order: 1
 start_here_label: What is ODD?
 ---
 
-# 🧠 Outcomes-Driven Development (ODD)
+# Outcomes-Driven Development (ODD)
 
-Outcomes-Driven Development (ODD) is an approach to building software that prioritizes real-world results over artifacts.
+Outcomes-Driven Development is an approach to building software that prioritizes real-world results over artifacts.
 
-In an environment where AI can generate code, interfaces, and entire applications quickly, the limiting factor is no longer production speed—it is clarity of intent, quality of verification, and the ability to choose among many possible outcomes.
+In an environment where AI can generate code, interfaces, and entire applications quickly, the limiting factor is no longer production speed — it is clarity of intent, quality of verification, and the ability to choose among many possible outcomes.
 
 ODD exists to make those constraints explicit.
+
+---
+
+## Why ODD Exists
+
+AI development has no shortage of tools, workflows, and governance frameworks. What it lacks is a shared discipline for answering the simplest question: *did this actually work?*
+
+**Spec-Driven Development** gives you structured specs so AI generates better code. **Evaluation-Driven Development** gives you metrics so you can measure model quality. **AI-native lifecycles** give you phases and gates so humans stay in the loop. **Governance frameworks** like NIST and the EU AI Act give you compliance requirements. **Agentic tooling** like LangGraph and CrewAI gives you orchestration infrastructure.
+
+ODD doesn't replace any of these. It asks the question none of them center on:
+
+**How do you know what's actually true?**
+
+AI agents produce fluent, confident output. That output may be correct, partially correct, or entirely fabricated — and it all looks the same. Specs don't solve this. Evals help but don't cover it. Compliance doesn't prevent it. ODD exists because the gap between *generated* and *verified* is where real damage happens.
+
+→ For a detailed comparison with SDD, EDD, AI-DLC, governance frameworks, and agentic tooling, see **[ODD Compared](/odd/odd-compared.md)**.
 
 ---
 
@@ -39,11 +55,7 @@ If a proposed pattern, principle, or addition conflicts with it, the proposal is
 
 ## The Core Idea
 
-Traditional software development often optimizes for outputs:
-
-- lines of code
-- shipped features
-- completed tickets
+Traditional software development often optimizes for outputs: lines of code, shipped features, completed tickets.
 
 ODD shifts the focus to outcomes:
 
@@ -59,17 +71,9 @@ Code is still written. Tools still matter. But they are means, not ends.
 
 AI changes the economics of software creation.
 
-When generation becomes cheap:
+When generation becomes cheap, variation explodes, artifacts become disposable, and maintenance becomes the real cost.
 
-- variation explodes
-- artifacts become disposable
-- maintenance becomes the real cost
-
-ODD responds by:
-
-- treating code as ephemeral
-- emphasizing verification over explanation
-- encouraging curation over accumulation
+ODD responds by treating code as ephemeral, emphasizing verification over explanation, and encouraging curation over accumulation.
 
 The goal is not to generate _more_ software, but to ship _better_ outcomes with less long-term drag.
 
@@ -79,26 +83,13 @@ The goal is not to generate _more_ software, but to ship _better_ outcomes with 
 
 ODD is guided by a small set of principles that recur across projects:
 
-- **Prompt over Code**
-  Natural language intent guides generation; code is an output, not the source of truth.
-
-- **Keep It Simple (KISS)**
-  Prefer the simplest solution that works and can be explained clearly.
-
-- **Don’t Repeat Yourself (DRY), with Isolation**
-  Reuse ideas and components where it helps, but avoid brittle global coupling.
-
-- **Consistency**
-  Similar problems should feel similar to users and maintainers.
-
-- **Maintainability**
-  Optimize for low-effort upkeep and clear handoff, not cleverness.
-
-- **Antifragility**
-  Systems should learn from stress and failure, not just survive them.
-
-- **Scalability**
-  Growth should increase capability without exploding complexity or cost.
+- **Prompt over Code** — Natural language intent guides generation; code is an output, not the source of truth.
+- **Keep It Simple (KISS)** — Prefer the simplest solution that works and can be explained clearly.
+- **Don't Repeat Yourself (DRY), with Isolation** — Reuse ideas and components where it helps, but avoid brittle global coupling.
+- **Consistency** — Similar problems should feel similar to users and maintainers.
+- **Maintainability** — Optimize for low-effort upkeep and clear handoff, not cleverness.
+- **Antifragility** — Systems should learn from stress and failure, not just survive them.
+- **Scalability** — Growth should increase capability without exploding complexity or cost.
 
 These principles are lenses, not rules. Their application changes as projects mature.
 
@@ -106,7 +97,14 @@ These principles are lenses, not rules. Their application changes as projects ma
 
 ## Foundational Values
 
-ODD is grounded in four explicit foundational axioms that define its commitment to truth: Reality Is Sovereign, A Claim Is a Debt, Integrity Is Non-Negotiable Efficiency, and You Cannot Verify What You Did Not Observe. These values are the author's moral commitments — explicit, intentional, and forkable. They are not neutral observations but active choices about what epistemic discipline requires.
+ODD is grounded in four axioms that define its commitment to truth:
+
+1. **Reality Is Sovereign** — The state of the world as it actually is always takes precedence over any claim, plan, or model.
+2. **A Claim Is a Debt** — Every assertion creates an obligation. If you say something is true, you owe evidence.
+3. **Integrity Is Non-Negotiable Efficiency** — Cutting corners on truth never saves time. A false "done" creates more work than an honest "I haven't checked."
+4. **You Cannot Verify What You Did Not Observe** — If you didn't look, you don't know.
+
+These values are the author's moral commitments — explicit, intentional, and forkable. They are not neutral observations but active choices about what epistemic discipline requires.
 
 If you do not share these commitments, ODD expects you to fork and encode your own — not to argue, but to build. See [`canon/values/axioms.md`](/canon/values/axioms.md) for the full axioms.
 
@@ -116,11 +114,7 @@ If you do not share these commitments, ODD expects you to fork and encode your o
 
 ODD places a strong emphasis on evidence.
 
-In practice, this means:
-
-- showing working systems
-- favoring visual or experiential proof
-- treating explanations as hypotheses until verified
+In practice, this means showing working systems, favoring visual or experiential proof, and treating explanations as hypotheses until verified.
 
 This is especially important in AI-assisted workflows, where fluent explanations are easy to produce but easy to trust incorrectly.
 
@@ -144,9 +138,12 @@ ODD is not:
 
 - a framework to install
 - a fixed workflow
+- a governance model to comply with
 - a claim that outcomes can be fully predicted
 
 It does not replace judgment. It exists to support it.
+
+If any part of ODD feels heavy, ceremonial, or joy-killing, it is being misapplied.
 
 ---
 
@@ -165,7 +162,7 @@ The Canon is designed for orientation, not enforcement.
 
 In AI-assisted development, outcomes are not deterministic. The same intent can produce different results depending on execution paths.
 
-This site reflects that reality. Ideas are tested, observed, and sometimes retried before conclusions are drawn. What you see here is not a straight line—it's a record of learning under uncertainty.
+This site reflects that reality. Ideas are tested, observed, and sometimes retried before conclusions are drawn. What you see here is not a straight line — it's a record of learning under uncertainty.
 
 ---
 
@@ -173,6 +170,7 @@ This site reflects that reality. Ideas are tested, observed, and sometimes retri
 
 If you want to explore further:
 
+- See how ODD relates to other approaches: **[ODD Compared](/odd/odd-compared.md)**
 - Read the **extended ODD Manifesto** in `/odd/manifesto.md`
 - See how rigor scales in **Project Maturity & Progressive Governance**
 - Browse the **Canon Index** to understand how decisions and verification are structured

--- a/odd/odd-compared.md
+++ b/odd/odd-compared.md
@@ -1,0 +1,140 @@
+# ODD Compared: What It Is, What It Isn't, and How It Relates to Everything Else
+
+> ODD is about preserving intent without freezing execution. The measure of success is not how elegant the artifact is, but whether the outcome holds up in the real world.
+
+---
+
+## Who This Is For
+
+You might be a developer evaluating how to work with AI agents. You might be a leader trying to understand the landscape. You might just be curious. This page meets you where you are.
+
+ODD — Outcomes-Driven Development — is an approach to building software that prioritizes real-world results over artifacts. It is not a framework, not a workflow, and not a product. It is a collection of patterns, derived from real use, that reduce specific kinds of friction in agentic coding.
+
+The best way to understand what ODD is: compare it to things it gets mistaken for.
+
+---
+
+## ODD vs. Spec-Driven Development (SDD)
+
+**What SDD does:** Treats structured specifications — requirements, acceptance criteria, design docs — as the primary artifact. AI generates code from specs. Tools like Kiro, GitHub Spec Kit, and Tessl automate the flow from spec to implementation.
+
+**Where they overlap:** Both treat natural language intent as more durable than code. ODD's "Prompt over Code" principle and SDD's "spec as source of truth" share DNA. Neither trusts code to be the authoritative record of what was intended.
+
+**Where they differ:** SDD is a workflow. It tells you how to structure files, when to generate, and what to keep. ODD doesn't prescribe any of that. ODD asks a different question: *did the outcome actually hold up?* You could use SDD inside an ODD-informed project. You could also use ODD without specs at all. SDD optimizes the generation pipeline. ODD governs whether the result was worth generating.
+
+---
+
+## ODD vs. Evaluation-Driven Development (EDD)
+
+**What EDD does:** Applies TDD thinking to probabilistic AI. Define what "good" looks like through evals and metrics before building, then iterate against those measurements. Popularized in AI engineering by practitioners like Chip Huyen.
+
+**Where they overlap:** Both insist on evidence over vibes. EDD says "define your evals first." ODD says "a claim is a debt" — every assertion requires evidence proportional to its weight. The instinct is the same: don't trust fluent outputs.
+
+**Where they differ:** EDD is scoped to model and system evaluation. ODD is broader. Evals are one form of evidence in ODD, but so are visual proof, working demonstrations, and direct observation of system state. ODD also carries governance patterns — progressive maturity, decision records, self-audit — that EDD doesn't address. EDD optimizes AI outputs. ODD governs the decisions around them.
+
+---
+
+## ODD vs. AI-Driven Development Life Cycle (AI-DLC)
+
+**What AI-DLC does:** Reimagines the software development lifecycle with AI as a central teammate rather than a tool. Phases like Inception, Construction, and Operations replace traditional sprints. Humans provide oversight at decision gates. Developed at AWS.
+
+**Where they overlap:** Both put human judgment at the center. AI-DLC's "human gates" and ODD's emphasis that "ODD does not replace judgment — it exists to support it" point at the same problem: AI is powerful but not trustworthy without oversight.
+
+**Where they differ:** AI-DLC is a lifecycle — it prescribes phases, roles, and a sequence. ODD is not a lifecycle. It's a set of lenses that work inside any lifecycle, including AI-DLC. You could run AI-DLC phases and apply ODD's evidence standards at each gate. ODD doesn't care what your process looks like, only whether your outcomes are real.
+
+---
+
+## ODD vs. Governance Frameworks (NIST AI RMF, EU AI Act, OECD Principles)
+
+**What they do:** Provide risk management, compliance requirements, and ethical principles for AI systems. NIST offers voluntary guidance (Govern, Map, Measure, Manage). The EU AI Act enforces legal requirements by risk tier. OECD Principles set international norms.
+
+**Where they overlap:** All share the goal of trustworthy AI. ODD's axioms — Reality Is Sovereign, Integrity Is Non-Negotiable Efficiency — echo the spirit of these frameworks. Both NIST and ODD want evidence-based assessment of AI systems.
+
+**Where they differ:** Governance frameworks operate at the organizational and regulatory level. They tell you what to report, what to assess, what to document for compliance. ODD operates at the development level. It shapes how you think while you build. A team could be fully NIST-compliant and still ship systems that quietly lie about their own state. ODD's axioms are designed to prevent exactly that — not through compliance, but through epistemic habit.
+
+---
+
+## ODD vs. Agentic Tooling (LangGraph, CrewAI, AutoGen)
+
+**What they do:** Provide orchestration and runtime infrastructure for AI agents. LangGraph offers graph-based control flow with strong observability. CrewAI organizes agents into role-based teams. AutoGen enables conversational multi-agent systems.
+
+**Where they overlap:** Both care about reliability in AI-driven systems. LangGraph's emphasis on observability and debugging resonates with ODD's axiom that "you cannot verify what you did not observe."
+
+**Where they differ:** These are implementation tools. ODD is not. You could build a LangGraph application governed by ODD's Canon — using its evidence standards to validate agent outputs, its progressive maturity to scale rigor, its decision records to track why an architecture was chosen. ODD doesn't compete with LangGraph any more than a building code competes with a crane. Different altitude entirely.
+
+---
+
+## The Difference Under the Differences
+
+Most approaches in the AI development space answer one of two questions: *How should we build?* (SDD, EDD, AI-DLC, agentic tools) or *What rules should we follow?* (NIST, EU AI Act, OECD).
+
+ODD asks a third question: **How do we know what's actually true?**
+
+This is the epistemic layer. Four axioms drive it:
+
+1. **Reality Is Sovereign** — observe before asserting. No narrative overrides what is observably true.
+2. **A Claim Is a Debt** — every assertion requires evidence. Unverified claims are liabilities.
+3. **Integrity Is Non-Negotiable Efficiency** — shortcuts on truth always cost more than they save.
+4. **You Cannot Verify What You Did Not Observe** — if you didn't look, you don't know.
+
+These aren't aspirational. They're load-bearing. They constrain behavior specifically when it would be easier to skip verification, assert completion, or trust a confident-sounding output.
+
+---
+
+## The Constraint That Governs Everything Else
+
+ODD has one supreme rule that overrides all its own patterns, principles, and structure:
+
+**Use Only What Hurts.**
+
+Structure is only allowed in response to concrete, experienced pain. If no specific friction can be named, do nothing. If the friction is tolerable, tolerate it. Completeness is not a goal. Elegance is not a goal. Relief is the goal.
+
+This is what makes ODD fundamentally different from frameworks. Frameworks ask you to adopt a system. ODD says: don't adopt anything until something actually hurts, and stop using it when the pain subsides.
+
+If ODD ever becomes something that must be followed, it has failed.
+
+---
+
+## When to Reach for ODD
+
+ODD is most useful when:
+
+- AI agents are generating plausible outputs that nobody is verifying
+- Your team ships fast but can't explain why things broke
+- Process exists for compliance but doesn't prevent real failures
+- You want governance that developers will actually use, not route around
+
+ODD is least useful when:
+
+- You need a specific tool or workflow (look at SDD tooling, LangGraph, etc.)
+- You need regulatory compliance documentation (look at NIST, EU AI Act)
+- You're not building with AI and don't experience the friction ODD addresses
+
+---
+
+## Summary
+
+| | What it gives you | What it doesn't |
+|---|---|---|
+| **SDD** | Spec-to-code workflow | Outcome verification |
+| **EDD** | Eval-driven model optimization | Governance beyond evals |
+| **AI-DLC** | AI-native lifecycle | Flexibility across lifecycles |
+| **NIST/EU/OECD** | Compliance and risk frameworks | Dev-level epistemic discipline |
+| **LangGraph/CrewAI** | Agent orchestration | Governance of agent outputs |
+| **ODD** | Epistemic discipline for outcomes | Prescribed tooling or workflow |
+
+ODD doesn't replace any of these. It layers underneath them — or beside them — as a set of patterns for making sure the outcomes are real.
+
+If that's useful to you, use it. If it isn't, don't. That's the whole point.
+
+---
+
+## See Also
+
+- **[Resonance Index](/canon/resonance/README.md)** — ODD's relationship with foundational works like Antifragile, Lean Startup, OODA Loop, Sprint, and the Double Diamond. Where ideas echo ODD — and where ODD explicitly chooses different tradeoffs.
+- **[Foundational Axioms](/canon/values/axioms.md)** — The four values from which all ODD epistemic discipline is derived.
+- **[ODD Overview](/odd/README.md)** — What ODD is, in its own terms.
+
+---
+
+*ODD is open, forkable, and designed to be adapted. If you don't share its axioms, fork and encode your own.*


### PR DESCRIPTION
## Summary

This PR adds comprehensive positioning documentation for ODD and clarifies its relationship to other AI development approaches. It introduces a new "ODD Compared" guide that contextualizes ODD against spec-driven development, evaluation-driven development, AI-native lifecycles, governance frameworks, and agentic tooling.

## Key Changes

- **New file: `odd/odd-compared.md`** — A detailed comparison guide that:
  - Explains what ODD is by contrasting it with SDD, EDD, AI-DLC, NIST/EU/OECD frameworks, and agentic tools
  - Identifies overlaps and differences with each approach
  - Articulates ODD's unique focus on epistemic discipline and outcome verification
  - Clarifies when to use ODD and when to reach for other tools
  - Includes a summary table for quick reference

- **Updated `odd/README.md`** — Restructured for clarity:
  - Added "Why ODD Exists" section that positions ODD as answering the question "How do you know what's actually true?" — a gap not centered by other approaches
  - Expanded foundational values section with clearer axiom descriptions
  - Simplified principle descriptions using em-dash formatting for consistency
  - Added clarification that ODD is not a governance model to comply with
  - Added note that if ODD feels heavy or ceremonial, it's being misapplied
  - Added cross-reference to the new ODD Compared guide

- **Updated `canon/resonance/README.md`** — Added reference to ODD Compared guide in the "See Also" section

## Notable Details

The new guide emphasizes that ODD doesn't replace existing approaches but operates at a different altitude — the epistemic layer. It introduces the concept that ODD's supreme rule is "Use Only What Hurts," meaning structure is only adopted in response to concrete, experienced pain. This reinforces ODD's philosophy that it should never become something that must be followed.

https://claude.ai/code/session_01NjeXEoidUaqEbokUzR82gT

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes (new/updated markdown and links) with no runtime or data-handling impact.
> 
> **Overview**
> Adds a new `odd/odd-compared.md` guide that positions ODD against spec-driven and evaluation-driven approaches, AI-native lifecycles, governance frameworks, and agent orchestration tools, clarifying where ODD overlaps and where it intentionally differs.
> 
> Updates `odd/README.md` to more explicitly explain *why* ODD exists (centering outcome verification and epistemic discipline), rewrites the values/principles sections for clarity, and adds cross-links to the new comparison page; `canon/resonance/README.md` now also links to `ODD Compared` in “See Also”.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ba1f8160dad9a898092216b109d3cc0015e45fbf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->