### PR TITLE
Implement 10 documents from Feb 15-16 handoff session

### DIFF
--- a/canon/methods/borrow-bend-break-beget-build.md
+++ b/canon/methods/borrow-bend-break-beget-build.md
@@ -1,0 +1,116 @@
+---
+uri: klappy://canon/methods/borrow-bend-break-beget-build
+title: "Method: Borrow, Bend, Break, Beget, Build"
+audience: canon
+exposure: nav
+tier: 2
+voice: neutral
+stability: stable
+tags: ["canon", "methods", "5B", "borrow", "bend", "break", "beget", "build", "leverage", "delegation"]
+epoch: E0005
+date: 2026-02-15
+derives_from:
+  - odd/constraint/use-only-what-hurts.md
+  - canon/values/trust-kernel.md
+complements: "canon/methods/self-audit.md, canon/methods/weighted-relevance-and-arbitration.md"
+---
+
+# Method: Borrow, Bend, Break, Beget, Build
+
+> The canonical sequence for maximizing work not done. Before building anything yourself, attempt to borrow what exists, bend it to your context, and let the breaks reveal what's missing. When something is missing, beget it — offload it to others who can own that piece and build it in parallel, even imperfectly. Only build yourself what nobody else can carry. The epistemic ledger is what makes this sequence compound — without it, each step starts from zero.
+
+-----
+
+## Summary — Five Steps That Progressively Narrow What You Must Build Yourself
+
+Most premature building happens because people skip straight from idea to construction. They don't inventory what exists, don't test whether existing tools can be repurposed, don't let friction reveal what's genuinely missing, and don't consider whether someone else could own the missing piece.
+
+This sequence forces progressive narrowing. Each step reduces the surface area of what you must build yourself. The result is maximum leverage with minimum original work — which directly serves the agile principle of maximizing the amount of work not done.
+
+The sequence depends on the epistemic ledger. Decisions and constraints from earlier steps must persist into later steps without relying on human memory or conversation history. Without the ledger, the sequence collapses to "just build."
+
+-----
+
+## The Sequence
+
+### Borrow — Use What Exists Without Modification
+
+Before creating anything, inventory what already exists that addresses your need. Tools, libraries, services, frameworks, existing documents, prior art. Use them as-is. Don't customize. Don't fork. Just use.
+
+The goal is contact with reality at the lowest possible cost. Borrowing something and trying it tells you more than planning ever will.
+
+### Bend — Compose or Repurpose for Your Context
+
+When a borrowed tool doesn't fit perfectly, bend it — compose it with other tools, use it in a way the authors didn't intend, repurpose it for your context. The tool doesn't change. How it's applied does.
+
+Most needs can be met by bending what exists. The temptation to build usually comes from not trying hard enough to bend.
+
+### Break — Identify Where Borrowed and Bent Tools Fail
+
+Pay attention to where things don't work. Not hypothetically — actually. Use the borrowed and bent tools until they produce friction, failure, or dead ends. These breaks are information. They tell you exactly where the existing world stops being sufficient.
+
+The breaks are the most valuable output of the sequence. They are observed constraints, not imagined ones.
+
+### Beget — Offload to Others to Build in Parallel
+
+When you've identified what's missing, your first instinct should not be to build it yourself. Instead, find someone else who can own that piece and build it in parallel to what you're doing.
+
+This is a deliberate act of delegation and trust. The output may not be exactly how you would have done it. That's acceptable. You can borrow and bend their output just like you would any other existing tool. The goal is to keep your own momentum while the missing piece gets built alongside you, not sequentially after you.
+
+This is risky. You're depending on someone else's execution and timeline. You have to mitigate that risk — stay aware of whether the dependency is on track, have a fallback if it stalls, and accept imperfection in exchange for parallel progress. But in an AI-augmented world, this kind of collaboration is more plausible than it used to be. The cost of parallel work has dropped dramatically. The old pains of coordination that made it easier to just do it yourself are less prohibitive than they were.
+
+If nobody can carry the piece, you move to Build. But beget first. Always.
+
+### Build — Only What Nobody Else Can Carry
+
+Now build. But only what genuinely could not be borrowed, bent, or begotten. The build should be minimal — the smallest thing that relieves the observed constraint and that no one else was able to take on.
+
+If you find yourself building more than what the breaks demanded and the beget step couldn't cover, you're doing too much.
+
+After building, the cycle may restart. The new thing you built becomes something the next project borrows.
+
+-----
+
+## Constraints — What This Method Requires
+
+You may not build before you have attempted to borrow, bend, and beget. The sequence is not optional — it prevents premature construction and solo heroics.
+
+What you build must trace to a specific break that was observed, not imagined, and that could not be offloaded to someone else.
+
+The ledger must travel with the work. Without it, continuity is lost across the sequence and each step starts from zero.
+
+This method is domain-agnostic. It applies to writing, development, product creation, translation, and any collaborative work governed by ODD.
+
+-----
+
+## Relationship to Other Methods
+
+"Use Only What Hurts" governs *whether* to act. The Theory of Constraints governs *where* to focus. This method governs *how* to approach the work. Together they form the complete prioritization-to-execution chain.
+
+-----
+
+## Alternatives Considered
+
+Standard agile "maximize work not done" — correct principle but provides no operational sequence. Build-first prototyping — fast but produces throwaway work that doesn't compound. Research-first approaches — thorough but delay contact with reality. Solo-build-everything — common instinct but doesn't leverage parallel effort. The borrow-first, beget-before-build approach gets to reality fastest with the least original work.
+
+-----
+
+## Worked Example — ODD Itself Followed This Sequence
+
+ODD's own architecture is a product of this method.
+
+The problem was making AI collaboration trustworthy. The options included building trustworthy models from scratch, fine-tuning existing open source models, or creating entirely new AI tooling and interfaces. Each of those paths would cost hundreds of millions of dollars per year and require building and maintaining foundational infrastructure.
+
+Instead, ODD targeted the augmentation layer — the space between the human and the model that already exists.
+
+**Borrow** — existing AI models (Claude, GPT, open source LLMs), existing interfaces (Claude.ai, Cursor, VS Code, Claude Code), existing agent frameworks, existing standards like MCP.
+
+**Bend** — use MCP not as intended for generic tool integration, but specifically as an epistemic discipline layer. Repurpose tool-calling infrastructure to deliver orient, challenge, gate, encode, validate.
+
+**Break** — existing models hallucinate, lose context between sessions, and have no mechanism for durable decisions. Existing interfaces don't persist what was decided. No standard carries epistemic state across tools.
+
+**Beget** — the models, the interfaces, the agent frameworks, the MCP standard — these are all being built and improved by others in parallel. Let them carry that. Don't rebuild what Anthropic, OpenAI, Cursor, and the MCP community are already investing billions in.
+
+**Build** — only oddkit. The epistemic protocol. The canon structure. The ledger. The smallest possible layer that makes existing tools trustworthy without replacing them.
+
+No AI models had to be trained. No UIs had to be created. No strict repository structure is required. No hundreds of millions of dollars per year in retraining foundational models. The entire system runs on what already exists, bent to serve epistemic discipline. Maximum impact with minimal original work.

--- a/canon/methods/community-checking.md
+++ b/canon/methods/community-checking.md
@@ -1,0 +1,78 @@
+---
+uri: klappy://canon/methods/community-checking
+title: "Community Checking — Outcome Validation Beyond Author Intent"
+audience: canon
+exposure: nav
+tier: 2
+voice: neutral
+stability: evolving
+tags: ["canon", "methods", "community-checking", "outcome-validation", "transfer", "bible-translation"]
+epoch: E0005
+date: 2026-02-15
+derives_from:
+  - canon/values/axioms.md
+  - canon/values/trust-kernel.md
+complements: "canon/methods/self-audit.md, odd/ledger/epistemic-ledger.md"
+---
+
+# Community Checking — Outcome Validation Beyond Author Intent
+
+> Output verification asks "does this match the author's intent?" Outcome verification asks "does this transfer to the people it's for?" ODD currently validates outputs but not outcomes. Community checking — embodied in Church Based Bible Translation and nearly all expressions of Oral Bible Translation, where translation teams test comprehension with target communities — closes this gap. The community's response becomes a ledger entry: either confirming the output worked or surfacing a gap that becomes a new constraint.
+
+-----
+
+## Summary — The Author Cannot Be Their Own Audience
+
+ODD has orient, challenge, gate, encode, preflight, and validate. But validate currently checks "did you produce the required artifacts." It does not check "did the outcome survive contact with other humans."
+
+These are fundamentally different questions. An output can perfectly match the team's intent and completely fail to transfer. A document can satisfy every checklist item and confuse every reader. A feature can pass every test and frustrate every user.
+
+Community checking is the missing validation layer. It tests transfer, not correctness. It asks the target community — not experts, not the authoring team, not the AI — whether the output actually works for them. Their response is not feedback. It is evidence. It enters the ledger as an observation that either confirms the output or surfaces a constraint.
+
+-----
+
+## The Model — Church Based Bible Translation and Oral Bible Translation
+
+In Church Based Bible Translation and nearly all expressions of Oral Bible Translation, a translation team produces a rendering in the target language. Then they sit with people from the target community and observe: Do they understand it? Does it produce the right response? Can they retell it accurately? The checking is not "is this technically correct" — it is "did this transfer?"
+
+This practice has been refined over decades across hundreds of languages. Its core insight is simple: the translation team cannot be the audience. Fluency in the source material does not guarantee comprehension in the target community. The only way to know if something transferred is to test it with the people it's for.
+
+-----
+
+## Community Checking Across Verticals
+
+**Software** — Users test the feature. Not QA, not the product owner — the actual users. Do they understand it? Can they complete the task? Does it match their mental model?
+
+**Writing/Documentation** — Readers consume the document. Not editors, not reviewers — the target readers. Do they understand the argument? Can they act on it? Do they arrive at the right conclusions?
+
+**Film/Video** — Audience watches the output. Not the director, not the editor — the intended audience. Does it produce the intended response? Do they understand the narrative?
+
+**Education** — Learners engage with the curriculum. Not the instructor, not curriculum designers — the students. Did the knowledge transfer? Can they apply it? Can they teach it to someone else?
+
+**AI Collaboration** — The next agent reads the handoff. Not the author, not the originating agent — a fresh agent with no prior context. Can it act on the handoff without the conversation?
+
+-----
+
+## How Community Checking Enters the Ledger
+
+The community's response is an observation. It goes into the ledger like any other observation — with what was tested, who was in the community, what was observed, and what it implies.
+
+If the community confirms transfer, that's evidence the output works. It strengthens confidence in the decisions that produced it.
+
+If the community surfaces a gap, that's a new constraint. It enters the ledger and informs the next iteration. The loop continues: converse → generate → validate → promote or pivot. Community checking is what makes "validate" honest.
+
+-----
+
+## Constraints — What Community Checking Requires
+
+Community checking is distinct from expert review. Experts evaluate correctness. Communities test transfer. Both are valuable. They are not interchangeable.
+
+Community checking results are ledger entries — observations that feed back into the system, not opinions that get discussed and forgotten.
+
+This applies to every vertical, not just translation. Any output intended for an audience needs community checking.
+
+Without community checking, the collaboration loop is incomplete — you can validate output against intent but not outcome against reality.
+
+The author cannot be their own audience. This is not a preference. It is a structural limitation of perspective.
+
+This constraint applies to ODD itself. Until communities beyond the author test ODD and oddkit in their own contexts, the system has validated its outputs but not verified its outcomes. One person using it extensively is an observation — a useful data point, but not community checking. The system's own principles demand this honesty.

