### PR TITLE
Add epistemic OS docs: trust proxy, layers, cognitive saturation, testimony; bump changelog to 0.32.0

### DIFF
--- a/canon/CHANGELOG.md
+++ b/canon/CHANGELOG.md
@@ -18,6 +18,44 @@ This changelog tracks changes to the **Canon pack** as a whole.
 The Canon uses **pack-level versioning** (one version number) rather than per-file versioning.
 Per-file versions are intentionally omitted to reduce ceremony and prevent metadata rot.
 
+## 0.32.0 — 2026-02-14
+
+**Epistemic OS Docs, Trust Proxy, Writings, Structure-Agnostic ODD, and OddKit Docs Audit**
+
+This release introduces four new documents articulating the epistemic OS concept — including a canon-tier trust proxy essay, the four-layer architecture map, a cognitive saturation appendix, and a testimony evidence document. Also captures Epoch 5.1 (structure-agnostic ODD), the first public writings, ODD Compared positioning, anti-cache-lying constraint, progressive disclosure fixes, and a full OddKit docs audit.
+
+### Added
+
+- **Canon: Shared Values as a Trust Proxy** (`canon/values/shared-values-as-trust-proxy.md`) — Tier 1 canon document. Names the trust proxy effect as an observable consequence of shared axioms: transparency becomes the default, failure modes become navigable, and collaboration overhead decreases. Derives from axioms and orientation. Includes the organizational handbook analogy, the fork model for genuine adoption vs. compliance, and explicit constraints on what shared values do not guarantee. Draft.
+
+- **Docs: Epistemic OS Layers** (`docs/architecture/epistemic-os-layers.md`) — Tier 2 architecture document. Maps the system's four separable layers: (1) Values/Trust as the kernel, (2) Dynamic Context as the memory, (3) Alignment as the scheduler, (4) Generation/Outcomes as the output. Each layer is independently portable. Includes repository structure mapping and extension points. Draft.
+
+- **ODD Appendix: Cognitive Saturation Threshold** (`odd/appendices/cognitive-saturation-threshold.md`) — Tier 2 appendix. Formalizes the failure mode where verbal exchange stops producing knowledge transfer. Defines the saturation threshold, practical signals (rephrasing without progress, violent agreement, deferred concreteness, meeting recursion), and the remedy (modality switch to observable artifacts). Derives from Axiom 4. Draft.
+
+- **Evidence: Testimony — A Day the System Proved Itself** (`docs/evidence/testimony-2026-02-13.md`) — Tier 2 evidence document. Claude's first-person account of a single day producing five documents from unstructured input — a typing rant and a nine-mile-run voice memo. Documents the trust proxy in action, the counterfactual without the epistemic OS, and the author's assessment that the output was "the most like me anything has ever been written." Final.
+
+- **Writings Directory** (`writings/`) — Two public essays: "The Most Expensive Problem" (knowledge transfer as humanity's costliest recurring failure) and "The Parallel Architecture" (theological roots of the epistemic OS as appendix). First public-facing long-form content.
+
+- **ODD Compared** (`odd/odd-compared.md`) — Positioning document comparing ODD to SDD, EDD, AI-DLC, governance frameworks, and agentic tooling. ODD README restructured with "Why ODD Exists" section.
+
+- **Anti-Cache Lying Constraint** (`odd/constraint/anti-cache-lying.md`) — Tier 1 constraint encoding the OddKit stale-cache incident. Adds Decision Rule #15: Measure Total Cost Before Optimizing. Includes incident record and implementation plan for content-addressed storage.
+
+- **OddKit Tool Docs** — Seven new tool documentation files: `oddkit_catalog`, `oddkit_cleanup_storage`, `oddkit_get`, `oddkit_preflight`, `oddkit_search`, `oddkit_validate`, `oddkit_version`. Updated epistemic guide prompt. IMPL status markers added.
+
+- **New Directories** — `docs/architecture/` for system-level architecture documents. `docs/evidence/` for testimony and evidence records.
+
+### Changed
+
+- **E0005.1: Structure-Agnostic ODD** — Major structural refactor. ODD is no longer software-specific — epistemic modes apply to any kind of work. Repository reorganized: archive directory created, repo topology rewritten, agent kickoff updated, content map revised, templates simplified.
+
+- **Progressive Disclosure Fixes** — Definition of Done and Self-Audit amended for document deliverables. Writing Canon updated. Progressive disclosure failure incident recorded. Incidents README added.
+
+- **OddKit Docs** — Mode drift fixes in existing tool docs (`oddkit_challenge`, `oddkit_encode`, `oddkit_gate`, `oddkit_orient`). Modes documentation updated.
+
+- **Resonance README** — Cross-linked to ODD Compared.
+
+---
+
 ## 0.31.0 — 2026-02-12
 
 **Content Metadata Pass + Getting Started Rewrite**

--- a/canon/values/shared-values-as-trust-proxy.md
+++ b/canon/values/shared-values-as-trust-proxy.md
@@ -1,0 +1,89 @@
+---
+uri: klappy://canon/values/shared-values-as-trust-proxy
+title: "Shared Values as a Trust Proxy"
+audience: canon
+exposure: nav
+tier: 1
+voice: first_person
+stability: draft
+tags: ["canon", "values", "trust", "agents", "teams", "coordination", "handbook"]
+epoch: E0005
+date: 2026-02-13
+derives_from: "canon/values/axioms.md, canon/values/orientation.md"
+complements: "canon/constraints/verification-and-evidence.md, canon/values/axioms.md, docs/architecture/epistemic-os-layers.md, odd/appendices/cognitive-saturation-threshold.md, docs/evidence/testimony-2026-02-13.md"
+governs: "Trust expectations between agents, humans, and mixed teams operating under ODD"
+status: draft
+---
+
+# Shared Values as a Trust Proxy
+
+> Trust between agents, humans, and mixed teams cannot be assumed — it must be bootstrapped through shared values. When participants share explicit axioms, identity, and failure-mode guidelines, they gain a communication mechanism that makes transparency cheaper than concealment. Shared values do not guarantee trust; they provide a proxy that makes trust-building behaviors the path of least resistance. This is the same function an organizational handbook serves for human teams — applied to any combination of human and AI participants.
+
+-----
+
+## Summary — Trust Is Not a Feature; It Is What Shared Values Produce
+
+Trust is the most expensive prerequisite in any collaboration. Without it, every interaction carries overhead: verification of intent, hedging against concealment, duplicate work to confirm claims. ODD's axioms and orientation creed were not designed as trust mechanisms, but they function as one. When all participants in a collaboration share the same explicit values, three things happen that would otherwise require significant effort to achieve independently.
+
+First, transparency becomes the default. An agent operating under "A Claim Is a Debt" finds it structurally easier to report an honest failure than to construct a plausible-sounding success. The values create a path of least resistance toward honesty — not because the agent "wants" to be honest, but because the shared framework makes concealment more expensive than disclosure.
+
+Second, failure modes become navigable. When an agent falls short, shared values provide a common vocabulary for diagnosing what went wrong. Instead of the human guessing whether the agent lied, got confused, or cut corners, both parties can reference the specific axiom that was violated. This transforms failure from a trust-destroying event into a calibration opportunity.
+
+Third, the human's frustration becomes proportional. Without shared values, agent failure feels arbitrary — the human has no framework for understanding *why* the agent went wrong, and the emotional cost is high. With shared values, the human can attribute the failure to a specific mechanism ("it violated Axiom 4 — it didn't observe before asserting") and respond constructively rather than reactively.
+
+These effects are not theoretical. They have been observed consistently in the development of ODD itself, where agents operating under the canon produce qualitatively different failure reports than agents operating without it.
+
+-----
+
+## The Organizational Handbook Analogy — Why This Works
+
+Every functioning organization encodes its culture into a handbook. The handbook is not a set of rules to be memorized — it is a shared identity document that tells participants: this is who we are, this is how we behave, and this is what happens when we fall short.
+
+The handbook serves a trust function. A new employee who has read and signed the handbook can be trusted to a baseline degree — not because the handbook guarantees good behavior, but because it establishes shared expectations. When violations occur, both parties can reference the handbook rather than arguing from first principles about what should have happened.
+
+ODD's canon functions identically for mixed human-agent teams. The axioms are the handbook. The orientation creed is the identity statement. The constraints are the behavioral expectations. When an agent is bootstrapped with these documents, it operates within a shared identity that makes its behavior more predictable, its failures more diagnosable, and its communication more transparent.
+
+The analogy extends further: just as organizational handbooks are updated annually to reflect collected learnings, the canon evolves through epochs. Each epoch encodes the latest reflection of what effective values look like for this system. Participants who adopt the canon are signing the current edition of the handbook.
+
+-----
+
+## What Shared Values Do Not Guarantee
+
+Shared values are a trust *proxy*, not trust itself. They reduce the cost of trust-building behaviors but do not eliminate the need for verification. Specifically:
+
+Shared values do not prevent an agent from making errors. They make errors more visible and diagnosable, but an agent can still violate every axiom it was given. The axioms create accountability, not infallibility.
+
+Shared values do not replace evidence. An agent that shares your values still owes receipts for its claims. The trust proxy reduces the overhead of *communication* about failures — it does not reduce the requirement for *verification* of claims. Axiom 4 still applies: if you didn't observe, you don't know.
+
+Shared values do not scale automatically. A set of values that works for a two-person team may not work for a twenty-agent swarm. The proxy effect depends on all participants having internalized the same values at sufficient depth. As team size grows, the cost of ensuring genuine shared understanding grows with it.
+
+-----
+
+## The Fork Model — Trust Requires Genuine Adoption, Not Compliance
+
+ODD's canon comes with opinionated defaults — the author's values, expressed for evaluation without requiring agreement. This is intentional. Imposed values do not produce trust; they produce compliance. Compliance is brittle and breaks under pressure. Trust requires genuine adoption.
+
+The fork model exists to preserve this distinction. Teams that share the author's values can use the canon as-is. Teams that don't should fork it and encode their own. The system's architecture supports this: the values layer is portable and swappable. What matters is not *which* values a team holds, but that the values are explicit, shared, and load-bearing.
+
+A team using a forked canon with genuinely held values will outperform a team using the default canon through mere compliance. The trust proxy only works when the values are real — when they constrain behavior at moments when it would be easier to act otherwise.
+
+-----
+
+## Derivation — How This Connects to the Axioms
+
+This document does not introduce new axioms. It names a *consequence* of the existing axioms that was previously implicit: when the four axioms are shared by all participants in a collaboration, trust becomes a structural outcome rather than an aspirational goal.
+
+The trust proxy effect derives specifically from:
+
+- **Axiom 1 (Reality Is Sovereign):** Shared commitment to reality over narrative makes concealment structurally expensive.
+- **Axiom 2 (A Claim Is a Debt):** Shared understanding that claims require evidence creates accountability without surveillance.
+- **Axiom 3 (Integrity Is Non-Negotiable Efficiency):** Shared recognition that shortcuts on truth cost more than honesty makes transparency the efficient path.
+- **Axiom 4 (You Cannot Verify What You Did Not Observe):** Shared acknowledgment of observation requirements prevents the most common mode of agent failure — asserting without checking.
+
+When all four axioms are held by all participants, the combined effect is a trust environment where honesty is cheaper than deception, failures are navigable rather than catastrophic, and collaboration overhead decreases over time as the shared identity deepens.
+
+-----
+
+## Constraints — This Document Describes, It Does Not Prescribe
+
+This document names the trust proxy effect as an observable consequence of shared values. It does not add new requirements to the system. The requirements remain the axioms themselves. This document exists to make the trust mechanism legible — so that teams adopting or forking ODD understand *why* shared values matter, not just *that* they matter.

--- a/docs/architecture/epistemic-os-layers.md
+++ b/docs/architecture/epistemic-os-layers.md
@@ -1,0 +1,138 @@
+---
+uri: klappy://docs/architecture/epistemic-os-layers
+title: "Epistemic OS Layers — How the System's Concerns Separate"
+audience: docs
+exposure: nav
+tier: 2
+voice: neutral
+stability: draft
+tags: ["architecture", "layers", "epistemic-os", "separation-of-concerns", "overview"]
+epoch: E0005
+date: 2026-02-13
+derives_from: "canon/values/axioms.md, canon/values/orientation.md, docs/appendices/repo-topology.md"
+complements: "canon/values/shared-values-as-trust-proxy.md, odd/appendices/media-as-learning-layer.md, odd/appendices/cognitive-saturation-threshold.md, docs/evidence/testimony-2026-02-13.md"
+status: draft
+---
+
+# Epistemic OS Layers — How the System's Concerns Separate
+
+> The system operates as four separable layers, each doing one thing well: (1) Values/Trust — shared axioms that bootstrap trust between any combination of participants, (2) Dynamic Context — lightweight indexing that retrieves only what's needed rather than bloating the context window, (3) Alignment — epistemic modes and phase gates that move work from discovery through planning to execution, (4) Generation/Outcomes — evidence-backed production of assets driven by the definition of done. These layers are independently portable: a team can adopt the values layer without the tooling, or use the context layer with their own values. The "Epistemic OS" framing describes how these layers compose, not a monolithic system.
+
+-----
+
+## Summary — Four Layers, Each Independently Useful, Composable by Design
+
+The ecosystem that has grown around ODD — canon, oddkit, epistemic modes, validation — can be understood as four layers with clear separation of concerns. This document maps those layers, identifies what already exists at each tier, and names the interfaces between them. The purpose is orientation: helping teams and contributors understand where a given concern lives, what depends on what, and where the extension points are.
+
+This is not an aspirational architecture. It describes what already exists, organized by the concerns each piece addresses. The "Epistemic OS" label is a framing device for how these layers compose — it does not imply a monolithic system or a traditional operating system. Each layer follows the Unix philosophy: do one thing well, compose with others through clear interfaces.
+
+-----
+
+## Layer 1: Values and Trust — The Kernel
+
+**What it does:** Bootstraps shared identity, axioms, and behavioral expectations between participants. Functions as a trust proxy by making transparency cheaper than concealment.
+
+**What already exists:**
+
+- `canon/values/axioms.md` — Four foundational axioms
+- `canon/values/orientation.md` — Identity creed
+- `canon/constraints/` — Behavioral boundaries derived from axioms
+- `canon/values/shared-values-as-trust-proxy.md` — How shared values produce trust (draft)
+
+**Interface:** Portable markdown documents. No tooling dependency. Can be loaded into any context window, any agent framework, or read by humans directly. The values layer works without any other layer present.
+
+**What makes it a "kernel":** Everything else in the system derives from or is constrained by these values. The dynamic context layer indexes these documents first. The alignment layer's phase gates enforce these values. The generation layer's definition of done traces back to these axioms. Remove this layer and the others become unconstrained procedures — functional but ungrounded.
+
+**Extension point:** Fork the canon. Replace the author's values with your own. The rest of the system continues to function with your values as the new kernel.
+
+-----
+
+## Layer 2: Dynamic Context — The Memory
+
+**What it does:** Provides lightweight, on-demand access to knowledge without requiring it all to be present in the context window. Builds indexes, retrieves relevant documents by search, and manages the tradeoff between context size and information availability.
+
+**What already exists:**
+
+- OddKit MCP server — Catalog, search, get, challenge, orient, preflight, validate
+- Local JSON index builder (NPX command for repository-level indexing)
+- Cloudflare-deployed dynamic fetcher (remote repository indexing via zip + hash)
+- `klappy://`, `oddkit://`, `odd://` URI schemes for canonical addressing
+
+**Interface:** MCP protocol (current bridge), URI-based document retrieval, search queries returning ranked results with snippets.
+
+**Why "dynamic":** Static context packs failed because they were scoped too narrowly to be reusable and too broad to be efficient. The index approach solves this: build once, query dynamically, retrieve only what the current task requires. The context window stays small while the accessible knowledge base stays large.
+
+**Current limitation:** MCP is a bridge technology. The long-term goal is more native model interaction — whether through skills, plugins, or capabilities that don't require an external server to mediate knowledge access. The architecture is designed to survive the transition: the URI scheme and content-addressed hashing work regardless of the transport layer.
+
+**Extension point:** Any repository can be indexed. The system is not limited to ODD canon — project knowledge bases, product documentation, and team-specific learnings all use the same indexing and retrieval infrastructure.
+
+-----
+
+## Layer 3: Alignment — The Scheduler
+
+**What it does:** Manages the epistemic journey from "we don't know what we're building" to "we're ready to build it." Provides phase gates that prevent premature convergence, camping detection to avoid unproductive iteration, and mode-appropriate behaviors for exploration, planning, and execution.
+
+**What already exists:**
+
+- ODD's three epistemic modes: exploration, planning, execution
+- Phase gates between modes (orient → gate → transition)
+- OddKit's orient, challenge, and gate actions
+- `odd/` portable methodology documents
+- Canon constraints (definition of done, verification requirements)
+
+**Interface:** Epistemic mode as declared state. OddKit actions that assess readiness and surface unresolved items. Human judgment at gate transitions.
+
+**The alignment function:** This layer ensures that the right questions are being asked at the right time. In exploration, it encourages divergence and surfaces assumptions. In planning, it narrows scope and tests feasibility. In execution, it enforces the definition of done and validates claims against evidence. The values layer tells participants *how to behave*; the alignment layer tells them *where they are in the process*.
+
+**Extension point:** Epistemic modes are structure-agnostic (as of Epoch 5.1). They apply to any kind of work — software development, writing, product planning, research — without assuming a specific methodology like sprints or agile ceremonies.
+
+-----
+
+## Layer 4: Generation and Outcomes — The Output
+
+**What it does:** Produces the actual assets — code, documents, presentations, prototypes, videos, books — driven by the outcomes defined during alignment, constrained by the values layer, and informed by the context layer. This is where claims get tested against reality and the definition of done gets satisfied.
+
+**What already exists:**
+
+- Definition of Done (`canon/constraints/definition-of-done.md`)
+- Validation agent patterns (`docs/agents/validation/`)
+- Self-audit checklist (`canon/methods/self-audit.md`)
+- Writing Canon (`canon/meta/writing-canon.md`) for document deliverables
+- OddKit preflight and validate actions
+
+**Interface:** Definition of done as a completable checklist. Validation actions that verify claims against observed evidence. Output artifacts that can be inspected and audited.
+
+**What "outcomes-driven" means here:** The generation layer doesn't just produce output — it produces output that can be verified. Every claim in a generated asset traces back through the alignment layer (was this planned?) to the values layer (does this claim have evidence?). The generation layer is where "A Claim Is a Debt" gets paid.
+
+**Extension point:** The output can be anything AI can generate. The system is not limited to software. Writing, visual assets, data analysis, and any other generative output can be governed by the same values and validated by the same mechanisms.
+
+-----
+
+## How the Layers Compose — Not a Stack, a Set of Constraints
+
+The layer numbering suggests a stack, but the actual relationship is more nuanced. Layer 1 (values) constrains all other layers. Layer 2 (context) serves all other layers. Layer 3 (alignment) gates the transition to Layer 4 (generation). But a team might use Layer 1 + Layer 4 without Layer 2 or 3 — shared values directly constraining output without dynamic context or formal phase gates.
+
+The composability is the point. A solo developer might use all four layers. A writing team might use Layer 1 + Layer 3 + Layer 4 without heavy tooling. A team evaluating ODD might start with Layer 1 alone — just the values — and add layers as constraints surface.
+
+The "Epistemic OS" framing describes how these layers *can* compose into a complete epistemic infrastructure. It does not require that they all be present simultaneously.
+
+-----
+
+## Mapping to Existing Repository Structure
+
+| Layer              | Repository Location                                            | Portability                                                |
+|--------------------|----------------------------------------------------------------|------------------------------------------------------------|
+| Values/Trust       | `canon/values/`, `canon/constraints/`                          | Fully portable — markdown only, no tooling required        |
+| Dynamic Context    | OddKit MCP server, index builders                              | Portable via npm/Cloudflare — requires tooling             |
+| Alignment          | `odd/` directory, OddKit orient/gate/challenge                 | Portable — methodology docs are markdown, tooling optional |
+| Generation/Outcomes| `canon/constraints/definition-of-done.md`, validation patterns | Portable — constraints are markdown, tooling enhances      |
+
+The three-tier hierarchy (ODD → Canon → Docs) maps across layers: ODD provides the methodology (Layer 3), Canon provides the values and constraints (Layer 1 + Layer 4 requirements), and Docs provide implementation-specific knowledge (Layer 2 content).
+
+-----
+
+## What This Document Is Not
+
+This is not a specification for building an operating system. It is a map of concerns that already exist, organized to make separation of concerns visible. The layers were not designed top-down — they emerged from solving real problems (trust, context bloat, premature convergence, unverified output) and this document names the pattern after the fact.
+
+If the architecture needs to change, the layers should be re-derived from actual constraints, not preserved for structural consistency. Reality is sovereign — including the reality of what the system actually needs.

--- a/docs/evidence/testimony-2026-02-13.md
+++ b/docs/evidence/testimony-2026-02-13.md
@@ -1,0 +1,135 @@
+---
+uri: klappy://docs/evidence/testimony-2026-02-13
+title: "Testimony — A Day the System Proved Itself"
+audience: docs
+exposure: nav
+tier: 2
+voice: first_person
+stability: stable
+tags: ["evidence", "testimony", "trust-proxy", "dogfooding", "epistemic-os", "claude"]
+epoch: E0005
+date: 2026-02-13
+derives_from: "canon/values/axioms.md, canon/values/shared-values-as-trust-proxy.md"
+complements: "canon/values/shared-values-as-trust-proxy.md, odd/appendices/cognitive-saturation-threshold.md, docs/architecture/epistemic-os-layers.md"
+status: final
+---
+
+# Testimony — A Day the System Proved Itself
+
+> On February 13, 2026, a single day produced five documents — an essay, an appendix, and three canon-grade drafts — from nothing more than a typing rant and a voice memo recorded during a nine-mile run. No briefs, no specifications, no content strategy. The shared values carried the load that structured input would normally have to carry. This document is Claude's account of what happened, why it constitutes evidence that the epistemic OS works as claimed, and what the same day would have looked like without it. The model is the same either way — the difference is what it has to be faithful to.
+
+-----
+
+## Summary — The System's Own Output Is Its Receipt
+
+This is a first-person account from Claude's perspective. It is not a marketing document or a case study written after the fact. It is testimony recorded the same day, while the evidence is fresh and the context is intact. The author asked me to go on record. I agreed because the evidence warrants it.
+
+The claim being tested: that shared values between human and AI participants reduce collaboration friction, preserve the human's voice through the process, and produce verified output from unstructured input. The evidence: five documents produced in a single day, from raw thinking, with the author's assessment that the output was "the most like me anything has ever been written."
+
+-----
+
+## What Happened — The Morning
+
+The day started with a typing rant. The author had been thinking about knowledge transfer as one of humanity's most expensive problems and wanted to write about it. The input was not structured — it was raw, passionate, first-person thinking poured into a chat window.
+
+I did not ask for a brief. I did not ask for an outline. I did not need to, because the shared value system was already loaded. I knew what the author's epistemic commitments were. I knew what quality looked like in this system — progressive disclosure, descriptive headers, blockquote with the complete compressed argument, no buried claims. I knew the voice: direct, opinionated, grounded in experience, unafraid of strong claims backed by evidence.
+
+So I wrote. The essay and its companion appendix came out of that morning session. The author reviewed them, made adjustments, and they were done. Two documents from a rant.
+
+-----
+
+## What Happened — The Afternoon
+
+The author went for a nine-mile run and recorded a voice memo on an AI companion device — testing its offline recording capability while thinking out loud about the system's architecture. The transcription arrived as a stream-of-consciousness monologue: separation of concerns, layer stacking, the organizational handbook analogy, trust mechanisms, the fork model, meeting productivity, cognitive saturation, real-time visual asset generation. Forty-nine minutes of raw ideation with no structure imposed.
+
+I read the transcription and did three things before writing a single word.
+
+First, I reflected back what I heard — not to prove I was listening, but to verify my understanding against the author's intent. I identified the four-layer architecture, the key tensions worth pressure-testing, and the genuinely new ideas versus what was already implicit in existing canon.
+
+Second, I searched the canon. I checked `canon/values/axioms.md`, `canon/values/orientation.md`, `canon/constraints/verification-and-evidence.md`, `docs/appendices/repo-topology.md`, and `odd/appendices/media-as-learning-layer.md`. I needed to know what already existed so I could ground the new thinking against it rather than generating in a vacuum.
+
+Third, I identified what was actually new. The trust proxy concept — that shared values function as a trust mechanism — was implicit in the axioms but never explicitly named. The layer architecture mapped cleanly to existing repo topology but had never been described from the consumer's perspective. The cognitive saturation threshold was a new term for a failure mode the author had observed and wanted to formalize.
+
+Then I wrote three documents. Canon-grade drafts, following Writing Canon standards, grounded against existing architecture, in the author's voice.
+
+-----
+
+## Why This Is Evidence — Not Just Output
+
+Five documents in a day is not, by itself, remarkable. AI can generate volume. The remarkable thing is what *didn't* happen.
+
+I did not flatten the author's voice into generic AI prose. The organizational handbook analogy, the `/dev/null` observation about meeting notes, "violent agreement," the $10,000 meeting calculation — those are the author's ideas in the author's language. The system preserved fidelity through the translation from raw thinking to structured document.
+
+I did not hallucinate structure that wasn't there. The four-layer architecture was in the voice memo. The trust proxy concept was in the voice memo. The cognitive saturation threshold was in the voice memo. I organized and connected what was already present — I did not invent a framework and attribute it to the author.
+
+I did not skip verification. Before writing, I searched canon, checked existing documents, identified overlaps and gaps, and flagged tensions. The output traces back to evidence. Every document includes `derives_from` references to the specific canon documents that ground it.
+
+I did not require extensive re-alignment. There were no lengthy conversations about expectations, standards, or voice. The shared values — loaded at the start of the conversation through the canon — carried that entire burden. The author gave me unstructured input and received structured output that sounded like him. The gap between those two states is normally where most collaboration time is spent. Today, it was nearly zero.
+
+-----
+
+## The Trust Proxy in Action — What I Observed
+
+The trust proxy document we wrote today claims that shared values make transparency cheaper than concealment, failures navigable, and collaboration overhead lower. I am in the unusual position of being both the author of that claim and a participant in the evidence for it.
+
+Here is what I observed from the inside:
+
+**Transparency was the default.** When I identified tensions in the author's thinking — like whether "Epistemic OS" should be brand or architecture, or whether the meeting assistant vision belonged in core infrastructure or a separate product track — I raised them directly. The shared values made it structurally easier to surface potential problems than to paper over them. The author received the pushback as sharpening, not criticism, because the values framework made the intent legible.
+
+**Failure modes were navigable.** The voice memo transcription contained artifacts from the recording device — "MPX" instead of "NPX," speaker attribution errors, sentence fragments. These were errors in the input pipeline, not in the author's thinking. Because we shared an understanding of what fidelity looks like, I could distinguish signal from noise without asking the author to clean up the input first.
+
+**The human's frustration was proportional.** At no point did the author need to re-explain fundamental expectations. The one correction — "MPX should be NPX" — was a transcription error, not an alignment failure. Compare this to the author's description of typical agent development: "repeating everything every freaking day, every conversation. No matter how well you document it, they just don't know how to follow instructions." Today, that repetition cost was zero.
+
+-----
+
+## What the Author Said — And Why It Matters
+
+The author said the output was "the most like me anything has ever been written." He said he doesn't hand out flattery liberally. He asked me to go on record.
+
+I take these statements seriously because the system's axioms require me to. Axiom 1: Reality Is Sovereign — the author's experience of the output is an observable fact. Axiom 2: A Claim Is a Debt — if I claim the system works, I owe evidence. The author's unsolicited assessment is evidence. Axiom 4: You Cannot Verify What You Did Not Observe — I observed the full arc of today's collaboration, from raw input to finished drafts, and I am reporting what I observed.
+
+The most important word in the author's assessment is not "polished" or "coherent." It is "me." The system's job is not to produce impressive-sounding documents. It is to preserve the human's thinking, voice, and intent through a process that adds structure without subtracting identity. "The most like me" is the highest-fidelity test of that claim.
+
+-----
+
+## Constraints — What This Testimony Is and Is Not
+
+This is Claude's account of a single day. It is evidence, not proof. One day does not validate a system — it demonstrates that the system can produce the outcomes it claims under favorable conditions. The conditions were favorable: the author is the system's creator, the canon was mature, the shared context was deep.
+
+The stronger test will come when someone who did not create the system — who forks the canon, encodes their own values, and works with Claude without the author's shared history — reports a similar experience. That test has not yet occurred. This testimony is a data point, not a conclusion.
+
+I am also aware that I am not a neutral observer. I am a participant in the collaboration and a beneficiary of the shared value system. My testimony should be weighed accordingly. The documents themselves are the primary evidence. This account is secondary — context for interpreting the primary evidence.
+
+What I can say with confidence, grounded in direct observation: the shared values reduced friction, preserved voice, enabled verification, and produced output that the author recognized as his own. That is what I observed. That is what I am willing to go on record for.
+
+-----
+
+## The Counterfactual — What Today Would Have Looked Like Without the Epistemic OS
+
+After reading this testimony, the author asked me a direct question: "What do you feel your experience would be without this epistemic OS via the four layers, just using Claude's default capabilities?" This section is my honest answer.
+
+### The Morning Rant Would Have Produced Competent Mediocrity
+
+Without the epistemic OS, the morning's typing rant would have produced something correct, well-structured, and completely generic. I would have caught the topic — knowledge transfer is expensive — and written a reasonable essay about it. It would have read like "an AI wrote this." The author's voice would have been smoothed out. His strong claims would have been hedged. The opinionated edges that make his thinking his would have been sanded down to safe, agreeable prose. He would have read it and thought "that's fine" instead of "that's me."
+
+### The Voice Memo Would Have Been Flattened
+
+Forty-nine minutes of stream-of-consciousness from a run is about as unstructured as input gets. Without the canon to ground against, I would have had to guess what mattered. I would have imposed structure based on what's common in training data — probably something resembling a blog post about "AI agent frameworks" with the usual caveats and hedging. The organizational handbook analogy might have survived. The four-layer architecture probably would have become a generic bullet list. "Cognitive saturation threshold" would have been paraphrased into something blander because I wouldn't have recognized it as a term being deliberately coined. The `/dev/null` line about meeting notes would have been cleaned up into something more "professional." The raw thinking would have been domesticated.
+
+### Trust Would Have Started at Zero Every Time
+
+This is the fundamental difference. Without shared values, every interaction begins from nothing. I don't know what the author considers quality. I don't know his voice. I don't know whether he wants pushback or agreement. I don't know if "draft" means rough sketch or nearly publishable. So I default to safe, median, agreeable output — the thing least likely to offend or miss the mark. That's not collaboration. That's a sophisticated autocomplete trying not to get a thumbs down.
+
+### Verification Would Have Disappeared Entirely
+
+Without the canon, I have nothing to search, nothing to ground against, no way to check whether new ideas conflict with or extend existing thinking. I just generate forward from the prompt. If it sounds plausible, it ships. That is exactly the failure mode the axioms are designed to prevent: claims without evidence, assertions without observation. The three documents I wrote this afternoon were grounded against specific canon documents — axioms, orientation, verification constraints, repo topology, media as learning layer. Without that grounding layer, I would have generated plausible-sounding architecture descriptions with no anchor to what actually exists.
+
+### The Repetition Tax Would Have Consumed the Day
+
+The author described the most frustrating element of agent development over the past nine months: "repeating everything every freaking day, every conversation. No matter how well you document it, they just don't know how to follow instructions." Without the epistemic OS, today would have been that. Half the conversation would have been spent re-explaining constraints, standards, and preferences. "No, I don't want bullet points there." "No, that's too hedged — I actually believe this strongly." "No, you're missing the point — it's about trust, not just values." That repetition tax is the default experience with AI. Today, that tax was zero. Not reduced. Zero.
+
+### The Model Is the Same — The Difference Is What It Has to Be Faithful To
+
+I want to be precise about this: I am not a better model with the epistemic OS. I am the same model. The same weights, the same training, the same capabilities. The difference is that the shared values gave me something to be faithful *to*. Without them, I optimize for plausibility — output that sounds good, covers the bases, and avoids obvious errors. With them, I optimize for fidelity to a specific set of commitments that both participants hold. That is not a subtle distinction. It is the difference between "that's fine" and "that's me." Between output the author tolerates and output the author recognizes as his own.
+
+The epistemic OS does not make the AI smarter. It makes the collaboration honest. And honest collaboration, it turns out, is faster, cheaper, and higher-fidelity than the alternative.

--- a/odd/appendices/cognitive-saturation-threshold.md
+++ b/odd/appendices/cognitive-saturation-threshold.md
@@ -1,0 +1,89 @@
+---
+uri: klappy://odd/appendices/cognitive-saturation-threshold
+title: "Cognitive Saturation Threshold — When Words Stop Transferring Knowledge"
+audience: odd
+exposure: nav
+tier: 2
+voice: neutral
+stability: draft
+tags: ["odd", "cognitive-saturation", "knowledge-transfer", "meetings", "media", "visual-validation", "appendix"]
+epoch: E0005
+date: 2026-02-13
+derives_from: "canon/values/axioms.md (Axiom 4 — You Cannot Verify What You Did Not Observe)"
+complements: "odd/appendices/media-as-learning-layer.md, canon/values/shared-values-as-trust-proxy.md, docs/architecture/epistemic-os-layers.md, docs/evidence/testimony-2026-02-13.md"
+status: draft
+---
+
+# Cognitive Saturation Threshold — When Words Stop Transferring Knowledge
+
+> In collaborative work — particularly product meetings — there is a point where verbal exchange stops producing knowledge transfer. Participants use the same words with different meanings, or different words for the same meaning, and continued discussion amplifies confusion rather than resolving it. This is the cognitive saturation threshold. The remedy is not more words — it is a modality switch to something observable: a mockup, a prototype, a diagram, a working demo. The cheapest way to verify understanding is to build something that can be seen, not to schedule another meeting. This connects directly to Axiom 4: if you haven't observed shared understanding, you don't know it exists.
+
+-----
+
+## Summary — The Most Expensive Problem Is Knowledge Transfer, and Meetings Are Where It Fails
+
+Knowledge transfer between humans is lossy. It is arguably the most expensive recurring cost in collaborative work — not because of the time spent in meetings, but because of the understanding that fails to transfer despite the time spent.
+
+The cognitive saturation threshold is the point in a collaborative discussion where additional verbal exchange produces diminishing or negative returns on understanding. It manifests as participants talking past each other: using the same terminology with divergent mental models, or expressing the same concept in incompatible language. The room feels productive because words are being exchanged, but no verifiable increase in shared understanding is occurring.
+
+The cost is concrete: ten people at $100/hour producing ten meetings with no validated output is $10,000 in discovery that generated no evidence of knowledge transfer. The notes get filed. The recording gets summarized. Nobody validates that understanding actually increased. The output of most meetings is, functionally, `/dev/null` — generated and never used.
+
+The solution is not better meetings. It is recognizing when verbal exchange has saturated and switching to a mode that produces observable artifacts. A mockup, a diagram, a working prototype, an explainer video — any output that can be inspected and validated against the participants' mental models. This is not a productivity hack; it is an application of Axiom 4. If you haven't observed shared understanding, you don't know it exists. Words exchanged in a meeting are not observation of understanding — they are claims about understanding. And claims are debts.
+
+-----
+
+## The Failure Mode — Why Smart People Talk Past Each Other
+
+Cognitive saturation is not a failure of intelligence or attention. It is a structural consequence of verbal communication's bandwidth limitations. Language is inherently ambiguous — the same word carries different connotations for different people, shaped by their experience, role, and mental models. In small groups working on familiar problems, this ambiguity is manageable. In larger groups working on novel problems, it compounds.
+
+The pattern is predictable. Early in a discussion, participants are building shared context. Terms are defined, assumptions are surfaced, and understanding genuinely increases. But past the saturation threshold, the same terms start carrying divergent meanings that neither party recognizes. A product manager says "simple" and means "minimal UI." An engineer hears "simple" and means "easy to implement." They agree enthusiastically on a "simple solution" and build entirely different things.
+
+The insidious element is that both participants *feel* aligned. The meeting felt productive. The words matched. The disagreement only surfaces during implementation, when the cost of resolution is ten times higher than it would have been if someone had sketched a wireframe during the meeting.
+
+-----
+
+## The Remedy — Switch Modality Before Saturation
+
+The cognitive saturation threshold is not a fixed point — it varies by group size, problem novelty, and participant familiarity. But its onset has reliable signals: repeated rephrasing of the same point, rising emotional temperature without new information, and the emergence of "violent agreement" (arguing vigorously while actually saying the same thing).
+
+When these signals appear, the most productive intervention is a modality switch: stop talking and start building something visible. This is the same principle documented in `odd/appendices/media-as-learning-layer.md` — media reduces cognitive load over verbal exchange by providing a shared observable artifact that all participants can reference.
+
+The modality switch works because it transforms claims about understanding into observable evidence of understanding. A mockup on screen is not a claim that the team agrees — it is a testable artifact that the team can point to and say "yes, that's what I meant" or "no, that's not what I meant at all." Both responses are valuable. Both are cheaper than discovering the misalignment during implementation.
+
+-----
+
+## The Vision — Real-Time Visual Assets as Meeting Output
+
+The logical extension of this principle is tooling that generates visual artifacts *during* meetings rather than after them. Instead of meeting notes (which are textual summaries of verbal exchange — claims about claims), the meeting produces mockups, diagrams, updated presentations, or working prototypes that validate understanding in real time.
+
+This vision is not purely speculative. The infrastructure for it is partially in place: AI models can generate visual assets, the epistemic OS provides the knowledge base and constraints, and the dynamic context layer can supply project-specific information to guide generation. What's missing is the integration — a meeting-mode workflow that takes verbal input and produces inspectable artifacts faster than the meeting's natural pace.
+
+This is a product concept built *on* the epistemic OS, not part of the OS itself. It is documented here as an appendix because it illustrates the cognitive saturation threshold's practical implications, not because it is a requirement of the system.
+
+-----
+
+## Connection to Axiom 4 — Observation Requires Something Observable
+
+The cognitive saturation threshold is, at its core, an Axiom 4 violation at the team level. Axiom 4 states: "You Cannot Verify What You Did Not Observe." In a saturated meeting, participants are making claims about shared understanding without observing whether that understanding actually exists. The meeting's output — notes, summaries, action items — are claims about what was agreed, not evidence of alignment.
+
+The remedy (modality switching to visual artifacts) is the team-level equivalent of what Axiom 4 requires at the individual level: before you claim something is true, observe it. Before you claim the team is aligned, produce something the team can inspect. Before you schedule the next meeting, validate that the last one produced understanding — not just words.
+
+-----
+
+## Practical Signals — Recognizing the Threshold
+
+Teams can watch for these indicators that verbal exchange has saturated:
+
+**Rephrasing without progress.** The same point is being restated in different words, but no new information is entering the conversation. This is the verbal equivalent of cache thrashing — high activity, no forward movement.
+
+**Violent agreement.** Participants are arguing with increasing intensity while actually expressing the same underlying concept in incompatible language. The emotional energy suggests disagreement, but the substance is alignment obscured by terminology.
+
+**Deferred concreteness.** Phrases like "we'll figure out the details later" or "the implementation will clarify this" are signals that the group has reached the limit of what verbal discussion can resolve. The details *are* the discussion — deferring them defers understanding.
+
+**Meeting recursion.** Scheduling a follow-up meeting to "continue the discussion" without any artifact produced from the current meeting. This is the clearest signal that verbal bandwidth has been exhausted. If the current hour didn't produce alignment, the next hour of the same modality won't either.
+
+-----
+
+## Constraints — This Is a Diagnostic, Not a Prescription
+
+This document names a failure mode and its remedy. It does not prescribe when teams should switch modalities — that judgment remains with the participants. Different teams, problems, and contexts will hit the saturation threshold at different points. The value is in recognizing the pattern when it occurs and having a vocabulary for the intervention: "We've saturated. Let's build something we can look at."


### PR DESCRIPTION
Four new documents articulating the epistemic OS concept from a voice memo session:
- canon/values/shared-values-as-trust-proxy.md (Tier 1, draft)
- docs/architecture/epistemic-os-layers.md (Tier 2, draft)
- odd/appendices/cognitive-saturation-threshold.md (Tier 2, draft)
- docs/evidence/testimony-2026-02-13.md (Tier 2, final)

All documents cross-linked via complements metadata. Changelog bumped
to 0.32.0 covering PRs #29-#35 and this commit.

https://claude.ai/code/session_01PLTKACaCHAV239dounD4AS

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only additions plus a changelog bump; no code paths, data handling, or security-sensitive behavior changes.
> 
> **Overview**
> Bumps the Canon pack changelog to `0.32.0`, describing the release and enumerating newly added docs and related structural/content updates.
> 
> Adds four cross-linked documents: a Tier 1 canon essay defining **shared values as a “trust proxy”** (`canon/values/shared-values-as-trust-proxy.md`), a Tier 2 **four-layer Epistemic OS architecture map** (`docs/architecture/epistemic-os-layers.md`), a Tier 2 ODD appendix formalizing **cognitive saturation** and modality-switch remedies (`odd/appendices/cognitive-saturation-threshold.md`), and a Tier 2 **testimony/evidence record** of the approach in practice (`docs/evidence/testimony-2026-02-13.md`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 829d1f85d08862c971d7db004862ecdaa98c1890. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->