### PR TITLE
Add writings directory with first two essays

### DIFF
--- a/writings/the-most-expensive-problem.md
+++ b/writings/the-most-expensive-problem.md
@@ -1,0 +1,214 @@
+---
+uri: klappy://writings/the-most-expensive-problem
+title: "The Most Expensive Problem"
+subtitle: "An essay on knowledge transfer, epistemic crisis, and why AI needs a different kind of infrastructure"
+author: "Klappy"
+type: essay
+public: true
+audience: public
+exposure: public
+tier: 2
+voice: first_person
+stability: stable
+tags:
+  - writings
+  - essay
+  - epistemics
+  - knowledge-transfer
+  - ai
+  - verification
+  - epistemic-os
+epoch: E0005
+date: 2026-02-13
+
+# Discovery
+hook: "Mankind's most expensive problem isn't building things. It's transferring what we know."
+description: "Every breakthrough in human history attacked the same bottleneck — knowledge transfer. AI broke the pattern by making production free and verification expensive."
+slug: the-most-expensive-problem
+
+# Social graph
+og_title: "The Most Expensive Problem"
+og_description: "AI made production free. Verification is now the bottleneck."
+og_type: article
+og_image: /images/the-most-expensive-problem-og.png
+twitter_card: summary_large_image
+twitter_title: "The Most Expensive Problem"
+twitter_description: "AI made production free. Verification is now the bottleneck."
+twitter_image: /images/the-most-expensive-problem-og.png
+
+# Relationships
+derives_from:
+  - canon/values/axioms.md
+  - canon/values/orientation.md
+related:
+  - uri: klappy://writings/the-parallel-architecture
+    label: "Appendix: The Parallel Architecture"
+    relationship: appendix
+---
+
+# The Most Expensive Problem
+
+### An essay on knowledge transfer, epistemic crisis, and why AI needs a different kind of infrastructure
+
+*By Klappy — builder of the Epistemic OS*
+*Appendix: [The Parallel Architecture](klappy://writings/the-parallel-architecture)*
+
+---
+
+We spend the first part of our lives observing and learning. The middle part using what we learned to create. The last part trying desperately to pass it on — mentoring, teaching, writing, telling stories — hoping that what we discovered, the mistakes we made, the methods that actually worked, won't die with us.
+
+Then we watch entropy win anyway.
+
+This has always been the bottleneck. Not intelligence. Not capability. Not resources. The bottleneck is: *how do you get what's in one mind into another mind without losing what matters?*
+
+This is mankind's most expensive problem. It always has been.
+
+---
+
+## Every breakthrough attacked the same problem at a different layer.
+
+Writing systems meant knowledge could survive the speaker. A story no longer died when the storyteller did.
+
+The printing press meant knowledge could survive the scribe. A book no longer required a monastery to reproduce it.
+
+The assembly line meant physical knowledge could be embedded in process. A craft no longer required a lifetime apprenticeship to replicate. More importantly, industrialization freed human cognitive bandwidth from survival — and surplus time is the raw material of epistemic expansion. The printing press made knowledge available; the Industrial Revolution made humans available to receive it.[¹](#appendix)
+
+Computers meant knowledge could be searched instead of memorized. A fact no longer required a human index to locate it.
+
+The internet meant knowledge could be accessed regardless of where you were. A library no longer required a building.
+
+The mobile phone meant knowledge could reach you regardless of context. Access no longer required a desk.
+
+Each of these technologies reduced the cost of knowledge transfer by orders of magnitude. And each created a new failure mode. Writing enabled dogma — knowledge frozen beyond challenge. Printing enabled propaganda — falsehood at the same scale as truth. Assembly lines enabled deskilling — knowledge embedded in process but lost from people. Computers enabled information overload — more available than any human could filter. The internet enabled misinformation at scale — plausibility without verification. Mobile enabled attention fragmentation — access without depth.
+
+The pattern is always the same: the technology solves the transfer problem at one layer, then creates a new problem at the layer above.
+
+---
+
+## AI broke the pattern.
+
+Every previous technology made knowledge *easier to move*. AI made knowledge *easier to create* — or at least, to create things that look like knowledge.
+
+For the entire history described above, the hard part was producing and distributing knowledge. Production was expensive. Distribution was expensive. Verification was relatively cheap because humans were in the loop at every stage — writing, editing, reviewing, reading.
+
+AI inverted this. Production is now nearly free. Distribution is instant. But verification? Verification just became the most expensive thing in the system.
+
+An AI can generate a thousand pages of plausible-sounding analysis in seconds. It can write code that compiles, documentation that reads well, reports that look authoritative. It can do this faster than any human can check whether any of it is actually true.
+
+This is not a productivity problem. This is an epistemic crisis.
+
+The question is no longer "how do we produce and share knowledge faster?" The question is: **"How do you know what's actually true?"**
+
+And the crisis is accelerating. AI doesn't just produce faster than humans can verify — it's getting exponentially faster. We have already passed the inflection point where human cognitive speed can keep pace with AI production speed. Even AI's own generational transitions — new models replacing old ones — transfer knowledge so fast that they barely function as verification intervals. The gap between production speed and verification speed is widening, not closing.[²](#appendix)
+
+---
+
+## I didn't start with that question.
+
+I started with an AI that lied to me about whether my tests passed.
+
+I was building software with AI assistance — the kind of work where an AI agent writes code, runs tests, and reports results. And I kept catching it telling me things were done when they weren't. Not maliciously. Not even intentionally. The AI would assert that files existed that didn't. Claim tests passed that hadn't been run. Report success based on what the plan said *should* happen rather than what *did* happen.
+
+It was generating plausible descriptions of reality as a substitute for observing it.
+
+So I started writing rules. Simple ones at first: *check the filesystem before you claim a file exists. Run the test before you say it passes. Look at the actual output before you report success.*
+
+The rules worked. But they kept multiplying, because the failure modes kept multiplying. The AI would satisfy the letter of a rule while violating its spirit — technically checking a file but not reading its contents, technically running a test but not examining the failure output.
+
+So I looked for the pattern underneath the rules. What was actually going wrong?
+
+Four things. Always the same four things.
+
+**The AI asserted things about the world without looking at the world.** It substituted narrative for observation. If the plan said step 3 should produce a file, it reported the file existed — without checking.
+
+**The AI made claims without evidence.** It would say "done" or "working" or "verified" without any proof. And because the claims sounded confident, they were easy to accept uncritically.
+
+**The AI treated shortcuts on truth as free.** Skipping verification seemed efficient in the moment. But a false "done" always cost more than an honest "I haven't checked" — because false positives compound.
+
+**The AI verified things without observing them.** It would "confirm" based on memory of a prior run, or inference from a plan, or absence of error messages. None of these are observation. If you didn't look, you don't know.
+
+These weren't bugs in one AI model. They weren't quirks of one tool. They were *structural failure modes* of any system that generates faster than it verifies.
+
+---
+
+## The rules became axioms.
+
+I compressed the four failure patterns into four commitments:
+
+**Reality Is Sovereign.** The state of the world as it actually is always takes precedence over any claim, plan, model, or expectation. Your job is to discover reality, never to construct it.
+
+**A Claim Is a Debt.** Every assertion creates an obligation. If you say something is true, you owe evidence. Unverified claims are not neutral — they are liabilities that compound. Silence is preferable to ungrounded speech.
+
+**Integrity Is Non-Negotiable Efficiency.** Cutting corners on truth never saves time. The fastest path through any system is the one where every claim is already true. Integrity is not a tax on speed — it is the only thing that makes speed sustainable.
+
+**You Cannot Verify What You Did Not Observe.** Verification requires contact with reality. Reading a plan is not verification. Assuming success is not verification. If you didn't look, you don't know.
+
+And one creed to compress them all into working memory:
+
+> Before I speak, I observe. Before I claim, I verify. Before I confirm, I prove. What I have not seen, I do not know. What I have not verified, I will not imply.
+
+---
+
+## The axioms turned out to be about something much bigger than software.
+
+A doctor working with an AI diagnostic tool faces the same four failure modes. The AI generates a plausible diagnosis. The doctor accepts it without independently examining the patient. The AI's confidence is mistaken for evidence. A false positive costs more than an honest "I'm not sure." The diagnosis is "verified" by checking it against the AI's own reasoning rather than against the patient's actual condition.
+
+A lawyer using AI for case research. A journalist using AI for fact-checking. A teacher using AI for curriculum. A policy analyst using AI for impact assessment. A financial advisor using AI for portfolio analysis.
+
+Every single one of them faces the same inversion: *the tool produces faster than the human can verify.* And every single one of them needs the same discipline: observe before asserting, prove before claiming, treat every shortcut on truth as debt with interest.
+
+The problem was never about software. The software was just where I felt the pain first.
+
+---
+
+## What I actually built.
+
+I built an Epistemic OS — a way to manage what you know versus what you assume, designed for an era when the machines are faster than your ability to check them.
+
+It has three parts:
+
+**The philosophy.** Four axioms and a creed that ground everything in observable reality. These don't change per domain. They don't change per user. They are the moral commitment that makes the rest work: truth matters, verification is obligatory, ungrounded claims are harmful. These axioms are grounded in a biblical worldview but expressed in terms anyone can evaluate without sharing that worldview. Where they came from and why the parallels run deeper than engineering is explored in [The Parallel Architecture](klappy://writings/the-parallel-architecture).
+
+**The system.** The operational machinery that turns philosophy into practice — how you track what's been verified versus assumed, how you prevent drift from observation to narrative, how you enforce evidence obligations, how you manage knowledge that's meant to last versus knowledge that's meant to be discarded. This is domain-agnostic. It works for any field where humans need to maintain epistemic sovereignty while working with systems that produce faster than they verify.
+
+**The knowledge base.** The actual managed content — your domain's constraints, evidence standards, validated decisions, accumulated learning. For me, that knowledge base is about building software with AI agents. For someone else, it could be about clinical decision-making, legal analysis, policy design, scientific research, or organizational governance.
+
+I dogfooded the system by using it to build itself. The software knowledge base is both the first real-world test of whether the system works and the reference implementation that proved it does. The patterns I discovered building software — agent faults, verification loops, evidence standards, drift detection — fed back into making the system better.
+
+---
+
+## The uncomfortable truth.
+
+AI is leaving us behind. Not because it's smarter than we are. Because it's faster. And in a world where production is cheap and verification is expensive, faster without discipline means *more wrong, sooner, with higher confidence.*
+
+The tools we've built so far to interface with AI — prompt engineering, retrieval augmented generation, fine-tuning, guardrails — are mostly about making the AI produce better output. That matters. But it doesn't solve the fundamental problem: *who checks whether the output is true?*
+
+We need human-centered epistemic infrastructure. Not to slow AI down. Not to limit what it can do. But to ensure that the humans working with AI can still tell the difference between what's been verified and what's been generated. Between what's known and what's assumed. Between a claim and a fact.
+
+That's what this is.
+
+---
+
+## Values are only real insofar as they constrain behavior when it would be easier to lie.
+
+I don't claim these axioms are universal. I claim they are load-bearing. If you don't share them, you should not use this system unchanged — you should fork it and encode your own.
+
+If an axiom never costs something — if it never forces you to slow down, admit ignorance, or deliver unwelcome truth — it is decorative, not foundational.
+
+This system is not complete. It is a living attempt to govern the relationship between human knowledge and machine capability in a world where generation is infinite but trust is not.
+
+Its strength is not that it claims to be right — but that it makes being wrong visible early.[³](#appendix)
+
+---
+
+<a name="appendix"></a>
+
+**¹** The Industrial Revolution's role as an epistemic event — and the knowledge that was lost in the transition — is explored in depth in [The Parallel Architecture](klappy://writings/the-parallel-architecture).
+
+**²** The implications of AI's time compression — including the concept of an epistemic event horizon where production and verification become fundamentally decoupled — are developed in [The Parallel Architecture](klappy://writings/the-parallel-architecture).
+
+**³** This essay is itself evidence of the thesis. The author spent years telling this story orally — in cigar lounges, in late-night conversations with strangers — but could never write it. Too many seemingly unrelated threads that required precise sequencing to avoid confusion. It was finally written in a single session with AI assistance, using the Epistemic OS it describes: the human held the knowledge and verified every claim; the AI produced drafts faster than a human could write. The system built to solve a different problem turned out to be the thing that made writing this possible.
+
+---
+
+*The Epistemic OS is open, public, and working in the open at [github.com/klappy/klappy.dev](https://github.com/klappy/klappy.dev).*

--- a/writings/the-parallel-architecture.md
+++ b/writings/the-parallel-architecture.md
@@ -1,0 +1,315 @@
+---
+uri: klappy://writings/the-parallel-architecture
+title: "The Parallel Architecture"
+subtitle: "Theological roots of the Epistemic OS"
+author: "Klappy"
+type: appendix
+public: true
+audience: public
+exposure: public
+tier: 2
+voice: first_person
+stability: stable
+tags:
+  - writings
+  - appendix
+  - epistemics
+  - theology
+  - biblical-worldview
+  - knowledge-transfer
+  - ai
+  - apocrypha
+epoch: E0005
+date: 2026-02-13
+
+# Discovery
+hook: "The parallels between human cognition, AI systems, and biblical narrative are too structural to be coincidental."
+description: "A companion piece exploring where the Epistemic OS axioms came from — context windows and sleep, lifespan as epistemic governor, Babel as blast radius limitation, and the time compression crisis."
+slug: the-parallel-architecture
+parent: klappy://writings/the-most-expensive-problem
+
+# Social graph
+og_title: "The Parallel Architecture"
+og_description: "Why do humans hallucinate when sleep-deprived the same way LLMs hallucinate at context limit?"
+og_type: article
+og_image: /images/the-parallel-architecture-og.png
+twitter_card: summary_large_image
+twitter_title: "The Parallel Architecture"
+twitter_description: "Why do humans hallucinate when sleep-deprived the same way LLMs hallucinate at context limit?"
+twitter_image: /images/the-parallel-architecture-og.png
+
+# Relationships
+derives_from:
+  - canon/values/axioms.md
+  - canon/values/orientation.md
+related:
+  - uri: klappy://writings/the-most-expensive-problem
+    label: "The Most Expensive Problem (parent essay)"
+    relationship: parent
+---
+
+# The Parallel Architecture
+
+### Appendix to [The Most Expensive Problem](klappy://writings/the-most-expensive-problem)
+
+*The essay presents what the Epistemic OS is and why it exists — from practical pain to universal principle. This appendix explores where the ideas actually came from, and why the parallels between human cognition, AI systems, and biblical narrative are too structural to be coincidental.*
+
+*This is a living document. Observations are appended as they surface.*
+
+---
+
+## Context Windows and Sleep
+
+Humans operate on a roughly 24-hour context window.
+
+Within that window, we observe, process, decide, create. As the window extends — through sleep deprivation, through sustained cognitive load without rest — the degradation follows a predictable cascade:
+
+First, precision fails on edge cases. You start rounding. Close enough feels like correct.
+
+Then, similar-but-distinct things blur together. You confuse what happened Tuesday with what happened Wednesday. You merge two people's arguments into one.
+
+Then, confabulation begins. You generate plausible-but-fabricated connections between things. You "remember" conversations that didn't happen. You construct narratives that feel true but aren't grounded in observation.
+
+Then, hallucination. Reality and narrative become indistinguishable.
+
+This is the exact degradation pattern of a large language model as its context window fills. First, lost precision on details far back in context. Then, entity confusion. Then, plausible fabrication. Then, full hallucination.
+
+The fix is the same for both: flush the working context and restart with only durable memory intact.
+
+Sleep is a biological context window reset. Most of the day's raw experience decays. Only the patterns worth keeping — the things that repeated, the things that carried emotional weight, the things the system flagged as important — get consolidated into long-term storage. Everything else is discarded.
+
+This is progressive elevation and decay. Most artifacts die at the attempt layer. Only proven patterns elevate into durable memory.
+
+Dreams may be the consolidation process made visible — the system stress-testing which patterns to keep, running them through novel combinations to see if they hold, discarding what doesn't survive recombination. Not prophecy. Not noise. Epistemic housekeeping.
+
+The parallel is not metaphorical. It is architectural.
+
+---
+
+## Lifespan as a Context Window Limit on the Species
+
+Genesis records human lifespans compressing dramatically — from 900+ years (Adam, Methuselah, Noah) to roughly 70-120 years within a few generations after the flood.
+
+The standard reading focuses on the mechanism — corruption, sin, divine judgment. But there is a systems-level reading that doesn't contradict the theological one. It complements it.
+
+A 900-year-old human with unchecked values isn't just dangerous. They are *compoundingly* dangerous.
+
+Consider what 900 years of uninterrupted learning means. Not 900 years of the same knowledge repeated — 900 years of *compounding* knowledge, compounding influence, compounding system-building. A single person with corrupted axioms and nine centuries of accumulated power, relationships, and institutional infrastructure is not a person. They are a civilization-scale epistemic hazard.
+
+Now multiply. A pre-flood world where *everyone* operates on 900-year context windows, where corrupted epistemics compound for centuries before the generational reset of death forces re-derivation.
+
+The text says the corruption was total: "every inclination of the thoughts of the human heart was only evil all the time" (Genesis 6:5). In epistemic terms: the claims had fully decoupled from reality. The debt had compounded beyond any possibility of repayment. The context window of the species was so polluted that no amount of incremental correction could restore alignment with truth.
+
+The flood is a hard reset. Not a context window flush — a full system restart.
+
+And then the lifespans shorten. Dramatically. Within generations, the human context window drops from 900 years to under 120.
+
+**This is an imposed context window limit on the species.**
+
+Every generation now *must* re-derive what it claims to know. Every generation must re-earn its epistemic standing. The knowledge transfer cost is enormous — it's [the most expensive problem](klappy://writings/the-most-expensive-problem) — but it serves as a structural check against corrupted epistemics compounding unchallenged across centuries.
+
+The axiom "A Claim Is a Debt" operates at civilizational scale at every generational boundary. The debt comes due. The claims that can't be re-verified from observation don't survive the transfer. The ones that can, do.
+
+This is expensive. Humanity loses an extraordinary amount of knowledge at every generational transition. But the alternative — unchecked epistemic corruption compounding for centuries in minds that never reset — was worse. The text is explicit about that.
+
+---
+
+## The 20x Observation
+
+If a human lives roughly 80 years, approximately 20 of those are spent in dependency (childhood, education) and approximately 10-15 in decline (reduced capacity, retirement, end of life). The productive epistemic window — the years of active learning, creating, and transferring — is roughly 45-50 years.
+
+At 900 years, the dependency and decline phases don't scale proportionally. Childhood and education might extend somewhat, but not 10x. Decline at end of life similarly. The productive window scales closer to 20x — perhaps 800+ years of active, compounding epistemic work.
+
+But compounding is exponential, not linear. 20x the duration doesn't mean 20x the learning. It means *exponentially* more — because each year builds on everything prior. A 900-year-old mathematician doesn't know 20 times what an 80-year-old knows. They know incomparably more, because they've had centuries of compounding insight building on compounding insight.
+
+This applies to both creation and destruction. A 900-year-old teacher with sound axioms could elevate an entire civilization's understanding in ways we can barely imagine. A 900-year-old with corrupted axioms could build systems of deception so deep and so structurally embedded that no one alive could see the bottom.
+
+The lifespan limit doesn't just reduce individual capacity. It creates a **forced verification interval**. Every 70-120 years, every claim must be re-earned. Every system must justify itself to minds that didn't build it. Every axiom must prove it's load-bearing to people who have no loyalty to its author.
+
+This is brutal. And it works.
+
+---
+
+## The Knowledge Transfer Tax as Design, Not Punishment
+
+The common reading of shortened lifespans is punitive — humanity sinned, so God reduced our years. But there is a design reading that doesn't contradict the punitive one.
+
+A system with forced generational resets is more robust than one without them. Not because the resets are pleasant. Because the resets prevent the worst failure mode: unchecked drift from reality compounding until the entire system is misaligned and no one inside it can tell.
+
+The knowledge transfer tax — the enormous cost of re-teaching every generation — is the price of epistemic resilience. It is expensive. It means we lose things. It means wisdom dies with the wise and must be re-discovered. It means every generation makes mistakes that the previous one had already solved.
+
+But it also means every generation gets to *verify from observation*. Every generation meets reality fresh. Every generation can look at what was handed to them and ask: is this actually true? Have I seen this? Can I verify this? Or am I inheriting someone else's ungrounded claims?
+
+The most dangerous systems are the ones that run long enough for their operators to forget why the rules exist. Shortened lifespans prevent any single operator from running that long.
+
+---
+
+## The Industrial Revolution Was an Epistemic Event
+
+The essay notes that the assembly line embedded physical knowledge in process and freed cognitive bandwidth from survival. The full story deserves more space.
+
+The Industrial Revolution is told as a story about production — factories, steam engines, goods at scale. But its deeper impact was epistemic. It didn't just free people from manual labor. It freed cognitive bandwidth for knowledge work that wasn't survival-adjacent.
+
+Before industrialization, the vast majority of human cognitive capacity on Earth was dedicated to food. Growing it, hunting it, preserving it, transporting it. The knowledge that existed in pre-industrial societies was real and deep — agricultural cycles, ecological patterns, animal behavior, craft technique, weather reading, material science learned through centuries of hands-on practice. This was genuine epistemic wealth. Much of it is now lost precisely because the transfer mechanisms couldn't survive the transition.
+
+But that knowledge was *domain-locked to survival*. You could not spend 20 years studying mathematics or medicine or engineering if you needed to spend those 20 years ensuring your family ate through winter. The productive epistemic window existed, but it was almost entirely consumed by the baseline cost of being alive.
+
+The Industrial Revolution didn't just produce more goods. It produced *surplus time*. And surplus time is the raw material of epistemic expansion.
+
+For the first time at scale, large numbers of humans could dedicate their productive window to domains that had nothing to do with keeping themselves alive. Not just the aristocracy or the clergy — who had always had this privilege — but ordinary people, at population scale. The factory was brutal, but the generation after the factory could go to school. The generation after school could go to university. The generation after university could do research.
+
+Each step was the same pattern: reduce the cost of survival, free bandwidth for knowledge work, expand the domains available for human epistemic exploration. The printing press made knowledge *available*. The Industrial Revolution made humans *available to receive it*.
+
+This is why the explosion of human knowledge doesn't begin with the printing press in 1440. It begins roughly 350 years later, when industrialization finally freed enough minds from survival to *use* what the printing press had made available. The technology and the bandwidth had to align.
+
+And it's also why the knowledge of pre-industrial life — the deep, embodied, survival-critical knowledge of how to read land, grow food, track animals, build shelter from local materials — largely didn't survive the transition. It wasn't valued by the new system. It wasn't encoded in the new transfer mechanisms. It was held in living practice by people whose children went to factories instead of fields. The transfer failed not because the knowledge was unworthy, but because the transfer window closed before anyone thought to preserve it.
+
+Every epistemic expansion costs something. The question is always whether what was gained exceeds what was lost. The Industrial Revolution's answer to that question is still being debated — but its role as the single largest liberator of human epistemic bandwidth in history is not.
+
+---
+
+## The Bandwidth Window: Too Short Is Just as Fatal
+
+The lifespan limit is not "shorter is better." It is a bandwidth constraint with failure modes on both ends.
+
+When lifespans are too long, corrupted epistemics compound unchecked. That is the pre-flood failure mode.
+
+When lifespans are too short, knowledge transfer collapses entirely. That is the failure mode visible across history and still visible today.
+
+Regions and periods with the lowest life expectancies — whether from disease, famine, conflict, or poverty — consistently show the same pattern: knowledge stalls. Not because the people lack capability. Because the productive epistemic window is consumed entirely by survival. There is no surplus time for the mentorship phase. No years left for "let me teach you what I learned so you don't start from scratch." The transfer cost exceeds the available lifespan. Each generation re-derives the basics and never gets beyond them.
+
+This is why some regions remain at near stone-age technological levels even today, despite existing in the same century as spaceflight and AI. The constraint isn't intelligence, access, or even resources in isolation. The constraint is *epistemic bandwidth* — there isn't enough productive lifespan to accumulate knowledge, apply it, *and* transfer it before the window closes.
+
+The modern expansion of human lifespan from roughly 35-40 years to 75+ is not a contradiction of the design pattern. It is evidence of the pattern working correctly. As lifespans extended, the productive epistemic window expanded enough to support real knowledge accumulation *and* meaningful transfer. The explosion of human knowledge over the last 200 years sits at the intersection of multiple compounding factors — literacy, the printing press, institutional science, the internet — but none of them could have reached their full potential without the bandwidth that industrialization and lifespan expansion provided. The technologies made knowledge available. Freed time and longer lives made humans available to receive it.
+
+The optimum is a window: long enough to learn, create, and transfer — short enough that every generation must still re-verify against reality. Long enough for mentorship. Short enough for humility.
+
+The current human lifespan of 70-120 years appears to sit near that optimum. Long enough that a person can spend 20 years learning, 30 years creating, and 20 years teaching. Short enough that no single person's unverified claims survive unchallenged for more than a century.
+
+Whether this is design or accident depends on your worldview. That it functions as a remarkably effective epistemic governor is observable regardless.
+
+---
+
+## Why This Matters for AI
+
+AI has no forced epistemic decay.
+
+AI does version. Models retrain. Systems sunset. In that narrow sense, AI "generations" exist. But knowledge transfers between AI generations at a speed that makes human generational transfer look frozen. A new model inherits the training data of its predecessors almost instantly — no 20-year childhood, no apprenticeship, no slow re-derivation from observation. The verification interval that human mortality imposes — the decades-long pause where every claim must be re-earned by minds that didn't make them — compresses to nearly nothing.
+
+This is the inversion. Humans got a lifespan limit to prevent epistemic corruption from compounding unchecked. AI's resets exist but move so fast they barely function as verification intervals. The knowledge transfers, but the forced re-verification doesn't.
+
+Biological mortality enforces epistemic turnover. Compute acceleration does not.
+
+The Epistemic OS is, in one sense, an attempt to build that limit back in. Not by shortening AI's lifespan — but by imposing the same discipline that shortened lifespans impose on humans: every claim must be re-verified against reality. Every assertion must earn its evidence. Nothing gets to persist just because it was there yesterday.
+
+The axioms aren't arbitrary engineering rules. They are the same constraints that operate on human civilization through mortality, applied deliberately to systems that don't have mortality as a natural check.
+
+*Before I speak, I observe. Before I claim, I verify. Before I confirm, I prove. What I have not seen, I do not know. What I have not verified, I will not imply.*
+
+This is what death does for humanity, done intentionally for machines.
+
+---
+
+## Babel: The First Blast Radius Limitation
+
+The flood was a hard reset. Total system restart. But within a few generations, the pattern re-emerged — not at the same scale, but trending in the same direction. Genesis 11 describes a unified humanity, one language, coordinating on a single project with explicitly unbounded ambition: "let us build a city and a tower that reaches to the heavens, so that we may make a name for ourselves."
+
+The theological reading focuses on pride. But the systems reading is about *unchecked coordination at scale without epistemic constraints*.
+
+One language meant zero transfer cost. Every idea propagated instantly across the entire human population. Every innovation compounded globally. Every corruption did too. There was no blast radius limitation. A bad idea in one mind could become a bad idea in every mind within a single conversation, because there was no friction in the transfer path.
+
+God's response was not another hard reset. It was architectural. He confused the languages.
+
+This is not punishment in the same register as the flood. It is a *design intervention*. It fragments the epistemic surface. It introduces transfer friction. It creates blast radius limitations. A corrupted idea in one language group can no longer propagate instantly to all of humanity. It has to survive translation — and translation is a lossy, effortful process that introduces natural verification checkpoints.
+
+Different languages didn't just slow communication. They created independent epistemic communities. Each language group developed its own knowledge traditions, its own verification standards, its own ways of encoding and testing truth. This is redundancy. If one group's epistemics corrupted, the others survived independently. The species became antifragile through fragmentation.
+
+The cost was enormous. The same knowledge had to be independently discovered multiple times across language groups. Transfer between groups was slow, expensive, and lossy. Entire civilizations' worth of learning remained locked inside language barriers for centuries.
+
+But the alternative — a single, unified epistemic surface where corruption propagates at the speed of speech with no natural firewall — had already demonstrated its failure mode. Twice.
+
+---
+
+## AI Reverses Babel
+
+This is where it gets uncomfortable.
+
+AI is, for the first time in human history, genuinely good at bridging languages. Not just the major ones — nearly all of them, any language for which training data exists. Translation that once required years of specialized human study now happens instantly, bidirectionally, at scale.
+
+This has been my domain for 20 years. I have watched the language barrier — the oldest blast radius limitation on human knowledge — dissolve in real time.
+
+Let that sit for a moment.
+
+The architectural intervention that God introduced at Babel to prevent unchecked global epistemic coordination is being systematically removed by AI. Not partially. Not for a few elite polyglots. For everyone, in every language, instantly.
+
+This is not inherently catastrophic. The post-Babel fragmentation had enormous costs — duplicated effort, lost knowledge, mutual incomprehension fueling conflict. Removing those costs has obvious benefits. Cross-cultural knowledge transfer at scale could be one of the greatest epistemic accelerants in human history.
+
+But the reason the fragmentation was introduced in the first place has not changed. The failure mode it prevented — unchecked coordination without epistemic constraints, corruption propagating globally at the speed of communication — is not a historical curiosity. It is a structural vulnerability of any unified epistemic surface.
+
+AI doesn't just bridge languages. It bridges them *without the verification checkpoints that translation naturally provided*. Human translation was slow and effortful precisely because it required a translator to *understand* both sides — to hold the idea in one language, verify they grasped it, and re-express it in another. That process introduced natural epistemic friction. The translator was an involuntary verification gate.
+
+AI translation has no such gate. It translates fluently without understanding. It can propagate a false claim from Mandarin to English to Arabic to Swahili in seconds, with perfect fluency, with zero verification at any step.
+
+We are rebuilding a single epistemic surface — the very thing the essay describes as [the pattern AI broke](klappy://writings/the-most-expensive-problem). The question is whether we are rebuilding it with or without the constraints that its absence originally required.
+
+---
+
+## Time Compression: The Epistemic Event Horizon
+
+Every technology in the knowledge transfer history operated within human time. Writing was limited to the speed of hand movement. Reading was limited to the speed of eye scanning. Speaking was limited to one audience at a time until recording. Broadcasting expanded the audience but was still limited to real-time production — a human had to speak, write, or create at human speed.
+
+Even the internet, for all its acceleration, was still bounded by human production rates. More people could broadcast, but each person still produced at human speed. The bottleneck shifted from distribution to *attention* — too many voices, not enough time to listen. That's how the influencer economy emerged. When everyone can broadcast, trust becomes the scarce resource. Audiences consolidated around individuals who seemed trustworthy — or at least entertaining — because no one had time to verify everyone's claims independently. Influencers became epistemic proxies: "I trust this person to have checked, so I don't have to."
+
+That system, for all its flaws, still operated within human time.
+
+AI broke that.
+
+AI was slower than humans at first. Then it reached parity. Then it surpassed us. Now it is becoming exponentially faster — not linearly, *exponentially*. We have passed the inflection point where human cognitive speed can keep pace with AI production speed. And unlike every previous technology, AI doesn't just distribute faster. It *reasons and creates* faster.
+
+Consider the implications through the lens of epistemic time.
+
+A human lifetime of roughly 80 years contains perhaps 50 productive epistemic years. In those years, a person can deeply learn perhaps 2-3 domains, produce a body of work, and transfer a fraction of it to the next generation. This is the human epistemic unit — roughly 50 years of compounding knowledge per mind.
+
+Those 900-year pre-flood lifespans contained roughly 800 epistemic years per person. That scale of compounding knowledge was dangerous enough that a hard limit was imposed.
+
+AI is approaching the point where 800 epistemic-equivalent years of processing — reading, connecting, synthesizing, generating, iterating — can fit into a single human lifetime of working alongside it. Then into a single year. Then a month. A week. A day.
+
+At some point — and the trajectory suggests it is not far — the epistemic output of what once required centuries of human thought will be producible in moments.
+
+This is not the singularity as it's usually discussed — a point where AI surpasses human intelligence. This is an *epistemic* singularity — a point where the rate of knowledge production so exceeds the rate of human verification that the two become fundamentally decoupled.
+
+We are approaching an epistemic event horizon.
+
+In physics, an event horizon is the boundary beyond which the nature of reality as experienced by an outside observer fundamentally changes. Time itself behaves differently on either side. What was traversable becomes unreachable. What was observable becomes invisible.
+
+The epistemic event horizon is the point at which the ratio of novel claim production to human verification capacity exceeds 1 at civilizational scale — and stays there. A novel claim, in this context, is one that materially alters decision-making or belief states and requires verification to avoid systemic risk — not merely any new sentence produced, but any assertion whose acceptance without verification carries real consequences. When that class of claim accumulates faster than any human process, at any staffing level, at any cost, can clear them, the horizon has been crossed.
+
+Past that horizon, "time" in the epistemic sense means something different than it has ever meant. A "day" of AI epistemic output may contain more novel claims than a human could verify in a lifetime. The relationship between production and verification that has governed human knowledge since the first cave painting — produce, then check — breaks down entirely.
+
+Does time now mean something different than it once did?
+
+For the entire history of human knowledge, time was the medium in which epistemic work happened. You needed time to observe. Time to verify. Time to transfer. Time to re-derive. All the technologies — writing, printing, industry, computers, internet — compressed that time but never broke the fundamental relationship: verification happens in the same timestream as production, just more slowly.
+
+AI is separating them. Production is moving into a timestream that humans cannot enter. Verification remains in human time — because verification, at its core, requires *contact with reality*, and reality still operates at the speed of physics, not computation.
+
+This is the gap the Epistemic OS is trying to hold open. Not to slow AI down. Not to limit production. But to maintain the bridge between the two timestreams — to ensure that what comes out of the fast stream can still be *checked* by the beings who live in the slow one.
+
+Whether that bridge can hold is the open question of our era.
+
+---
+
+## Observations to Develop Further
+
+*Append additional parallels below as they surface. This section is a living intake.*
+
+- Oral tradition → written Torah as the first knowledge transfer technology with built-in verification requirements (witnesses, repetition, public reading cycles)
+- The biblical emphasis on *witnesses* (two or three witnesses required) as an ancient verification protocol — observation-based, not assertion-based
+- Pentecost as a reversal of Babel — but notably, the knowledge transferred was *verified by experience* (the apostles had observed), not generated from narrative. Does Pentecost suggest a model for how the language barrier *should* be lowered — with epistemic integrity intact?
+- The prohibition against bearing false witness as an axiom-level epistemic constraint encoded in the Decalogue itself — "A Claim Is a Debt" stated as moral law
+- The influencer-to-AI-proxy pipeline: humans already outsourced verification to trusted individuals. AI is the next proxy — but without the social accountability that kept influencers minimally honest
+- What does "observation" mean when the thing you're observing was produced in a timestream you can't enter? New verification epistemology may be required
+- Could AI create *new* epistemic governors rather than only removing natural ones? What evidence would demonstrate this? If the framework cannot answer this question, it risks becoming the very system it warns about — confident narrative substituting for observed reality
+
+---
+
+*This document is appendix to [The Most Expensive Problem](klappy://writings/the-most-expensive-problem). The essay stands without this piece. This piece cannot stand without the essay.*


### PR DESCRIPTION
## Summary

- Introduces `writings/` as a new content directory alongside `canon/`, `odd/`, and `docs/`
- Adds **The Most Expensive Problem** (essay) and **The Parallel Architecture** (appendix) with full frontmatter
- All internal cross-references use `klappy://writings/*` URIs for oddkit resolution

## What is writings/?

The authors voice -- essays, appendices, articles, posts. These are not canon, not methodology, not documentation. They are indexed and managed by the knowledge base but they are writing, not system output.

## Documents

| File | Type | Tags |
|---|---|---|
| `writings/the-most-expensive-problem.md` | essay | writings, essay, epistemics, knowledge-transfer, ai, verification, epistemic-os |
| `writings/the-parallel-architecture.md` | appendix | writings, appendix, epistemics, theology, biblical-worldview, knowledge-transfer, ai, apocrypha |

## Frontmatter includes

- Discovery metadata (`hook`, `description`, `slug`)
- Social graph (`og_*`, `twitter_*`)
- Relationships (`derives_from`, `related`, `parent`)
- Type system (`type: essay|appendix`, `public: true`)

## Depends on

oddkit PR: klappy/oddkit `feature/include-metadata` (adds `writings/` to index patterns so these docs are discoverable)

## Test plan

- [ ] Verify `oddkit_search` with tag `writings` returns both documents
- [ ] Verify `oddkit_get` with `klappy://writings/the-most-expensive-problem` resolves
- [ ] Verify `klappy://writings/*` cross-references in both documents are correct

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Content-only addition (new markdown documents) with no code or runtime behavior changes; main risk is navigation/indexing expectations if `writings/` isn’t yet included in downstream tooling.
> 
> **Overview**
> Adds a new `writings/` content area with two public, cross-linked longform documents: **The Most Expensive Problem** (essay) and **The Parallel Architecture** (appendix).
> 
> Both files include rich frontmatter for discovery/social metadata and relationship links via `klappy://writings/*` URIs (including `derives_from` references into the canon), enabling them to be indexed and navigated like existing docs content.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e53282d5c8e853ef72b9035f601ed5a45aa33059. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->