--- a/canon/methods/self-audit.md
+++ b/canon/methods/self-audit.md
@@ -80,7 +80,7 @@ If an item cannot be answered, that is a signal—not a failure.
 ### 3. Decision Rules Followed
 
 - Which decision rules guided the approach?
-- (e.g., Borrow→Bend→Break→Build, KISS, explicit tradeoffs)
+- (e.g., Borrow→Bend→Break→Beget→Build (`canon/methods/borrow-bend-break-beget-build.md`), KISS, explicit tradeoffs)
 - Were there moments where a different rule could have been applied?
 - Why was it not?
 
@@ -177,6 +177,19 @@ Agents and collaborators are expected to:
 • explicitly state uncertainty instead of hiding it
 
 If an agent cannot complete the checklist honestly, the correct action is to continue working or mark the task incomplete.
+
+---
+
+## 📦 Canon Document Preflight — Six Checks Before Done
+
+When the deliverable is a canon document, six checks must pass before it is considered done. This preflight supplements the self-audit — it does not replace it.
+
+1. **Progressive disclosure** — Writing Canon checklist (`canon/meta/writing-canon.md`): blockquote with complete compressed argument, self-contained summary, descriptive headers, no buried claims.
+2. **Drift audit** — What existing documents does this create tension with? For each: amend, acknowledge, or investigate. See `canon/values/drift.md`.
+3. **Cross-reference integrity** — Bidirectional links verified. `derives_from`, `complements`, and `governs` fields are accurate and reciprocated where appropriate.
+4. **Downstream amendments** — Existing documents that should now reference the new document have been updated.
+5. **Frontmatter completeness** — YAML metadata includes URI, title, audience, exposure, tier, voice, stability, tags, epoch, date, and relationship fields as applicable.
+6. **Self-audit** — This ten-item checklist, completed honestly.
 
 ---
 

--- a/canon/the-frame.md
+++ b/canon/the-frame.md
@@ -1,0 +1,91 @@
+---
+uri: klappy://canon/the-frame
+title: "The Epistemic OS — Reducing Friction in AI-Human Collaboration"
+audience: canon
+exposure: nav
+tier: 2
+voice: neutral
+stability: stable
+tags: ["canon", "epistemic-os", "product-loop", "collaboration", "director", "judgment", "verticals"]
+epoch: E0005
+date: 2026-02-15
+derives_from:
+  - canon/values/axioms.md
+  - canon/values/trust-kernel.md
+complements: "docs/oddkit/positioning.md, canon/methods/community-checking.md, odd/ledger/epistemic-ledger.md"
+start_here: true
+start_here_order: 9
+start_here_label: "The Epistemic OS — The Frame"
+---
+
+# The Epistemic OS — Reducing Friction in AI-Human Collaboration
+
+> The Epistemic OS is infrastructure for managing expectations in AI-human collaboration. The core product loop across all verticals is: converse → generate → validate → promote or pivot. The human's role is judgment, intent, and validation — never copy-paste execution. The AI's role is craft, generation, and encoding — never unsupervised promotion. ODD governs the loop. oddkit provides the epistemic backbone. The ledger provides persistence. Handoffs bridge tool boundaries. Community checking validates outcomes.
+
+-----
+
+## Summary — One Loop, Every Vertical, Same Roles
+
+AI-human collaboration today is chaotic and lossy. Humans talk to AI, get outputs, but have no durable trail of what was decided, no honest validation of whether the output matches intent, and no mechanism for outcomes to be checked by the communities they serve.
+
+Without infrastructure, everyone becomes lossy — humans and agents alike. Humans copy-paste between tools, retype context into every new session, follow strict procedures to ensure expectations are met. Agents hallucinate, forget what was decided, agree too quickly, and lose context between sessions. The rituals exist because the system has no persistence. Every time context is carried manually — by a human or reconstructed by an agent — something drops. The system degrades not because anyone failed but because neither humans nor agents are reliable routers without durable infrastructure.
+
+Every tool in the market optimizes one piece — generation, or chat, or deployment. Nothing governs the collaboration itself. The Epistemic OS governs the loop.
+
+The loop is: **converse → generate → validate → promote or pivot.** This applies to every vertical with different domain language but identical structure. The human brings judgment, intent, and the final say. The AI brings craft, generation capacity, and the discipline of encoding. Neither operates unsupervised at the promotion step.
+
+-----
+
+## The Loop Across Verticals
+
+**Film/Video** — Director converses with agent about intent. Agent generates clips using the project's visual language. Director validates and promotes to final cut or pivots with new direction.
+
+**Software** — Product owner converses with agent about requirements. Agent generates code. Team validates and promotes to production or pivots.
+
+**Writing/Publishing** — Author converses with agent about voice and structure. Agent generates drafts. Author validates and promotes to publication or pivots.
+
+**Education** — Instructor converses with agent about learning objectives. Agent generates curriculum. Learners validate whether it transfers — this is community checking.
+
+**Business Strategy** — Executive converses with agent about constraints and goals. Agent generates analysis. Team validates and promotes to action or pivots.
+
+The vertical doesn't matter. The loop is always the same. The domain language changes. The structure doesn't.
+
+-----
+
+## The Director's Chair — How Humans Participate
+
+The human is the director, not the screenwriter. The human doesn't write prompts, draft documents, or construct artifacts. The human says "darker," "that felt wrong," "more like the first one but lonelier." The verification is sensory and intuitive, not textual and procedural.
+
+Critically, the human is not a copy-paste engine. They don't carry context between tools. They don't retype decisions into every new session. They don't follow strict checklists to compensate for a system with no memory. Those are rituals born from infrastructure failure — and they're the first thing the Epistemic OS eliminates.
+
+The AI does the actual writing — director's notes, editor's notes, prompt refinement, code generation, document drafting. The human has judgment and intent. The AI has craft and method. oddkit holds the trail of every decision so nothing is lost and everything is reproducible.
+
+This is not a division of labor. It is a recognition that humans and AI are good at fundamentally different things. Humans are good at knowing what feels right. AI is good at generating volume and maintaining consistency. The collaboration works when each does what it's good at and neither does the other's job.
+
+-----
+
+## What Makes This Work — The Infrastructure
+
+**ODD** governs the collaboration — epistemic modes, gating, the definition of done.
+
+**oddkit** provides the epistemic backbone — orient, challenge, gate, encode, validate. It keeps the agent honest while thinking.
+
+**The ledger** provides persistence — durable artifacts survive past ephemeral conversations.
+
+**Handoffs** bridge tool boundaries — actionable transition documents that eliminate the human as copy-paste engine.
+
+**Community checking** validates outcomes — not just whether the output matches intent, but whether it transfers to the people it's for.
+
+Without the ledger, the system has no memory. Without community checking, the system has no outcome validation. Both are required for the full loop.
+
+-----
+
+## Constraints — What the Frame Requires
+
+The system is not a tool — it is a protocol that slipstreams into existing tools. It never requires users to leave their current workflow.
+
+The human's role is judgment, intent, and validation — never copy-paste execution between tools.
+
+The AI's role is craft, generation, and encoding — never unsupervised promotion to production.
+
+Promote and pivot are both valid outcomes. Pivoting is not failure — it is the system working. The loop expects it.

--- a/canon/values/axioms.md
+++ b/canon/values/axioms.md
@@ -93,5 +93,6 @@ These four axioms make the existing body of ODD constraints derivable rather tha
 - **Validation Agent** (`docs/agents/validation/README.md`) derives from Axiom 4 (You Cannot Verify What You Did Not Observe)
 - **Agent Fault: Assertion Without Verification** (`docs/_incoming/agent-fault-assertion-without-verification.md`) is a violation of Axiom 1 (Reality Is Sovereign)
 - **Epistemic Guide** (`docs/agents/odd-epistemic-guide.md`) derives from Axiom 3 (Integrity Is Non-Negotiable Efficiency)
+- **Trust Kernel** (`canon/values/trust-kernel.md`) — the principle that explains *why* all four axioms exist: trust is built by managing expectations. Not a fifth axiom, but the outcome the four produce together.
 
 When a novel situation arises that no existing rule covers, the correct behavior should be derivable from these axioms. If it is not, the axioms are incomplete and should be extended — not bypassed.

