### PR TITLE
Fix start_here_order collisions and reorder homepage sections

### DIFF
--- a/canon/constraints/README.md
+++ b/canon/constraints/README.md
@@ -10,7 +10,7 @@ tags: ["constraints", "assumptions"]
 relevance: decision
 execution_posture: governing
 start_here: true
-start_here_order: 5
+start_here_order: 14
 start_here_label: Constraints
 ---
 

--- a/canon/constraints/definition-of-done.md
+++ b/canon/constraints/definition-of-done.md
@@ -11,7 +11,7 @@ derives_from: "canon/values/axioms.md (Axiom 2 — A Claim Is a Debt)"
 relevance: decision
 execution_posture: governing
 start_here: true
-start_here_order: 4
+start_here_order: 13
 start_here_label: Definition of Done
 ---
 

--- a/canon/values/axioms.md
+++ b/canon/values/axioms.md
@@ -11,7 +11,7 @@ epoch: E0005
 date: 2026-02-09
 governs: "All epistemic constraints, validators, and definitions of done derive from these axioms"
 start_here: true
-start_here_order: 12
+start_here_order: 11
 start_here_label: Foundational Axioms
 ---
 

--- a/canon/values/shared-values-as-trust-proxy.md
+++ b/canon/values/shared-values-as-trust-proxy.md
@@ -14,7 +14,7 @@ complements: "canon/constraints/verification-and-evidence.md, canon/values/axiom
 governs: "Trust expectations between agents, humans, and mixed teams operating under ODD"
 status: final
 start_here: true
-start_here_order: 9
+start_here_order: 3
 start_here_label: "Shared Values as a Trust Proxy"
 ---
 

--- a/docs/architecture/epistemic-os-layers.md
+++ b/docs/architecture/epistemic-os-layers.md
@@ -13,7 +13,7 @@ derives_from: "canon/values/axioms.md, canon/values/orientation.md, docs/appendi
 complements: "canon/values/shared-values-as-trust-proxy.md, odd/appendices/media-as-learning-layer.md, odd/appendices/cognitive-saturation-threshold.md, docs/evidence/testimony-2026-02-13.md, writings/the-most-expensive-problem.md"
 status: final
 start_here: true
-start_here_order: 11
+start_here_order: 4
 start_here_label: "How the System Works"
 ---
 

--- a/odd/appendices/cognitive-saturation-threshold.md
+++ b/odd/appendices/cognitive-saturation-threshold.md
@@ -13,7 +13,7 @@ derives_from: "canon/values/axioms.md (Axiom 4 — You Cannot Verify What You Di
 complements: "odd/appendices/media-as-learning-layer.md, canon/values/shared-values-as-trust-proxy.md, docs/architecture/epistemic-os-layers.md, docs/evidence/testimony-2026-02-13.md, writings/the-most-expensive-problem.md"
 status: final
 start_here: true
-start_here_order: 13
+start_here_order: 5
 start_here_label: "Cognitive Saturation Threshold"
 ---
 

--- a/odd/manifesto.md
+++ b/odd/manifesto.md
@@ -10,7 +10,7 @@ tags: ["odd", "philosophy", "outcomes-driven-development", "manifesto", "governa
 relevance: background
 execution_posture: exploratory
 start_here: true
-start_here_order: 14
+start_here_order: 12
 start_here_label: The Manifesto
 epoch: E0005
 derives_from: "canon/values/axioms.md"

--- a/writings/the-most-expensive-problem.md
+++ b/writings/the-most-expensive-problem.md
@@ -46,7 +46,7 @@ related:
     relationship: appendix
 complements: "writings/the-parallel-architecture.md, canon/values/shared-values-as-trust-proxy.md, docs/architecture/epistemic-os-layers.md, odd/appendices/cognitive-saturation-threshold.md, docs/evidence/testimony-2026-02-13.md"
 start_here: true
-start_here_order: 7
+start_here_order: 1
 start_here_label: "The Most Expensive Problem — Why This Exists"
 ---
 

--- a/writings/the-parallel-architecture.md
+++ b/writings/the-parallel-architecture.md
@@ -48,7 +48,7 @@ related:
     relationship: parent
 complements: "writings/the-most-expensive-problem.md, canon/values/shared-values-as-trust-proxy.md, docs/architecture/epistemic-os-layers.md, docs/evidence/testimony-2026-02-13.md"
 start_here: true
-start_here_order: 8
+start_here_order: 2
 start_here_label: "The Parallel Architecture — Where the Axioms Came From"
 ---
 


### PR DESCRIPTION
Public story arc (START HERE, orders 1-6) now leads with
the-most-expensive-problem and the-parallel-architecture,
followed by trust proxy, system layers, cognitive saturation,
and Claude's testimony. Internal governance docs (GO DEEPER,
orders 10-14) are moved after the public content. No two
documents share the same start_here_order value.

https://claude.ai/code/session_01K1K8L8qQX7VYbw5DEvcRvE

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only documentation changes that affect navigation ordering, with no runtime logic or data-handling impact.
> 
> **Overview**
> Reorders the `start_here_order` frontmatter across several canon/odd/docs/writings pages to create a clear public “Start Here” reading arc (leading with `writings/the-most-expensive-problem.md` and `writings/the-parallel-architecture.md`, then trust/layers/saturation) and to move internal governance content later.
> 
> This also eliminates duplicate `start_here_order` values by renumbering affected documents (e.g., `canon/values/axioms.md`, `canon/constraints/definition-of-done.md`, `canon/constraints/README.md`, `odd/manifesto.md`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 75b65f5e1b40555b2f0bb656361280afb5e0351c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->