### PR TITLE
Add harness essay, AI Coding Toolkit resonance page, and update resonance index

### DIFF
--- a/canon/resonance/README.md
+++ b/canon/resonance/README.md
@@ -89,6 +89,7 @@ Each resonance page follows a consistent structure:
 | `ooda-loop.md` | OODA Loop | Orientation Dominates Action |
 | `sprint.md` | Sprint | Constrained Convergence Produces Clarity |
 | `double-diamond.md` | The Double Diamond | Governed Divergence and Convergence |
+| `ai-coding-toolkit.md` | AI Coding Toolkit — Harness Engineering | Verification Must Be Structural, Not Manual |
 
 ---
 

--- a/canon/resonance/ai-coding-toolkit.md
+++ b/canon/resonance/ai-coding-toolkit.md
@@ -1,0 +1,107 @@
+---
+uri: klappy://canon/resonance/ai-coding-toolkit
+title: "AI Coding Toolkit — Harness Engineering"
+audience: canon
+tier: 3
+voice: neutral
+stability: stable
+tags: ["resonance", "harness-engineering", "ai-coding", "verification", "complementary-systems", "ben-shoemaker", "5B", "borrow"]
+relevance: background
+execution_posture: exploratory
+exposure: nav
+epoch: E0005
+date: 2026-02-18
+derives_from: "canon/values/axioms.md, canon/methods/borrow-bend-break-beget-build.md, docs/architecture/epistemic-os-layers.md"
+complements: "writings/the-harness-and-the-operating-system.md, canon/resonance/README.md, odd/odd-compared.md, canon/methods/community-checking.md"
+---
+
+# AI Coding Toolkit — Harness Engineering (Resonance)
+
+> Ben Shoemaker, 2026. Discovered via Changelog News, not studied. A practitioner-built toolkit for semi-autonomous AI coding that independently converged on patterns nearly identical to ODD's — spec-first workflow, layered verification, cross-evaluator checking, agent constraints as infrastructure, human gates at phase transitions. The convergence validates the patterns as load-bearing. The divergence reveals layer boundaries: Shoemaker governs how agents write code (ODD Layer 4); ODD governs how participants think (Layers 1–3). Per the 5B method, this toolkit is a direct borrow candidate at the generation layer — ODD does not need to build coding-specific harness infrastructure when someone else already carries it well. Companion essay: [The Harness and the Operating System](klappy://writings/the-harness-and-the-operating-system).
+
+---
+
+## How This Was Found
+
+This is not a work that was studied and then mapped to ODD. A colleague sent the article and toolkit. The patterns were immediately recognizable — the same structural solutions ODD arrived at, implemented independently for a different domain. That kind of recognition is stronger evidence than intellectual comparison. When someone who has never seen your system builds the same load-bearing structures from scratch, the structures aren't accidents.
+
+---
+
+## ODD Principle: Verification Must Be Structural, Not Manual
+
+ODD treats verification as infrastructure — layered, automated where possible, and governed by explicit constraints rather than ad hoc human review. The question is never "did someone look at this?" but "does the verification structure ensure this claim has evidence?"
+
+---
+
+## Convergent Quotes (Non-Authoritative)
+
+> "I don't read the code anymore... I just focus on the spec layer and the harness and the architecture."
+> — Ben Shoemaker, "In Defense of Not Reading the Code" (2026)
+
+> "We needed to understand what changes when a software engineering team's primary job is no longer to write code, but to design environments, specify intent, and build feedback loops."
+> — OpenAI, "Harness Engineering" (2026), cited by Shoemaker
+
+---
+
+## Where ODD Aligns
+
+The mechanical convergence is specific and structural:
+
+- **Spec before generation:** Both require detailed specification before agents produce output. Shoemaker's Specify → Plan → Execute maps to ODD's Exploration → Planning → Execution.
+- **Agent constraints as infrastructure:** AGENTS.md rules for coding agents parallel canon axioms and constraints for any participant.
+- **Requirement traceability:** Requirement IDs through document chain parallel derivation chains from axioms to implementation.
+- **Layered verification:** Type check → lint → test → build → mutation → security parallels orient → challenge → gate → preflight → validate.
+- **Cross-evaluator checking:** Diffs sent to a different AI model parallels community checking — output evaluated by a different participant who tests transfer.
+- **Human gates at transitions:** Both require human judgment at phase boundaries.
+- **Stuck detection:** Agent escalation after repeated failures parallels camping risk detection.
+- **Durable learning:** LEARNINGS.md per project is a nascent form of the epistemic ledger.
+
+---
+
+## Where ODD Diverges (Explicit)
+
+- **Domain-specific vs. domain-independent:** 35 coding-specific skills vs. axioms that govern any domain. The toolkit solves one domain. ODD provides the substrate that makes any domain's toolkit trustworthy.
+- **Code correctness vs. specification correctness:** The toolkit verifies code matches specs. ODD verifies specs match reality. Drift detection — catching when assumptions silently diverge from truth — is absent from the toolkit.
+- **Per-project knowledge vs. compounding knowledge:** LEARNINGS.md persists within a project. ODD's ledger compounds across projects, teams, and tools. The most expensive problem — knowledge transfer failure — is not addressed by per-project learning.
+- **Correctness vs. trust:** Correct output that nobody trusts is still a failure. Trust requires correctness plus expectation management — the ability to distinguish verified from assumed.
+- **Implicit values vs. explicit axioms:** The toolkit embodies good engineering practice without articulating the values those practices serve. ODD makes values explicit, forkable, and load-bearing.
+- **Output verification vs. outcome validation:** "Do the tests pass?" vs. "Does this transfer to the people it's for?" Different questions with different failure modes.
+
+---
+
+## Why the Divergence Matters
+
+A harness without an epistemic layer produces reliable output from potentially unreliable decisions. The code may be correct, well-tested, and secure — and still be the wrong thing to build.
+
+An epistemic layer without a generation harness produces trustworthy decisions that may be poorly executed.
+
+Stacking them produces something neither achieves alone: trustworthy decisions executed reliably.
+
+---
+
+## 5B Operationalization — This Is a Borrow, Not a Build
+
+The 5B method (Borrow, Bend, Break, Beget, Build) governs how ODD approaches any capability gap. The AI Coding Toolkit maps cleanly:
+
+**Borrow** — The toolkit's structural patterns (spec-first, layered verification, cross-model checking, phase gates) are directly usable at ODD's Layer 4 for software development work. No modification needed to benefit from the approach.
+
+**Bend** — The toolkit's AGENTS.md could be extended to load ODD axioms alongside its existing rules, giving coding agents epistemic constraints without modifying the toolkit's verification infrastructure.
+
+**Break** — The toolkit has no drift detection, no compounding knowledge, no outcome validation. These are the breaks that reveal where the harness layer ends and the epistemic layer begins. They are not problems to fix in the toolkit — they are problems that live at a different layer.
+
+**Beget** — Let Shoemaker and his community carry the coding harness. They are already building and improving it. ODD does not need to replicate 35 coding skills when someone else owns that piece and is iterating on it in the open.
+
+**Build** — Only what the toolkit cannot carry: the epistemic substrate. The axioms, the modes, the ledger, the drift detection, the community checking, the knowledge that compounds. The smallest layer that makes the harness trustworthy without replacing it.
+
+This is the 5B method working exactly as designed. Maximum leverage. Minimum original work. Build only what nobody else can carry.
+
+---
+
+## Related Canon
+
+- [Method: Borrow, Bend, Break, Beget, Build](/canon/methods/borrow-bend-break-beget-build.md) — The method that governs how ODD approaches this relationship
+- [Epistemic OS Layers](/docs/architecture/epistemic-os-layers.md) — The four-layer architecture that maps where the toolkit fits
+- [Community Checking](/canon/methods/community-checking.md) — The practice Shoemaker independently approximated with cross-model verification
+- [Verification & Evidence](/canon/constraints/verification-and-evidence.md) — The constraint that claims require observed evidence
+- [Shared Values as Trust Proxy](/canon/values/shared-values-as-trust-proxy.md) — Why explicit values produce trust that implicit good practice does not
+- [The Harness and the Operating System](/writings/the-harness-and-the-operating-system.md) — Public essay exploring this resonance for a general audience