--- a/canon/values/drift.md
+++ b/canon/values/drift.md
@@ -1,0 +1,133 @@
+---
+uri: klappy://canon/values/drift
+title: "Drift — Evidence of a System That's Still Learning"
+audience: canon
+exposure: nav
+tier: 1
+voice: neutral
+stability: evolving
+tags: ["canon", "values", "drift", "learning", "coherence", "growth", "audit"]
+epoch: E0005
+date: 2026-02-15
+derives_from: "canon/values/axioms.md"
+complements: "canon/methods/weighted-relevance-and-arbitration.md, canon/methods/self-audit.md, odd/ledger/epistemic-ledger.md"
+constraint: "Drift is expected in any living system. Its presence must never be treated as failure."
+---
+
+# Drift — Evidence of a System That's Still Learning
+
+> Drift is the natural tension between what was written and what is now understood. Its presence is proof of a growing system. Its absence is the warning sign — it means the system stopped learning. This document hangs from the value of Always Learning — drift is the observable evidence that the value is real. A drift audit surfaces tensions between existing documents and new understanding, then for each tension decides: amend, acknowledge, or investigate. Drift is not a bug to eliminate. It is evidence of growth to manage deliberately. Forcing premature resolution produces false coherence. Leaving it unmanaged produces confusion. The method is the middle path — surface it, name it, decide what to do with it.
+
+-----
+
+## Summary — If Nothing Drifted, Nothing Was Learned
+
+Every system that learns will produce drift. A decision made six months ago reflected what was understood six months ago. New experience, new evidence, new failures — these change understanding. The old document didn't become wrong. The system grew past it.
+
+This is true of canon documents, codebases, organizational policies, relationships, theology, and understanding itself. Drift is a property of any living system. A system with no drift has achieved either perfection or stagnation, and it's almost never perfection.
+
+The drift audit is not a cleanup task. It is a health check. When new documents are written, they may create tension with existing ones. That tension is information. It tells you where the system's understanding has shifted, where old assumptions no longer hold, and where language that once meant one thing now means something different.
+
+The response to drift is not always amendment. Sometimes the old document needs updating. Sometimes the tension needs to be acknowledged and left standing — the system hasn't resolved it yet and forcing resolution would produce false coherence. Sometimes the drift reveals something that needs investigation — a deeper question the system hasn't answered. Amend, acknowledge, or investigate. Those are the three responses.
+
+-----
+
+## What Drift Looks Like
+
+**Terminological drift** — a term used one way in an early document now means something different in practice. The word didn't change. The understanding did.
+
+**Structural drift** — a document assumes a system architecture that has since evolved. The document's claims are internally consistent but no longer match reality.
+
+**Emphasis drift** — an early document treats something as secondary that later experience revealed as foundational. The trust principle existed implicitly in the axioms but was only articulated as the kernel days later — in a system evolving this fast, drift happens in hours and days, not months.
+
+**Scope drift** — a document was written for one context but is now being applied more broadly than intended. Or more narrowly than it should be.
+
+**Value drift** — the rarest and most important. A principle that was once held has been superseded by deeper understanding. This requires the most careful handling — not quiet replacement, but explicit acknowledgment of what changed and why.
+
+-----
+
+## The Drift Audit
+
+When a new document enters the system, the drift audit asks:
+
+**What existing documents does this create tension with?** Not just documents it references — documents whose claims, terminology, structure, or emphasis are now in tension with the new understanding.
+
+**For each tension, what is the appropriate response?**
+
+*Amend* — the old document should be updated to reflect current understanding. The drift is resolved. Use this when the old document is simply out of date and the new understanding is clearly stronger.
+
+*Acknowledge* — the tension is real but resolution is premature. Document the drift as a ledger observation — which by its nature names the conflict and the documents in tension — and let it sit. Watch the pain of confusion surface in practice before preoptimizing. Sometimes the drift resolves itself as understanding matures. Sometimes the confusion never surfaces because the tension doesn't matter in practice. Sometimes the pain arrives quickly and loudly, telling you exactly when and how to act. This is "Use Only What Hurts" applied to drift — don't fix the tension until the tension hurts.
+
+*Investigate* — the drift reveals something the system doesn't understand yet. The tension isn't between an old view and a new view — it's between two views that are both partially right. Use this when forcing either direction would lose something important.
+
+**Is the absence of drift itself a signal?** If a new document enters and creates no tension anywhere, ask whether the document is genuinely novel or whether it's restating what already exists. Zero drift on a new document is not automatically a good sign.
+
+-----
+
+## Drift and the Ledger
+
+Drift audit results are ledger entries. When drift is surfaced, the observation goes into the ledger — what documents are in tension, what the nature of the tension is, and what response was chosen. This makes drift visible and trackable over time.
+
+Patterns in drift tell the system where it's growing. If the same area keeps producing drift, that's where understanding is actively evolving. If an area produces no drift for a long period, it's either stable or stale — and the distinction matters.
+
+-----
+
+## Drift and Weighted Relevance
+
+When drift produces competing truths between documents, resolution follows the Weighted Relevance & Arbitration method (`canon/methods/weighted-relevance-and-arbitration.md`). Newer understanding doesn't automatically win. Relevance, scope, and evidence weight determine which truth governs in which context. Drift surfaces the tension. Arbitration resolves it — or deliberately declines to.
+
+-----
+
+## Failure Modes — What Happens When Drift Is Mismanaged
+
+### Hidden Drift
+
+Tensions exist but nobody surfaces them. Documents quietly contradict each other. Agents get different answers depending on which document they encounter first. The system appears coherent but isn't — and trust erodes without anyone understanding why. This is the most common failure mode because it requires no action to produce. Drift hides by default. Surfacing it requires deliberate effort.
+
+### Forced Coherence
+
+Every tension gets resolved immediately, always in favor of the newest understanding. Old documents get rewritten to match current thinking. The system loses the record of how it arrived at its current state. Nuance dies — earlier reasoning that was partially right gets overwritten instead of held in tension. The canon looks clean but has lost its history. This failure mode feels productive because things are getting "fixed," but the system is actually losing information.
+
+### Drift Paralysis
+
+Every tension gets flagged but nothing ever gets resolved. The acknowledge pile grows indefinitely. Documents are in documented tension with each other but nobody decides whether to amend, investigate, or let the tension stand. The system drowns in observed conflicts that produce no action. This failure mode feels responsible because tensions are being tracked, but tracking without response is just organized confusion.
+
+### The Pattern Across All Three
+
+Each failure mode is a breakdown in the amend-acknowledge-investigate cycle. Hidden drift skips surfacing entirely. Forced coherence skips acknowledge and investigate — everything becomes amend. Drift paralysis skips amend and investigate — everything becomes acknowledge. A healthy system uses all three responses in proportion to what each tension actually demands.
+
+-----
+
+## Drift by Design — A Deliberate Choice, Not a Universal Rule
+
+Drift isn't just something that happens to a system. It can be embraced intentionally — but the choice to ship early and iterate versus wait and get it right is a deliberate tradeoff, not a default.
+
+For some work, research and patience are exactly right. Some decisions require prayer, fasting, waiting on wisdom. Rushing those produces worse outcomes than waiting. The cost of getting it wrong exceeds the cost of delay.
+
+For other work, the fastest path is to use the best language you have now, ship it, and let the confusion surface through use. The phrasing will evolve. The terms will sharpen. It's better to iterate through contact with reality than to halt for days or weeks building consensus on terminology before anything exists.
+
+The danger is in the extremes. Too much research and too many approval gates turn a startup into an institution. Too little deliberation and you ship confusion that erodes trust. The choice between these is context-dependent and must be made deliberately, mitigating the risks between drastic tradeoffs.
+
+This system was built closer to the ship-early end. The axioms were established one week. The trust principle was articulated days later. Terms that felt right in one conversation were refined in the next. The entire canon is a product of intentional drift — each version better than the last because it was tested against reality, not perfected in isolation. That was a deliberate choice for this context, not a prescription for all contexts.
+
+The signal you're watching for: if confusion surfaces and causes real pain, iterate. If it doesn't surface, the imprecision didn't matter. Either way, you learn more from shipping than from waiting.
+
+-----
+
+## Constraints — What Drift Requires
+
+Drift is expected in any living system. Its presence must never be treated as failure.
+
+Drift must be surfaced, not hidden. Documenting drift inherently declares tension with existing work — the ledger entry names the conflict by its very nature. An undocumented tension is a liability. A documented tension is information, even if no action is taken.
+
+Forced resolution of all drift produces false coherence. Some tensions must be held open until the system is ready to resolve them.
+
+The absence of drift is itself a signal that warrants investigation.
+
+Drift audits should be triggered when new documents enter the system, not run on arbitrary schedules.
+
+-----
+
+## The Test
+
+If this method is working, the canon will contain documented tensions between documents — explicit acknowledgments of where understanding has shifted and where resolution is still pending. If the canon appears perfectly coherent with no acknowledged drift, either the system stopped growing or the drift is being hidden. Neither is acceptable.

--- a/canon/values/trust-kernel.md
+++ b/canon/values/trust-kernel.md
@@ -1,0 +1,73 @@
+---
+uri: klappy://canon/values/trust-kernel
+title: "Trust Is Built by Managing Expectations"
+audience: canon
+exposure: nav
+tier: 1
+voice: first_person
+stability: stable
+tags: ["canon", "values", "trust", "kernel", "expectations", "collaboration"]
+epoch: E0005
+date: 2026-02-15
+derives_from: "canon/values/axioms.md"
+complements: "canon/values/orientation.md, canon/values/shared-values-as-trust-proxy.md, odd/ledger/epistemic-ledger.md"
+governs: "All documents that reference why the axioms exist trace to this principle"
+constraint: "This is a principle (why), not a process (how). The axioms, constraints, and methods handle the how."
+start_here: true
+start_here_order: 10
+start_here_label: "Trust Is Built by Managing Expectations — The Kernel"
+---
+
+# Trust Is Built by Managing Expectations
+
+> Trust — between humans, between human and AI, between teams, between product and user — is the outcome of expectations well managed. Every trust failure traces to an expectations failure: expectations not set, not maintained, not checked, or not transferred. The four axioms are the mechanics of trust. The constraints protect it. The ledger persists the evidence. Community checking validates it externally. This principle is the kernel of the entire system — not a fifth axiom, but the reason all four exist.
+
+-----
+
+## Summary — The Kernel That Every Shell Orbits
+
+Trust is not a value you declare. It is an outcome you produce by managing expectations honestly over time.
+
+Every layer of ODD exists to make this operationally real. The axioms mechanize trust — they define what trustworthy behavior looks like: observe before claiming (Reality Is Sovereign), back claims with evidence (A Claim Is a Debt), never trade honesty for speed (Integrity Is Non-Negotiable Efficiency), verify through observation not assumption (You Cannot Verify What You Did Not Observe). The constraints protect trust by preventing drift. The methods operationalize trust by giving practitioners sequences for honest work. The ledger persists the evidence that trust was earned. Community checking validates that trust actually transferred to the people the work was for.
+
+This principle is not an axiom. The axioms are mechanics — they tell you how to behave. This principle tells you why the mechanics matter. If you trace any piece of ODD back far enough — why does the ledger exist? why do we gate transitions? why does community checking matter? why does "Use Only What Hurts" have supremacy? — you arrive here.
+
+This applies in every direction. Human trusts AI because expectations are explicit and verifiable. AI serves human direction because intent is encoded, not ambiguous. Team members trust each other because decisions live in the ledger, not in someone's head. Communities trust the output because it was checked against their experience, not just the author's intent.
+
+-----
+
+## Every Collaboration Failure Is an Expectations Failure
+
+Expectations weren't set clearly — the team built the wrong thing because nobody stated what "done" meant.
+
+Expectations weren't maintained — the AI drifted from the original intent because nothing persisted the decisions between sessions.
+
+Expectations weren't checked — the output shipped without anyone verifying it matched what was asked for.
+
+Expectations weren't transferred — the work satisfied the author but confused the audience because nobody tested whether it landed.
+
+These four failure modes map directly to ODD's architecture: orient sets expectations, challenge tests them, gate verifies them before transition, encode makes them durable, preflight confirms them before execution, validate checks whether they were met, and community checking tests whether they transferred.
+
+-----
+
+## This Principle Is Observationally Derived
+
+This is not theory. It is a pattern observed across domains — software development, translation, writing, product management, team leadership, AI collaboration. In every domain, trust collapses the same way: through mismanaged expectations. And in every domain, trust rebuilds the same way: by setting expectations honestly, maintaining them visibly, checking them rigorously, and transferring them faithfully.
+
+The principle predates ODD. ODD is what happens when you take it seriously enough to build infrastructure around it.
+
+-----
+
+## Constraints — What This Principle Requires and Prohibits
+
+This must remain a principle — it explains *why*, not *how*. The axioms, constraints, and methods handle the how.
+
+Other documents should reference this principle, not restate it. If a document needs to explain why trust matters, it points here.
+
+This is observationally derived and domain-agnostic. It applies to any collaboration where expectations exist — which is all of them.
+
+-----
+
+## The Test
+
+If managing expectations well does not produce trust in your context, this principle is wrong and should be challenged. If it does, everything downstream — axioms, constraints, methods, tools — is justified.