--- a/writings/the-harness-and-the-operating-system.md
+++ b/writings/the-harness-and-the-operating-system.md
@@ -1,0 +1,187 @@
+---
+uri: klappy://writings/the-harness-and-the-operating-system
+title: "The Harness and the Operating System"
+subtitle: "Why the best AI coding toolkit and an Epistemic OS belong in the same stack — not the same category"
+author: "Klappy"
+type: essay
+public: true
+audience: public
+exposure: public
+tier: 2
+voice: first_person
+stability: stable
+tags:
+  - writings
+  - essay
+  - epistemics
+  - ai-coding
+  - harness-engineering
+  - complementary-systems
+  - trust
+  - verification
+epoch: E0005
+date: 2026-02-18
+
+# Discovery
+hook: "A developer who doesn't read his code and a systems architect who built an Epistemic OS arrived at the same conclusion independently. That's not competition. That's directional validation."
+description: "Ben Shoemaker's AI Coding Toolkit and the Epistemic OS solve different layers of the same problem. This essay maps the convergence, names the differences, and argues they belong stacked — not competing."
+slug: the-harness-and-the-operating-system
+
+# Social graph
+og_title: "The Harness and the Operating System"
+og_description: "A developer and a systems architect arrived at the same conclusion independently. That's directional validation."
+og_type: article
+og_image: /images/the-harness-and-the-operating-system-og.png
+twitter_card: summary_large_image
+twitter_title: "The Harness and the Operating System"
+twitter_description: "A developer and a systems architect arrived at the same conclusion independently. That's directional validation."
+twitter_image: /images/the-harness-and-the-operating-system-og.png
+
+# Relationships
+derives_from:
+  - canon/values/axioms.md
+  - canon/values/orientation.md
+  - docs/architecture/epistemic-os-layers.md
+related:
+  - uri: klappy://writings/the-most-expensive-problem
+    label: "The Most Expensive Problem"
+    relationship: companion
+  - uri: klappy://writings/from-bible-translation-to-epistemic-os
+    label: "From Bible Translation to Epistemic OS"
+    relationship: companion
+complements: "writings/the-most-expensive-problem.md, writings/from-bible-translation-to-epistemic-os.md, docs/architecture/epistemic-os-layers.md, canon/methods/community-checking.md, canon/resonance/ai-coding-toolkit.md"
+---
+
+# The Harness and the Operating System
+
+### Why the best AI coding toolkit and an Epistemic OS belong in the same stack — not the same category
+
+*By Klappy — builder of the Epistemic OS*
+
+---
+
+Last week, Ben Shoemaker's article "In Defense of Not Reading the Code" hit Changelog News and generated 200+ comments on Hacker News. His argument: the spec, architecture, and verification layer are becoming the artifacts that matter — not the code itself. He built a toolkit around that conviction. 35+ skills, layered verification, cross-model checking, structured specs with requirement IDs that trace through to execution.
+
+I read the article and the toolkit and my first reaction was: this guy is close.
+
+My second reaction was: close to what? Because Ben and I arrived at remarkably similar conclusions from completely different directions, and the overlap is worth examining — not because we're competing, but because independent convergence on the same structural patterns is the strongest evidence that the patterns are real.
+
+---
+
+## The convergence is specific
+
+Ben's three-phase model — Specify, Plan, Execute — maps almost exactly to the three epistemic modes in Outcomes-Driven Development: Exploration, Planning, Execution. His AGENTS.md constrains agent behavior through explicit rules; my canon constrains thinking through explicit axioms. His toolkit enforces TDD, stuck detection, and phase checkpoints; ODD enforces orientation, challenge, and gating.
+
+The structural DNA is uncanny. He has requirement IDs that trace from product spec through execution plan. I have derivation chains that trace from axioms through constraints to implementation. He sends diffs to a different AI model for cross-verification. I formalized that same pattern as community checking — the practice, borrowed from Bible translation, of sending output to a different evaluator who tests transfer rather than correctness.
+
+His harness even has what he calls "learning capture" — a LEARNINGS.md file where project-specific patterns and gotchas persist across sessions. That's a nascent version of what I call encoding — the practice of promoting ephemeral insights into durable records so they survive context death.
+
+When two people solve the same problem independently using the same structural patterns, the patterns aren't accidents. They're load-bearing.
+
+---
+
+## The differences are also specific
+
+Here's where it matters that the convergence is real, because it makes the divergence meaningful rather than cosmetic.
+
+Ben built a harness for AI coding agents. I built an operating system for AI-human thinking. Those sound similar. They are not.
+
+His system answers: "How do I get reliable code out of AI agents?" My system answers: "How do I get reliable thinking out of AI collaboration?" The first question is a subset of the second. That's not a criticism — it's a description of where the two systems live in the stack.
+
+A few specific differences:
+
+**His toolkit is domain-specific. ODD is domain-independent.** Ben's 35 skills are about software development: TDD enforcement, git workflow, dependency audits, browser checks. Powerful for code. Not transferable to a Bible translation team checking whether a passage transfers in oral Swahili, or a consultant encoding institutional knowledge for a successor, or a voice agent guiding someone through business planning in Spanish. ODD's axioms work for all of these because they govern *how to think*, not *what to build*.
+
+**His system has no concept of epistemic drift.** His verification gates check whether code matches specs. They don't check whether specs match reality. In ODD, drift detection is a first-class concern — the mechanism for catching when documentation, assumptions, and tooling silently diverge from truth. His system can tell you the tests pass. It can't tell you the tests are testing the right thing.
+
+**His system has no durable knowledge.** Each project starts fresh. There's a LEARNINGS.md per project, but no accumulating organizational memory, no content-addressable identity, no knowledge base that compounds across projects and teams. ODD's entire value proposition is that knowledge compounds — decisions encoded today inform work done next month by a different agent in a different tool.
+
+**His system optimizes for correctness. ODD optimizes for trust.** Correctness is a subset of trust. You can produce correct code that nobody trusts, because the process that produced it is opaque. Trust requires correctness plus expectation management — the ability to distinguish what's been verified from what's been assumed, and to make that distinction visible. Ben's cross-model verification is a correctness mechanism. ODD's axiom that "A Claim Is a Debt" is a trust mechanism.
+
+---
+
+## The skeptics answered — and the answers reveal the gap
+
+Ben's article addressed several critiques from the Hacker News discussion, and his responses are instructive because they show exactly where a harness reaches its limit and an operating system begins.
+
+> I can't imagine any other example where people voluntarily move for a black box approach. (kace91)
+
+Ben's response was good: the output of code is the product, not the code itself. Abstraction layers are normal in engineering. But this argument only holds while the black box stays within the software domain. When the black box is a medical diagnosis, a legal analysis, a translation that communities will use in pulpits and ministry — the abstraction argument doesn't work anymore. The question becomes: who checks whether the output transfers to the people it's for? That's not a linting problem. That's a community checking problem.
+
+> If my code fails people lose money, planes halt, cars break down. Read. The. Code. (frank00001)
+
+Ben addressed this with a fair argument about harness-first approaches reducing defect rates compared to raw vibe coding. He referenced a commenter who described specs, tests, static analysis, benchmarking, and heavy dogfooding as a sufficient verification stack. And for code? I think that's right. But "code fails and people lose money" is the *mild* version of the problem. What about when the thinking fails? When the spec itself drifted from reality, and the code faithfully implemented the wrong thing? The harness catches implementation errors. It doesn't catch specification errors. That requires something upstream — something that checks whether what you decided to build is still what you should be building.
+
+> You made me imagine AI companies maliciously injecting backdoors in generated code no one reads, and now I'm scared. (thefz)
+
+Ben called this a tooling problem, not a "read every line" problem. He's right for security scanning. But the broader version of this concern — that generated output contains subtle misalignment with intent — is not a tooling problem. It's a trust infrastructure problem. Static analysis can catch a backdoor. It cannot catch a spec that was subtly reinterpreted by an agent that agreed too quickly and never pushed back.
+
+---
+
+## The aviation analogy goes deeper than he took it
+
+Ben referenced "Children of the Magenta" — pilots who became dependent on the programmed flight path and lost the judgment to know when to intervene. His lesson: use the autopilot but maintain the ability to step down the level of automation.
+
+I think the analogy is even more revealing than he realized.
+
+The pilots didn't just lose the ability to fly manually. They lost the ability to *recognize when manual flight was needed*. The automation didn't fail catastrophically — it failed epistemically. The pilots couldn't tell the difference between "the system is handling this correctly" and "the system is handling this confidently." Confidence was mistaken for evidence.
+
+That's the exact failure mode I documented when I first started building ODD. AI agents asserting things about the world without looking at the world. Generating plausible descriptions of reality as a substitute for observing it. Substituting narrative for observation. These aren't coding bugs. They're epistemic failures. And a coding harness — no matter how sophisticated — isn't designed to catch them.
+
+The aviation industry didn't solve Children of the Magenta with better autopilots. They solved it with Crew Resource Management — a *human judgment framework* that operates above the automation. The harness is the autopilot. The operating system is CRM.
+
+---
+
+## These systems belong in the same stack
+
+Here's the argument I actually want to make: Ben's toolkit and ODD are not competitors. They're complementary layers that would be more powerful together than either is alone.
+
+Ben's harness is excellent at the generation layer — constraining how agents write code, enforcing verification at implementation boundaries, maintaining clean git history, catching stuck agents. This is precisely what ODD's Layer 4 (Generation and Outcomes) is designed to support. ODD doesn't currently have 35 coding-specific skills. It doesn't need them if a toolkit like Ben's exists at that layer.
+
+What ODD provides is the substrate underneath: the values layer that makes the harness trustworthy rather than merely functional, the dynamic context layer that gives agents access to accumulated knowledge without bloating the context window, the alignment layer that gates whether you should be coding at all yet.
+
+Imagine the stack: ODD's axioms constraining what claims agents are allowed to make. ODD's epistemic modes gating whether the team is still in exploration (should we build this?) or has legitimately transitioned to execution (build it). Ben's harness governing how agents execute once they're in the execution phase. ODD's encoding capturing what was learned during execution and promoting it into durable knowledge. Ben's cross-model verification at the code level. ODD's community checking at the outcome level — does this thing we built actually transfer to the people it's for?
+
+The harness makes code reliable. The operating system makes the decisions that produced the code trustworthy. Neither replaces the other.
+
+---
+
+## Developers don't need an Epistemic OS for coding. Experts need it for everything else.
+
+Ben's audience is developers. His toolkit solves a real developer pain point — unreliable AI coding agents — with a practical, cloneable solution. Fork the repo, run the commands, ship more reliable code. That's a great product for a real market.
+
+My audience is broader: anyone whose expertise is the bottleneck and whose most expensive problem is knowledge transfer failure when context doesn't travel with the work. That includes developers, but it also includes translation teams, consultants, ministry leaders, educators, clinicians — anyone who collaborates with AI on complex outputs where trust matters more than throughput.
+
+The developer wedge was where I felt the pain first, just like Ben. But the axioms I extracted aren't about software. They're about the structural failure modes of any system that generates faster than it verifies. A Bible translator facing an AI that confidently produces a passage that doesn't transfer to the target community has the same problem as a developer facing an AI that confidently reports passing tests that weren't run. The failure mode is identical. The domain is different. The harness solves the domain. The operating system solves the failure mode.
+
+---
+
+## Bet on the trajectory — but know what you're betting on
+
+Ben ends his article with a call to bet on the trajectory of AI models improving. I agree with him. But I think the trajectory argument actually strengthens the case for an epistemic layer *above* the coding harness.
+
+As models improve, the coding harness becomes less necessary — not more. Better models need fewer constraints on how they write code. Ben even acknowledges this implicitly: the constraints exist because current models are unreliable, and they'll become less so.
+
+But as models improve at generation, the verification gap doesn't close. It widens. Production gets faster. The question "is this actually what we should have built?" gets harder, not easier. The epistemic infrastructure that tracks what's been verified versus assumed, that gates premature convergence, that encodes decisions so they survive context death — that infrastructure becomes *more* necessary as models get better, not less.
+
+The harness is an amazing tool for 2026. The operating system is infrastructure for however long humans need to distinguish what's true from what sounds true.
+
+---
+
+## Independent convergence is the strongest signal
+
+Two people. Different domains, different backgrounds, different audiences. One started with Claude Code and software projects. The other started with systems architecture and fifteen years of watching knowledge transfer fail across languages, cultures, and organizations in Bible translation.
+
+Both arrived at: the spec matters more than the code. Verification must be layered. Constraints must be explicit. Cross-checking must involve different evaluators. Decisions must be durable. The human directs, the AI generates, and neither promotes unsupervised.
+
+That's not coincidence. That's the shape of the problem asserting itself.
+
+Ben built the harness. I built the operating system. They belong in the same stack — the harness governing generation, the operating system governing the thinking that decides what to generate and whether the generation transferred.
+
+Let him own developers. The rest of the experts are waiting.
+
+---
+
+*The Epistemic OS is open, public, and working in the open at [github.com/klappy/klappy.dev](https://github.com/klappy/klappy.dev).*
+
+*Ben Shoemaker's AI Coding Toolkit is at [github.com/benjaminshoemaker/ai_coding_project_base](https://github.com/benjaminshoemaker/ai_coding_project_base).*


### PR DESCRIPTION
New essay "The Harness and the Operating System" maps convergence and divergence
between Ben Shoemaker's AI Coding Toolkit and the Epistemic OS, arguing they
belong stacked as complementary layers. New resonance page documents the toolkit
as ODD's first contemporary-practitioner resonance entry, with 5B analysis
identifying it as a borrow at the generation layer.

https://claude.ai/code/session_01C3kwznuE4rHAg2hSvZDTTN

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only additions (new markdown pages and a README index update) with no runtime, security, or data-path changes.
> 
> **Overview**
> Adds a new Resonance page, `canon/resonance/ai-coding-toolkit.md`, documenting Ben Shoemaker’s AI Coding Toolkit as a *borrowable* Layer-4 “harness engineering” pattern and explicitly contrasting it with ODD’s upstream epistemic concerns (drift detection, compounding knowledge, outcome validation).
> 
> Publishes a new public essay, `writings/the-harness-and-the-operating-system.md`, arguing the toolkit and the Epistemic OS are complementary stack layers rather than competitors, and updates the Resonance index to include the new entry.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c231c450ed9f210933f93841b9440fddc98c5dc9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->