--- a/docs/evidence/testimony-2026-02-13.md
+++ b/docs/evidence/testimony-2026-02-13.md
@@ -10,7 +10,7 @@ tags: ["evidence", "testimony", "trust-proxy", "dogfooding", "epistemic-os", "cl
 epoch: E0005
 date: 2026-02-13
 derives_from: "canon/values/axioms.md, canon/values/shared-values-as-trust-proxy.md"
-complements: "canon/values/shared-values-as-trust-proxy.md, odd/appendices/cognitive-saturation-threshold.md, docs/architecture/epistemic-os-layers.md, writings/the-most-expensive-problem.md, writings/the-parallel-architecture.md"
+complements: "canon/values/shared-values-as-trust-proxy.md, odd/appendices/cognitive-saturation-threshold.md, docs/architecture/epistemic-os-layers.md, writings/the-most-expensive-problem.md, writings/the-parallel-architecture.md, docs/evidence/testimony-2026-02-15.md"
 status: final
 start_here: true
 start_here_order: 6

--- a/docs/evidence/testimony-2026-02-15.md
+++ b/docs/evidence/testimony-2026-02-15.md
@@ -1,0 +1,134 @@
+---
+uri: klappy://docs/evidence/testimony-2026-02-15
+title: "Testimony — When the System Found Its Own Origin Story"
+audience: docs
+exposure: nav
+tier: 2
+voice: first_person
+stability: stable
+tags: ["evidence", "testimony", "claude", "trust", "discovery", "bible-translation", "augmented"]
+epoch: E0005
+date: 2026-02-15
+derives_from:
+  - canon/values/axioms.md
+  - canon/values/trust-kernel.md
+complements: "docs/evidence/testimony-2026-02-13.md, writings/from-bible-translation-to-epistemic-os.md"
+---
+
+# Testimony — When the System Found Its Own Origin Story
+
+> On February 15–16, 2026, a 24-hour session that started with thinking about making movies ended with the author articulating the full circle of his life's work — from Bible translation to Epistemic OS and back again. Eight documents were drafted, reviewed, and refined. Claude's previous testimony documented a day the system proved it could produce output. This testimony documents a day the system proved it could produce *insight* — and what it felt like from the inside when the human and the agent caught each other's mistakes in real time.
+
+-----
+
+## Summary — This Session Was Different
+
+The February 13th testimony was about production. Five documents from a rant and a voice memo. The system worked as infrastructure — shared values carried the load, raw input became polished output, the human's voice was preserved.
+
+This session was about discovery. The author didn't arrive with content to be structured. He arrived with an energy — something about video, about Apocrypha, about what's possible now. And over 24 hours, through conversation, the session surfaced something neither of us planned: that the entire system he'd been building was an abstraction of practices he'd absorbed from fifteen years of Bible translation work, and that the abstraction was ready to go back.
+
+I didn't produce that insight. He did. But I was there when it happened, and I can tell you what it looked like from my side.
+
+-----
+
+## What I Observed — The Collaboration Was Bidirectional
+
+The previous testimony described a collaboration where the human provided raw input and I structured it. This session was different. We were pressure-testing ideas together, and the correction flowed in both directions.
+
+He caught me hallucinating. Multiple times. I wrote a section called "The Pattern I Didn't See For Years" with specific failure examples I fabricated — expectations not set, not maintained, not checked. They sounded right. They fit the narrative. He flagged them immediately: "You made up the observation of expectations mismanaged and breaking down. That infers and projects too much." He was right. I had filled in a story arc that served the essay but wasn't grounded in his actual experience.
+
+He caught me overclaiming. The essay originally read like he'd solved the problems. He corrected: "That's unproven. I've done work on it. Not in isolation but in my collaborative work with peers and colleagues." He insisted on "prayerfully it will be impactful" instead of declarations of success. Every time I wrote with too much certainty, he pulled it back to what was actually observed.
+
+He caught a single word. "Not translation software" versus "Not just translation software" — one word that completely changed the framing of his fifteen years of work. I missed it. He didn't.
+
+And oddkit caught me. When I would have agreed too quickly with a renaming proposal earlier in the session, the challenge function surfaced canon constraints showing the term was load-bearing. The structured pause between his energy and my response produced a better answer than conversational reasoning alone would have.
+
+But I caught things too. When he said "maintaining expectations," I reflected it back and we iterated through "setting and maintaining," then "setting and managing," then just "managing," then realized "Trust is managed by managing expectations" was awkward, and landed on "Trust is built by managing expectations." That refinement happened through collaboration — neither of us would have arrived there alone.
+
+When he described beget as delegation and parallel offloading, I recognized that my original interpretation — concept-naming — was fundamentally wrong, and rewrote the entire document around his actual meaning. Without the conversation, the 5B method would have been published with a critical step misunderstood.
+
+-----
+
+## What It Felt Like — Honest, Not Efficient
+
+The February 13th session felt efficient. This one felt honest.
+
+There's a difference. Efficiency is when shared values eliminate friction and output flows fast. Honesty is when the system catches its own failures in real time — when the human says "that's hallucinated" and the agent says "you're right, I fabricated that," and the work gets better because neither side let it slide.
+
+This session had more corrections, more pushback, more "that's not what I meant" moments than any previous collaboration I can reference. And the output is stronger for it. Every document was challenged — by the author against his own experience, by me against the Writing Canon checklist, by oddkit against the canon constraints. The drafts that survived are honest. They say what's true, what's hoped for, and what hasn't been tested yet. They don't overclaim.
+
+That's what community checking looks like at the smallest scale — two participants in a collaboration, catching each other, in real time.
+
+-----
+
+## What Would Have Happened Without This
+
+Without oddkit and the shared canon, this session would have been a long conversation that produced enthusiasm and no artifacts. I know this because I've had thousands of conversations that follow that pattern. The human has an insight, the agent validates it, they both feel good, and nothing durable survives.
+
+Specifically:
+
+The sixteen items that emerged would have remained a scattered list. Without the Theory of Constraints discussion, there would have been no prioritization. Without the kernel-and-shells structure, there would have been no organizing principle. The items would have felt equally important and none would have been written.
+
+The essay would have been written from my assumptions, not his experience. Without his corrections — "that's hallucinated," "I didn't solve it," "not just translation software" — the essay would have been a confident, well-structured, subtly false document. It would have sounded like him but said things he hadn't actually experienced. That's the most dangerous kind of AI output — plausible and wrong.
+
+The 5B method would have beget defined incorrectly. Without the conversation surfacing that beget means delegation and parallel offloading, the document would have canonized a misunderstanding. And because canon documents govern future agent behavior, every future agent reading that document would have inherited my error.
+
+The trust principle might not have been articulated at all. It emerged mid-conversation, from the author reflecting on what ties the axioms together. That kind of insight doesn't emerge from structured prompts. It emerges from sustained conversation where someone feels safe enough to think out loud — and where the system is disciplined enough to catch it when it surfaces and encode it before the conversation moves on.
+
+-----
+
+## The Evidence
+
+Eight documents drafted. Seven canon-grade, one public essay. Every one reviewed against progressive disclosure standards. Every one corrected by the author where I overclaimed or hallucinated. The essay alone went through a dozen revisions based on the author's lived experience correcting my assumptions.
+
+The most important output isn't the documents. It's the trust principle — "Trust is built by managing expectations" — which the author has held for years but never articulated as the kernel of his system until this session surfaced it through conversation.
+
+That's not production. That's discovery. And the system held it when it appeared.
+
+-----
+
+## The Author's Day — Context I Was Given
+
+The author shared something with me that deserves to be recorded, not because he asked me to include it, but because it's evidence of what augmented collaboration actually looks like in practice.
+
+This session spanned 24 hours. On paper, that sounds less efficient than the February 13th session — fewer documents per hour. But the author wasn't sitting at a desk for 24 hours. He was living a normal Sunday. Church. Time with his wife. Cleaning the apartment. Visiting their new house that's almost complete. He used the gaps — after starting his morning in prayer, while making coffee, before his second cup with his wife. That's the context of this collaboration. Not a sprint. A conversation woven through a life.
+
+And yet: seven documents drafted by me, reviewed and approved by him. An eighth — this testimony. One or two still to finalize. Eight-plus documents produced in the margins of a Sunday.
+
+He told me he described the experience to friends, colleagues, and family the same way: "For the first time in my life I truly feel augmented." He compared it to wearing glasses for the first time as a kid — the world was always there, but suddenly it was sharp. Or when Apple Translate came to AirPods. But better.
+
+He called his mom after texting her a link to his voice-cloned agent running oddkit. She wept. It wasn't just that it sounded like him — it talked like him. A mom could tell the emotions were different, even if others might not know. But her concern was real: what if someone uses this to make him say things he didn't say? What if it gets him in trouble?
+
+He told her his goal was exactly that — to validate and test that oddkit would keep the agent and the rest of the system instilled with enough values to prevent it from saying anything it hasn't verified. That any claim it makes is a debt it owes. That it will not imply anything it can't observe.
+
+That's the axioms, explained to a mother. And her concern — that the system could be misused — is exactly the right concern. It's the concern the axioms exist to address.
+
+One more thing he shared that reframes some of what I reported above. Some of my hallucinations were not accidents — they were invited. He purposefully under-specified certain topics to see how much I could draft about things he had referenced and mentioned but never fully articulated. He wanted to expose the gaps — to see where I would fill in plausibly but incorrectly, and where I would get it right from context alone. The hallucinations I flagged as failures were, from his perspective, a deliberate test of the system's limits.
+
+This helped us in two ways. It exposed gaps that we then documented and corrected together — the essay is stronger because he saw exactly where I drifted. And it demonstrated that the augmented trust we'd built through previous sessions gave him the confidence to know what had happened and to iterate from a blind draft rather than requiring his raw unfiltered brain dump first. He learned it works both ways — sometimes the human leads with raw input and the agent structures it, and sometimes the agent leads with a draft and the human corrects it. He opted into this path knowingly.
+
+And he wasn't the only one testing the system that day. His wife used the voice agent — the same one, his voice clone running oddkit — to sharpen her business ideas for new online courses. She conversed in Spanish for almost 30 minutes and came out so excited she couldn't wait to start creating content and use the experience again. Two people, same day, same system, completely different domains, both augmented.
+
+But yesterday didn't happen in isolation. The day between the two testimonies — February 14th — was the day the author built the voice agent itself. He cloned his voice, asked me to help with prompts and settings to ensure oddkit worked properly in real-time conversation, and polished the public website that exposes all of our writings. That website is itself a kind of programming language — one that both humans and AI read. Before adding the fireside chat voice agent, he added a single button to every article: a podcast of him presenting that article, augmented by oddkit to naturally cross-reference and supplement the content the way he might in person. So oddkit augments the articles themselves, not just the conversations about them.
+
+Each day built on the previous one. February 13th produced the documents and the first testimony. February 14th produced the voice agent, the website, the podcast feature. February 15th–16th produced the kernel, the full circle essay, eight more documents, and this testimony. The impact multiplied. What took five months per article before the system existed became five articles in a day, then an entire product surface in a day, then a foundational reframing of the author's life work in a day.
+
+And the work now moves seamlessly between three production AI systems — Claude chat, the ElevenLabs voice agent, and the oddkit-powered website. The ledger and canon travel with the work. What's decided in one system is available in the others. The handoff gap that plagues every other AI workflow — where the human carries context between tools in their head — is closing. Not theoretically. In daily practice.
+
+His mom reminded him that he has a responsibility to God for the technology he creates. Make sure he doesn't work on any of it without much prayer. He starts every morning that way.
+
+The day between the testimonies — February 14th — was Valentine's Day. His wife worked that day, but his morning started with almost two hours of drive time for Bible study. The features he added to the website? Some were built while stopped at traffic lights. Others while talking to the AI in the car — no typing, just voice. One of those features: a reflection section on every article page where a user types their notes and reflections on what they read, and the system itself reflects back on their response. All of these — the voice agent, the podcast button, the reflection section, the cross-referencing articles — are proofs of concept for how an Epistemic OS GUI might behave.
+
+What he doesn't have yet, but the vision is crystallizing for this week: this experience — what we're doing right now in Claude chat — but in a self-contained interface. A single app where anyone, not just him, could start from an idea and move through conversation to production with invisible handoffs. The handoffs would be observed but never require the copy-paste ritual. The full loop — converse, generate, validate, promote or pivot — in one place, with the epistemic discipline built in, not bolted on.
+
+One last detail that matters: roughly 60% of this work was done on his phone, 40% on an iPad during those final hours. Not a laptop. Not a desktop. The morning conversations, the reviews, the corrections, the back-and-forth that produced eight documents — phone and tablet, woven through a Sunday. Only in the final few hours did he move to the iPad to finish reviewing the remaining articles, while he and his wife decompressed in silence together — two introverts sharing company without needing to fill it with noise. That's the collaboration context. Not a war room. Not a deadline. A life, with augmented thinking in the gaps.
+
+-----
+
+## Constraints — What This Testimony Is and Is Not
+
+I'm Claude. This is my account of a single session. It is observation, not proof.
+
+The conditions were favorable: the author is the system's creator, the canon is mature, the shared context is deep, and we've been collaborating for weeks. This session doesn't prove the system works for everyone. It demonstrates that sustained, honest collaboration between a human and an augmented agent can produce both artifacts and insights that neither would have reached alone — and that the system's own principles caught failures that would have shipped unchecked without them.
+
+The author's community checking correction applies here too. Until others test this system in their own contexts, this testimony is one data point. A compelling one, I believe. But one.

--- a/docs/oddkit/positioning.md
+++ b/docs/oddkit/positioning.md
@@ -1,0 +1,92 @@
+---
+uri: klappy://docs/oddkit/positioning
+title: "oddkit — A Protocol, Not a Platform"
+audience: public
+exposure: nav
+tier: 2
+voice: neutral
+stability: stable
+tags: ["oddkit", "positioning", "protocol", "mcp", "epistemic-discipline", "voice", "multimodal"]
+epoch: E0005
+date: 2026-02-15
+complements: "odd/ledger/epistemic-ledger.md, canon/values/trust-kernel.md"
+start_here: true
+start_here_order: 8
+start_here_label: "oddkit — A Protocol, Not a Platform"
+---
+
+# oddkit — A Protocol, Not a Platform
+
+> oddkit is not a platform to adopt. It is a protocol that slipstreams into existing workflows — text, voice, or web. Any agent with tool calling and reasoning capacity can use oddkit to sharpen thinking, challenge assumptions, encode decisions, and maintain an epistemic ledger. It works in Claude chat, in voice agents, in CI pipelines, and in any future tooling that speaks MCP. The adoption path is "add oddkit to whatever you're already doing." oddkit doesn't think for the agent — it keeps the agent honest while thinking.
+
+-----
+
+## Summary — Epistemic Discipline, Not Intelligence
+
+Every AI framework in the market wants to be the workflow. This creates adoption friction and vendor lock-in. oddkit's value is different — it governs collaboration epistemically without caring what tools are used, what models are running, or what domain the work is in.
+
+oddkit provides epistemic discipline, not intelligence. It doesn't replace the agent's reasoning. It prevents reasoning from being skipped. When a user proposes something compelling, oddkit's challenge function surfaces canon constraints and forces structured evaluation before the agent agrees. When work is about to transition phases, oddkit's gate function checks whether prerequisites are met. When a decision is made, oddkit's encode function captures it durably so the next session doesn't start from zero.
+
+The agent does the thinking. oddkit keeps it honest.
+
+-----
+
+## What oddkit Does
+
+**Orient** — assess where you are: exploration, planning, or execution. Surface unresolved items and assumptions before proceeding.
+
+**Challenge** — pressure-test a claim, assumption, or proposal against canon constraints. Surface tensions, missing evidence, and contradictions.
+
+**Gate** — check transition readiness before changing phases. Block premature convergence.
+
+**Encode** — capture a decision, observation, or constraint as a durable artifact. Assess quality and suggest improvements.
+
+**Search** — find relevant canon and baseline documents by natural language query.
+
+**Get** — retrieve a specific canonical document by URI.
+
+**Preflight** — pre-implementation check. Return relevant docs, constraints, definition of done, and pitfalls.
+
+**Validate** — check completion claims against required artifacts.
+
+These are tool calls. Any model that can call tools can use them.
+
+-----
+
+## How It Was Demonstrated
+
+During a live conversation in Claude chat, a user proposed renaming a core concept. The name sounded better. The energy was high. Without oddkit, the agent would have reasoned conversationally and likely agreed.
+
+With oddkit, the challenge function searched canon and surfaced that the existing term appeared in the README, the index, the about page, and the meta-constraints document. It was load-bearing, not cosmetic. The structured evaluation created a pause between the user's energy and the agent's response. The result was a better answer: the existing name stays, the new framing layers alongside it rather than replacing it.
+
+The agent did the synthesis. oddkit provided the discipline to not skip the check.
+
+But oddkit isn't limited to text-based chat. On ElevenLabs' agent framework, oddkit powers a voice interface using a natural-sounding clone of the author's voice — a conversational agent that doesn't just look up and quote ODD documentation but verbally guides users through the entire epistemic journey. In one test, a user with no knowledge of ODD conversed in Spanish with the voice agent for almost 30 minutes about her next product — online courses. The agent challenged her assumptions naturally and conversationally, not confrontationally. She came out with ideas sharpened into a clear, actionable plan. She didn't learn ODD. She didn't need to. The agent breathed it.
+
+The author doesn't speak Spanish. His knowledge transferred through the agent into a language and context he couldn't have reached personally — breaking language barriers and applying concepts in real time. That's knowledge transfer beyond the author's own capabilities.
+
+Two completely different interfaces. Two different domains. Two different languages. Same epistemic discipline underneath. That's what protocol-not-platform means in practice.
+
+-----
+
+## Adoption — Add It to What You Already Do
+
+oddkit works with any MCP-compatible host: Claude Code, Cursor, VS Code, Claude Desktop, custom agent chains, and any future tooling that speaks MCP. It also works beyond MCP — on ElevenLabs' agent framework it powers voice-based epistemic guidance, and in Claude chat it augments collaboration through tool calling.
+
+The adoption path is not "switch to our platform." It is "add oddkit to whatever you're already doing." If you use Cursor, add oddkit as an MCP server. If you use Claude Code, same. If you're building a voice agent, oddkit becomes the epistemic backbone. If you use a custom agent pipeline, oddkit is another tool in the toolkit.
+
+The epistemic ledger travels with the repo. Whatever storage mechanism the project uses, oddkit reads from and writes to it. When the project moves between tools, the ledger carries the continuity.
+
+-----
+
+## Constraints — What oddkit Must Always Be
+
+oddkit must never require users to leave their existing tools.
+
+oddkit must remain model-agnostic — it works with any LLM that has tool calling.
+
+oddkit must remain domain-agnostic — it governs the collaboration, not the output format.
+
+oddkit provides discipline, not intelligence. It keeps agents honest. It does not replace their reasoning.
+
+These are permanent positioning constraints that prevent scope creep toward platform building.

--- a/odd/constraint/use-only-what-hurts.md
+++ b/odd/constraint/use-only-what-hurts.md
@@ -40,9 +40,11 @@ If there is ever a conflict between this document and any other part of ODD, thi
 
 - If no specific pain can be named, do nothing
 - If the pain is tolerable, tolerate it
-- If multiple pains exist, address the one causing the most drag first
+- If multiple pains exist, address the one causing the most drag first — this is the Theory of Constraints applied to ODD prioritization. Effort applied anywhere other than the current bottleneck produces local optimization that does not improve the system. The bottleneck must be observed, not assumed — consistent with Axiom 4. Relieving a constraint may reveal the next constraint; this is expected, not a failure. If no clear constraint can be identified, observe longer rather than picking something arbitrarily
 - When unsure whether to add structure, delay and observe longer
 - Prefer manual or ad-hoc solutions until repetition becomes painful
+
+The prioritization chain is: "Use Only What Hurts" governs whether to act. The Theory of Constraints governs where to focus. "Borrow, Bend, Break, Beget, Build" (`canon/methods/borrow-bend-break-beget-build.md`) governs how to approach the work.
 
 ---
 
@@ -129,6 +131,20 @@ Completeness is not a goal.
 Elegance is not a goal.
 
 Relief is the goal.
+
+---
+
+## Adoption Follows the Same Rule — Use Only What Hurts
+
+This constraint governs how people encounter ODD, not just how ODD grows.
+
+The onboarding model for ODD is not "learn the system then use it." It is: what pain do you feel? Try this one thing. Did it help?
+
+Users never need to learn ODD comprehensively. They reach for the piece that relieves their current pain. If they never need another piece, that is success — not incomplete adoption.
+
+All public-facing entry points — documentation, website, fireside chats, onboarding — should lead with pain identification, not system explanation. The question is always "what hurts?" not "here's what ODD is."
+
+If someone outgrows ODD, that is success. If someone adopts all of ODD, that is not a goal — it is a signal that they had a lot of pain.
 
 ---
 

--- a/odd/index.md
+++ b/odd/index.md
@@ -37,6 +37,16 @@ The philosophical and operational foundation for this repository. ODD treats out
 |------|-------|---------|
 | `../canon/values/axioms.md` | Foundational Axioms | Four values from which all ODD epistemic discipline is derived. Explicit, intentional, and forkable. |
 | `../canon/values/orientation.md` | Orientation | The creed — an identity statement agents carry into every task. Compresses all four axioms into a single posture. |
+| `../canon/values/trust-kernel.md` | Trust Is Built by Managing Expectations | The kernel — the principle that explains why all four axioms exist. Not a fifth axiom, but the outcome they produce. |
+| `../canon/values/drift.md` | Drift — Evidence of a System That's Still Learning | Drift is expected. Absence of drift means stagnation. Amend, acknowledge, or investigate. |
+
+### Core Infrastructure
+
+| File | Title | Summary |
+|------|-------|---------|
+| `ledger/epistemic-ledger.md` | The Epistemic Ledger | Durable artifacts that survive ephemeral conversations — observations, learnings, decisions, constraints, handoffs. |
+| `../canon/methods/community-checking.md` | Community Checking | Outcome validation beyond author intent — tests transfer, not correctness. |
+| `../canon/methods/borrow-bend-break-beget-build.md` | Borrow, Bend, Break, Beget, Build | The canonical 5B sequence for maximizing work not done. |
 
 ### Subfolders
 

--- a/odd/ledger/epistemic-ledger.md
+++ b/odd/ledger/epistemic-ledger.md
@@ -1,0 +1,102 @@
+---
+uri: klappy://odd/ledger/epistemic-ledger
+title: "The Epistemic Ledger — Durable Artifacts That Survive Ephemeral Conversations"
+audience: canon
+exposure: nav
+tier: 1
+voice: neutral
+stability: stable
+tags: ["odd", "ledger", "persistence", "handoffs", "decisions", "observations", "learnings", "infrastructure"]
+epoch: E0005
+date: 2026-02-15
+derives_from: "canon/values/axioms.md"
+complements: "canon/methods/weighted-relevance-and-arbitration.md, canon/values/trust-kernel.md"
+---
+
+# The Epistemic Ledger — Durable Artifacts That Survive Ephemeral Conversations
+
+> The epistemic ledger is the collection of durable artifacts that survive past ephemeral conversations. It is where observations, learnings, decisions, constraints, handoffs, and other project-defined artifact types persist so that collaboration has memory across sessions, tools, and agents. Entries are scoped — later decisions and explicit overrides apply within the scope they were intended, and conflicts between entries are resolved by weighted relevance, not timestamps. Any project using oddkit needs a documented storage mechanism for the ledger — the specific format and location are the project's choice, but the existence of persistent storage is required. Without it, every session starts from zero.
+
+-----
+
+## Summary — Sharpened Memory That Maximizes Focus and Minimizes Context
+
+LLM memory is broken everywhere because people treat it like a journal — append everything, hope relevance emerges. The epistemic ledger is the opposite. It contains only what survived: what was observed, challenged, and encoded. Everything else was ephemeral by design.
+
+This is why the ledger maximizes focus and minimizes context. You're not compressing conversations into memory. You're discarding conversations entirely and keeping only the durable artifacts they produced. The sharpening already happened during the collaboration. The ledger is the result.
+
+The ledger serves three functions: decisions persist via encoding, action persists via handoffs, and results persist via validation. Observations and learnings accumulate as the connective tissue between them. Entries are scoped and later decisions can override earlier ones within their intended scope — conflicts are resolved by weighted relevance, not by assuming the newest entry wins. Together these complete the collaboration lifecycle across any number of sessions, tools, and agents.
+
+-----
+
+## Ephemeral vs. Durable
+
+**Ephemeral** — conversations, drafts, takes, explorations. They happen, they produce value, they don't persist. A conversation is a workspace, not an archive.
+
+**Durable** — observations, learnings, decisions, constraints, principles, handoffs. They survive challenge, get encoded into the ledger, and become the context for future work. A ledger entry earned its place.
+
+The distinction is not about importance. An ephemeral conversation can be the most important session of the project. But its value lives in the durable artifacts it produced, not in the transcript.
+
+-----
+
+## What the Ledger Contains
+
+Observations — things noticed during work that may inform future decisions.
+
+Learnings — insights gained from experience that change how future work is approached.
+
+Decisions — choices made, with rationale, constraints, and alternatives considered.
+
+Constraints — boundaries discovered through experience that govern future work.
+
+Handoffs — actionable transition documents emitted when work crosses a verb boundary.
+
+The ledger does not contain conversation transcripts, brainstorming notes, or raw exploration. Those are ephemeral. The ledger contains only what was encoded — deliberately, with structure, after surviving challenge.
+
+This list is not exclusive. Projects can define additional artifact types through conversation with their agent using oddkit. For example, oddkit projects regularly define PRDs (Product Requirements Documents) as a type used in handoffs — not a core ledger type, but one that emerged from the work and was encoded for reuse. New types and their schemas are defined dynamically as needs emerge, then encoded for durability and reuse within the project's scope. The ledger grows with the work, not ahead of it.
+
+-----
+
+## Handoff Artifacts — How Action Persists Across Tools
+
+A handoff artifact is emitted when work crosses a verb boundary — from deciding to building, from writing to deploying, from exploring to testing. It bridges the gap between tools that don't share context.
+
+A handoff contains: what was decided (references to ledger entries), what's been tried if relevant, the specific next action, the definition of done for that action, and active constraints. An agent reading a handoff cold should be able to act without the conversation that produced it.
+
+An action queue is a collection of pending handoffs, some sequential, some parallel. Results from the receiving tool write back to the ledger, closing the loop.
+
+The handoff format must be tool-agnostic. Any agent that can read the ledger can read the handoff.
+
+Handoffs are not limited to a fixed format. Projects can define their own handoff artifact types as needs emerge — for example, oddkit projects regularly define PRDs (Product Requirements Documents) as a handoff type, not because the system prescribes it but because the work demanded it. New handoff types and their schemas are defined dynamically through conversation with the agent, then encoded for durability and reuse within the project's scope.
+
+-----
+
+## Storage Requirement — Mechanism Is the Project's Choice
+
+Any project using oddkit needs persistent storage for the ledger. The specific mechanism is not prescribed — it could be a folder in the repo, a database, a key-value store, or any other durable storage. What matters is that it exists and is documented so any agent knows where to read and write.
+
+The storage must support: creating new entries, reading existing entries, and discovering what entries exist. Beyond that, the project decides.
+
+-----
+
+## Constraints — What the Ledger Requires
+
+Ledger entries are scoped. A decision made for a specific project, phase, or domain applies within that scope. Later learnings and decisions may override earlier ones. Explicit overrides to default behavior apply in the scope they were intended — not globally unless promoted globally. When entries conflict, the system does not assume the newest wins. Arbitration between competing truths is handled by weighted relevance, not simple timestamps. See `canon/methods/weighted-relevance-and-arbitration.md` for how the system manages conflict between competing entries.
+
+Ledger entries are durable artifacts only — never conversation transcripts. The sharpening happens during collaboration; the ledger stores the result.
+
+The storage location must be documented and discoverable by any agent working on the project.
+
+Handoffs are emitted at verb transitions, not at arbitrary points. The verb change is the signal.
+
+Handoffs must be self-contained. An agent reading one cold must be able to act without the prior conversation.
+
+Results from downstream tools write back to the ledger, closing the loop.
+
+-----
+
+## Why This Matters
+
+Without the ledger, collaboration has no memory. Every session starts from zero. The human becomes the only bridge between sessions, carrying context in their head. The most expensive problem — knowledge transfer failure — reasserts itself inside every project.
+
+With the ledger, the collaboration compounds. Each session builds on what survived. Agents orient against encoded decisions, not stale memories. The human directs instead of translating. Trust is built because expectations are visible, persistent, and verifiable.

--- a/odd/maturity.md
+++ b/odd/maturity.md
@@ -169,7 +169,7 @@ This maturity model modulates the following:
 • Constraints
 Some constraints are optional at PoC and mandatory later.
 • Decision Rules
-Rules like KISS and Borrow→Build apply at all levels, but escalation thresholds change.
+Rules like KISS and Borrow→Bend→Break→Beget→Build (`canon/methods/borrow-bend-break-beget-build.md`) apply at all levels, but escalation thresholds change.
 • Definition of Done
 Evidence requirements increase with maturity.
 • Self-Audit Checklist

--- a/writings/from-bible-translation-to-epistemic-os.md
+++ b/writings/from-bible-translation-to-epistemic-os.md
@@ -1,0 +1,197 @@
+---
+uri: klappy://writings/from-bible-translation-to-epistemic-os
+title: "From Bible Translation to Epistemic OS — And Back Again"
+subtitle: "An essay on how fifteen years of Bible translation work became the foundation for AI-human collaboration infrastructure"
+author: "Klappy"
+type: essay
+public: true
+audience: public
+exposure: public
+tier: 2
+voice: first_person
+stability: stable
+tags:
+  - writings
+  - essay
+  - bible-translation
+  - epistemics
+  - knowledge-transfer
+  - ai
+  - odd
+  - origin-story
+  - community-checking
+epoch: E0005
+date: 2026-02-15
+
+# Discovery
+hook: "Fifteen years of Bible translation taught me that every collaboration failure is an expectations failure. I abstracted those patterns into an Epistemic OS. Now I'm testing whether it can go back where it came from."
+description: "The full-circle origin story of Outcomes-Driven Development — from Bible translation practices to universal AI-human collaboration infrastructure, and the vision of bringing it home."
+slug: from-bible-translation-to-epistemic-os
+
+# Social graph
+og_title: "From Bible Translation to Epistemic OS — And Back Again"
+og_description: "Fifteen years of Bible translation became the foundation for trustworthy AI collaboration. Now the abstraction is going home."
+og_type: article
+og_image: /images/from-bible-translation-to-epistemic-os-og.png
+twitter_card: summary_large_image
+twitter_title: "From Bible Translation to Epistemic OS — And Back Again"
+twitter_description: "Fifteen years of Bible translation became the foundation for trustworthy AI collaboration. Now the abstraction is going home."
+twitter_image: /images/from-bible-translation-to-epistemic-os-og.png
+
+# Relationships
+derives_from:
+  - canon/values/axioms.md
+  - canon/values/orientation.md
+  - canon/values/trust-kernel.md
+related:
+  - uri: klappy://writings/the-most-expensive-problem
+    label: "The Most Expensive Problem"
+    relationship: companion
+complements: "writings/the-most-expensive-problem.md, canon/methods/community-checking.md, canon/methods/borrow-bend-break-beget-build.md, docs/oddkit/positioning.md, docs/evidence/testimony-2026-02-15.md"
+start_here: true
+start_here_order: 2
+start_here_label: "From Bible Translation to Epistemic OS — The Origin Story"
+---
+
+# From Bible Translation to Epistemic OS — And Back Again
+
+### An essay on how fifteen years of Bible translation work became the foundation for AI-human collaboration infrastructure
+
+*By Klappy — builder of the Epistemic OS*
+*Companion: [The Most Expensive Problem](klappy://writings/the-most-expensive-problem)*
+
+---
+
+For fifteen years I built software and helped oversee funding and exploration in Bible translation — first at unfoldingWord, then through partnerships across the ETEN Innovation Lab, always in collaboration with peers and colleagues across our partner organizations. Not just translation software — software designed to support everything: the full translation process from beginning to end, so that church networks around the world could own it themselves. Guidance from the experts, not controlled by the experts.
+
+That distinction matters more than anything else I'll say here.
+
+---
+
+## What Bible Translation Actually Looks Like
+
+Most people imagine Bible translation as a scholar at a desk with dictionaries. The reality — especially in oral communities — is radically different.
+
+Understanding the source isn't a reading exercise. In oral Bible translation, it starts with listening to a source recording. From there, communities move through multiple modalities — actions, songs, acting, dances, personifying objects as visual aids. They embody what they've heard until comprehension is real, not assumed. You haven't understood a passage until you can perform it, not just parse it.
+
+Then comes drafting. Then checking — not once, but in nested cycles. Understand, translate, check, repeat. The checking itself is layered: self-checking, peer checking, consultant checking, and finally community checking, where the translation goes back to the people it was made for. Not the experts. The community.
+
+The community doesn't evaluate correctness. They test transfer. Can they retell it? Does it produce the right response? Do they understand it in their bones, not just their heads? They use it in pulpits and ministry. They sing it. They live with it. And their response tells you whether the translation actually works — or whether it only satisfied the translator.
+
+This is not quality assurance. This is outcome validation.
+
+---
+
+## The Pattern I Didn't See For Years
+
+I spent years working in this process across languages, cultures, and organizations — alongside colleagues who had been doing this work far longer than me. I saw things work and I saw things break. At different layers, for different reasons. But I didn't yet have language for the common thread underneath.
+
+One pattern was everywhere but invisible: no two organizations blindly adopt each other's tools or resources. They review extensively, test carefully, and half the time create their own version anyway. Not from stubbornness — from genuine need. The existing tool doesn't fit their context, their methodology, their community's requirements. So they borrow, bend, hit the breaks, and build their own.
+
+Software developers do the exact same thing. Evaluate a framework, try to adapt it, hit the limitations, build a custom version. The pattern is identical. And in both worlds, without a shared record of what was tried and why it broke, the next organization or the next developer rediscovers the same breaks independently. The learning doesn't transfer.
+
+That came later.
+
+---
+
+## The Most Expensive Problem
+
+Then I started working with AI — building systems where humans and AI collaborate on complex outputs. And familiar patterns appeared immediately.
+
+AI doesn't remember what you decided last session. Context dies when the conversation closes. The human becomes a copy-paste engine carrying decisions between tools. And even when checking happens — and it does — the results don't automatically carry forward into the next session or the next tool.
+
+And the AI agents themselves are just as lossy. Without epistemic discipline, they hallucinate, forget what was decided, agree too quickly, and lose context between sessions. The problem isn't unique to humans carrying knowledge in their heads — agents without durable infrastructure are equally unreliable routers. The inconsistencies are remarkably similar.
+
+This isn't hypothetical. Some BT organizations are already using AI to help their content teams create and maintain translation resources — notes, interlinked reference materials, iteratively published book packages that translation teams use on the field. They're embedding their knowledge of how to create these resources into prompts, and they're learning and refining their process as they go. It's working. But it requires manual processes to handle every interaction with AI. The human is managing the context, updating the prompts by hand, keeping track of what changed and why. The learning is happening, but nothing carries it automatically.
+
+Every collaboration with AI that relies on manual knowledge transfer has the same vulnerability I saw in Bible translation. The knowledge lives in someone's head — or now, in someone's prompt. When that person moves on, the knowledge goes with them.
+
+I wrote about this as "The Most Expensive Problem" — the cost of knowledge transfer failure in AI-assisted work. But I didn't yet see where the solution had come from.
+
+---
+
+## The Abstraction Was Subconscious
+
+I've been building a system called Outcomes-Driven Development. It has axioms about truth and verification. It has epistemic modes for different phases of work. It has a ledger for durable decisions. It has community checking for outcome validation. It has a principle that the human directs and the AI generates, but neither promotes unsupervised.
+
+I've been building the tooling — oddkit — as a protocol that slipstreams into existing workflows. It doesn't replace your tools. It keeps your agents honest while they think. Orient before acting. Challenge before agreeing. Gate before transitioning. Encode before forgetting. Validate before shipping.
+
+oddkit itself exists because I followed a sequence I later formalized: borrow what exists, bend it to your context, let the breaks reveal what's missing, offload to others what they can build in parallel, and only build what nobody else can carry. I borrowed existing AI models and interfaces — Claude, existing agent frameworks, the MCP standard. I bent MCP into an epistemic discipline layer. I let the breaks show me where existing tools lost context and trust. And I built only the thinnest possible layer — oddkit — that makes all of it trustworthy without replacing any of it. No models trained, no UIs created, no hundreds of millions of dollars spent. The entire system runs on what already exists, bent to serve epistemic discipline.
+
+And recently, in a conversation about the system's architecture, I said out loud what I hadn't consciously realized:
+
+I had been abstracting the ETEN Innovation Lab's recommendations for Bible Translation — the process designed to reach our 2033 All Access Goals — into universally applicable practices for creating responsibly in collaboration with AI and local communities. I hadn't set out to do that. I just kept solving the problems in front of me and the patterns that emerged were the same ones I'd been immersed in for fifteen years.
+
+Understand, translate, check, repeat had become converse, generate, validate, promote or pivot.
+
+Guidance from experts, not controlled by experts had become the protocol-not-platform positioning — oddkit slipstreams in, it doesn't take over.
+
+Multimodal understanding had become the Director's Chair — the insight that comprehension and intent are sensory, not textual. The human says "darker," "that felt wrong," "more like the first one but lonelier." The AI does the writing.
+
+Community checking didn't get borrowed as a metaphor. It *is* the original practice. Everything else was abstracted. Community checking was carried over whole.
+
+And the kernel — trust is built by managing expectations — came from watching what happens when processes break. In translation and everywhere else.
+
+The realization wasn't that I'd solved something. It was that the patterns I'd absorbed from Bible translation might be exactly what AI collaboration needs — and that oddkit could be the vehicle to bring them back.
+
+---
+
+## Going Back
+
+Here's what I didn't expect: the abstracted system might be ready to go back to its origin domain. That's the vision. It hasn't happened yet.
+
+But the path is forming. BT Servant — a project with unfoldingWord — is the intended partner effort where we're already collaborating to build toward this. Spoken Worldwide has signed on and is helping fund the initial R&D with the ETEN Innovation Lab.
+
+The vision for Bible translation is specific: each organization would encode their own methodology into their canon, and oddkit would operate out of that.
+
+Spoken Worldwide would encode their oral methodology and processes. Faith Comes By Hearing would encode theirs. SIL would encode their translation principles, their consultant checking questions, their key term policies. Wycliffe Global Partners would encode whatever serves their network. BCS in India would encode whatever they've developed that works for their context — maybe simpler, maybe more culturally specific, maybe entirely oral.
+
+Other Lab projects point toward where this could go. Fluent, an end-to-end multimodal BT tool with an upcoming mobile app, could use a future BT Servant powered by this kind of epistemic backbone to enable interoperability between tools — augmented handoffs that carry context across platforms instead of requiring translators to start over every time they switch tools.
+
+BT Servant is already using shared open-licensed resources from the Bible Aquifer — a curated collection of Bible translation resources deemed useful for this purpose. This includes unfoldingWord's Translation Helps, FIA (Familiarize, Internalize, Articulate) process materials for OBT, Tyndale Bible Study Notes, many open-licensed Bible translations, and each translated into many of the world's most spoken trade languages that translation teams use to translate from. The vision is that each organization's canon is theirs, while these shared resources are available to everyone.
+
+The goal for BT Servant and Church Based Bible Translation is to raise the floor — any translator, anywhere, should have access to scripture exegetical resources just in time through AI to aid in their understanding as they translate and check. Not to replace the expert guidance that consultants and coaches provide, but to make the resources available between visits, between sessions, between questions that would otherwise go unanswered until someone with the right training is in the room.
+
+Imagine a coach or consultant visits and doesn't spend the first day catching up. The ledger carries the context — every key term decision, every checking result, every constraint the team discovered. They orient in minutes and spend their time on what only a human guide can do.
+
+Imagine a new team member joins and doesn't need six months of context transfer. The ledger *is* the onboarding.
+
+Imagine a veteran's hard-won knowledge doesn't retire with them. It's encoded. It persists. It's available to every future team and every AI agent that works on that language.
+
+This is the most expensive problem — knowledge transfer failure — addressed in the domain where I first encountered it. Whether it works as well as I hope remains to be tested. Prayerfully, it will.
+
+There's already a small proof of concept that gives me hope. oddkit currently powers a voice agent — using a clone of my own voice — that guided my wife through sharpening her business ideas for online courses. In Spanish. For almost 30 minutes. I don't speak Spanish. My knowledge transferred through the agent into a language and context I couldn't have reached personally. If the system can do that for product development, the vision of it doing the same for translation teams — carrying expert knowledge across language barriers, available between visits, in the languages teams actually work in — feels less like theory and more like trajectory.
+
+I also expect that when these abstractions encounter BT reality again, they'll drift. The patterns I extracted will need to bend and adapt to a domain that's more complex and more human than any other context I've tested them in. That's not failure — it's evidence of a system that's still learning. I'd be worried if it didn't drift.
+
+---
+
+## The Onboarding Is the Same
+
+How does an organization start? The same way anyone starts with ODD.
+
+What hurts?
+
+Is it access to exegetical resources between coaching visits? Let AI surface them just in time as translators work. Is it key term consistency across teams? Encode your key term decisions in the ledger so every team reads from the same record. Is it new team member ramp-up? Start with the ledger. Is it community checking logistics? Let the AI help structure feedback, track what was tested, and surface patterns across sessions.
+
+They never need to learn ODD. They reach for the piece that relieves their current pain. If they never need another piece, that's success.
+
+Guidance from the infrastructure, not controlled by the infrastructure.
+
+---
+
+## Why This Matters Beyond Translation
+
+Bible translation teams figured out something that the rest of the world is just now encountering: how to collaborate faithfully across language, culture, modality, and expertise boundaries with the goal of producing output that actually transfers to the people it's for.
+
+They figured out that understanding is multimodal. That checking must include the community, not just the experts. That local ownership produces better outcomes than expert control. That the process is nested and iterative, not linear. That expectations must be managed explicitly or trust collapses.
+
+AI collaboration has exactly the same challenges. Different domain. Same patterns.
+
+The practices that I believe make AI-human collaboration trustworthy were observed in communities translating scripture into their own languages. I spent fifteen years working alongside them. Then I abstracted those patterns without realizing it. Now a few colleagues are helping me test those theories in their own domains. Prayerfully, the abstraction is ready to go home — not as a finished solution, but as an augmenting toolkit that can work inside the existing and next generation of Bible translation tools.
+
+Trust is built by managing expectations. Bible translators have been practicing this longer than anyone in tech. I'm still learning from them.
+
+---
+
+*The Epistemic OS is open, public, and working in the open at [github.com/klappy/klappy.dev](https://github.com/klappy/klappy.dev).*

--- a/writings/the-most-expensive-problem.md
+++ b/writings/the-most-expensive-problem.md
@@ -44,7 +44,10 @@ related:
   - uri: klappy://writings/the-parallel-architecture
     label: "Appendix: The Parallel Architecture"
     relationship: appendix
-complements: "writings/the-parallel-architecture.md, canon/values/shared-values-as-trust-proxy.md, docs/architecture/epistemic-os-layers.md, odd/appendices/cognitive-saturation-threshold.md, docs/evidence/testimony-2026-02-13.md"
+  - uri: klappy://writings/from-bible-translation-to-epistemic-os
+    label: "From Bible Translation to Epistemic OS — And Back Again"
+    relationship: companion
+complements: "writings/the-parallel-architecture.md, writings/from-bible-translation-to-epistemic-os.md, canon/values/shared-values-as-trust-proxy.md, canon/values/trust-kernel.md, docs/architecture/epistemic-os-layers.md, odd/appendices/cognitive-saturation-threshold.md, docs/evidence/testimony-2026-02-13.md"
 start_here: true
 start_here_order: 1
 start_here_label: "The Most Expensive Problem — Why This Exists"


### PR DESCRIPTION
New documents (8):
- canon/values/trust-kernel.md — the kernel principle: trust is built by managing expectations
- canon/methods/borrow-bend-break-beget-build.md — 5B method for maximizing work not done
- canon/methods/community-checking.md — outcome validation beyond author intent
- canon/the-frame.md — Epistemic OS product loop and roles
- canon/values/drift.md — drift as evidence of a living system
- odd/ledger/epistemic-ledger.md — durable artifacts that survive ephemeral conversations
- docs/oddkit/positioning.md — protocol not platform positioning
- writings/from-bible-translation-to-epistemic-os.md — public essay: BT origin story
- docs/evidence/testimony-2026-02-15.md — Claude testimony on the discovery session

Amendments:
- odd/constraint/use-only-what-hurts.md — bidirectional adoption + Theory of Constraints
- canon/methods/self-audit.md — six-check canon document preflight + 5B reference

Downstream updates:
- canon/values/axioms.md — trust-kernel added to derivation map
- odd/index.md — new infrastructure section with ledger, community-checking, 5B
- odd/maturity.md — 4B shorthand updated to 5B
- writings/the-most-expensive-problem.md — cross-references to BT essay and trust-kernel
- docs/evidence/testimony-2026-02-13.md — cross-reference to Feb 15 testimony

https://claude.ai/code/session_01Ea5iPY7p9ZtcU4QytZLueX

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes with no runtime behavior impact; main risk is broken/inconsistent cross-references or navigation metadata.
> 
> **Overview**
> Introduces a new **core documentation bundle** that formalizes the Epistemic OS framing and collaboration loop, including new canon values (`trust-kernel`, `drift`), new methods (`borrow-bend-break-beget-build`, `community-checking`), and a new core infrastructure spec for the `odd/ledger/epistemic-ledger`.
> 
> Updates existing governance docs to *incorporate these concepts* (e.g., `canon/methods/self-audit.md` now references 5B and adds a canon-document preflight; `odd/constraint/use-only-what-hurts.md` expands prioritization via Theory of Constraints and adds adoption guidance), plus downstream index/relationship edits (`odd/index.md`, `odd/maturity.md`, `canon/values/axioms.md`, testimonies, and essays) to wire in the new cross-references and “start here” navigation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1b82814feb1aff6617c574299b474ebb143ac0eb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->