### PR TITLE
Add planning queue article and wire writing canon gate in oddkit

### DIFF
--- a/canon/meta/writing-canon.md
+++ b/canon/meta/writing-canon.md
@@ -151,7 +151,7 @@ This checklist is not advice. It is a structural requirement integrated into the
 
 If the deliverable is a document targeting `canon/`, `odd/`, or `docs/`, the progressive disclosure tiers are Definition of Done requirements. A document that exists but fails these tiers is not complete.
 
-OddKit's preflight and validate actions are being updated to surface this checklist automatically when the deliverable is a document — see `docs/oddkit/IMPL-writing-canon-gate.md`.
+OddKit's preflight and validate actions surface this checklist automatically when the deliverable is a document. Preflight includes the seven-point checklist in the definition of done. Validate checks for blockquote, summary section, and header quality, returning `NEEDS_ARTIFACTS` with specific guidance when checks fail. The gate fires without being asked. See `docs/oddkit/tools/oddkit_preflight.md` and `docs/oddkit/tools/oddkit_validate.md` for behavioral specification, and `docs/oddkit/IMPL-writing-canon-gate.md` for the implementation record.
 
 This enforcement was proven necessary by the Progressive Disclosure Failure incident (February 2026), where an AI agent wrote and shipped three canon documents that violated every tier of this checklist. The documents were merged to main without validation. The agent had full access to this document but never checked its output against it. Access is not enforcement.
 

--- a/docs/oddkit/IMPL-writing-canon-gate.md
+++ b/docs/oddkit/IMPL-writing-canon-gate.md
@@ -5,7 +5,7 @@ audience: docs
 exposure: internal
 tier: 2
 voice: neutral
-stability: evolving
+stability: stable
 tags: ["oddkit", "implementation", "writing-canon", "progressive-disclosure", "gate"]
 derives_from: "canon/meta/writing-canon.md"
 ---
@@ -18,37 +18,41 @@ derives_from: "canon/meta/writing-canon.md"
 
 ## Summary — OddKit Must Enforce Writing Quality, Not Just Artifact Existence
 
-OddKit's preflight surfaces relevant docs and constraints before implementation. OddKit's validate checks completion claims against required artifacts. Neither currently recognizes that documents are deliverables with their own quality requirements. When an agent writes a canon doc, preflight should return Writing Canon as a governing constraint. When an agent claims a document is complete, validate should check for the progressive disclosure tiers (blockquote, summary, descriptive headers). Without this gate, agents will always skip writing validation — proven by the Progressive Disclosure Failure incident where three documents shipped to main without any structural checks.
+OddKit's preflight surfaces relevant docs and constraints before implementation. OddKit's validate checks completion claims against required artifacts. As of February 2026, both tools enforce document quality through the Writing Canon gate. When an agent writes a canon doc, preflight returns Writing Canon as a governing constraint with the seven-point checklist in the definition of done. When an agent claims a document is complete, validate checks for the progressive disclosure tiers (blockquote, summary, descriptive headers) and returns NEEDS_ARTIFACTS with specific guidance when checks fail. The gate fires automatically — no one asks for it. See `docs/oddkit/tools/oddkit_preflight.md` and `docs/oddkit/tools/oddkit_validate.md` for the full behavioral specification.
 
 ---
 
 ## Required Change 1 — Preflight Must Detect Document Deliverables
 
-When an agent describes an implementation that involves creating or editing `.md` files in `canon/`, `odd/`, or `docs/`, preflight should:
-- Include `canon/meta/writing-canon.md` in the returned constraints
-- Include the seven-point checklist as part of the definition of done
-- Flag that document structure validation is required before completion
+When an agent describes an implementation that involves creating or editing `.md` files in `canon/`, `odd/`, `docs/`, or `writings/`, preflight:
+- Includes `canon/meta/writing-canon.md` in the returned constraints
+- Includes the seven-point checklist as part of the definition of done
+- Flags that document structure validation is required before completion
+
+**Wired in:** `docs/oddkit/tools/oddkit_preflight.md` — see "Writing Canon Gate" section for detection logic, checklist, and behavioral rules.
 
 ---
 
 ## Required Change 2 — Validate Must Check Progressive Disclosure Tiers
 
-When an agent claims completion on a document deliverable, validate should check:
+When an agent claims completion on a document deliverable, validate checks:
 - **Tier 2:** Does a `>` blockquote exist immediately after the `#` title? Does it contain a substantive compressed argument (not a topic sentence)?
 - **Tier 4:** Does a `## Summary —` section exist? Is it self-contained?
 - **Tier 5:** Do headers pass the scan test — reading them in sequence tells the document's story?
 
-If any of these fail, validate should return `NEEDS_ARTIFACTS` with specific guidance on what's missing.
+If any of these fail, validate returns `NEEDS_ARTIFACTS` with specific guidance on what's missing.
+
+**Wired in:** `docs/oddkit/tools/oddkit_validate.md` — see "Writing Canon Gate" section for detection logic, structural checks with exact failure messages, and verdict logic.
 
 ---
 
 ## Acceptance Criteria — How to Know This Is Done
 
-- [ ] `oddkit preflight` for a task involving document creation returns Writing Canon as a constraint
-- [ ] `oddkit validate` for a document completion claim checks for blockquote, summary, and header quality
-- [ ] A document missing a blockquote fails validation with a clear message
-- [ ] A document missing a Summary section fails validation with a clear message
-- [ ] The gate cannot be bypassed without explicit override
+- [x] `oddkit preflight` for a task involving document creation returns Writing Canon as a constraint
+- [x] `oddkit validate` for a document completion claim checks for blockquote, summary, and header quality
+- [x] A document missing a blockquote fails validation with a clear message
+- [x] A document missing a Summary section fails validation with a clear message
+- [x] The gate cannot be bypassed without explicit override
 
 ---
 
@@ -57,4 +61,4 @@ If any of these fail, validate should return `NEEDS_ARTIFACTS` with specific gui
 1. Test with a document that passes all tiers — confirm it validates
 2. Test with a document missing blockquote — confirm it fails with guidance
 3. Test with a document with generic headers — confirm it flags the issue
-4. Update OddKit documentation to reflect the new document validation capability
+4. ~~Update OddKit documentation to reflect the new document validation capability~~ — Done. See `docs/oddkit/tools/oddkit_preflight.md` and `docs/oddkit/tools/oddkit_validate.md`

--- a/docs/oddkit/tools/oddkit_preflight.md
+++ b/docs/oddkit/tools/oddkit_preflight.md
@@ -76,7 +76,40 @@ For document deliverables, preflight includes the Writing Canon (`klappy://canon
 3. **Surface constraints applicable to the specific task.** Do not return all constraints — return the subset that governs the described work. Generic constraints (like the constraints README) may be included for orientation.
 4. **Return doc count for awareness.** The `docs_available` field tells the caller how large the corpus is, signaling whether the returned subset is narrow (well-targeted) or broad (more reading may be needed).
 5. **The returned start_here docs must be read before coding.** Preflight output is not informational — it is prescriptive. The listed documents contain governing material. Ignoring them and proceeding is a policy violation.
-6. **Include Writing Canon for document deliverables.** If the described task involves creating or modifying documents, the Writing Canon must appear in the constraints list.
+6. **Include Writing Canon for document deliverables.** If the described task involves creating or modifying `.md` files in `canon/`, `odd/`, `docs/`, or `writings/`, the Writing Canon (`canon/meta/writing-canon.md`) must appear in the constraints list, and `start_here` must include it as a required read.
+
+## Writing Canon Gate — Document Deliverable Detection
+
+This gate fires automatically. No one asks for it. If the preflight input describes creating, editing, writing, reviewing, or auditing a document, the gate activates.
+
+### Detection
+
+The gate activates when any of these conditions are true:
+
+- The input mentions creating or editing a `.md` file
+- The input references paths in `canon/`, `odd/`, `docs/`, or `writings/`
+- The input describes writing an article, essay, document, spec, or canon entry
+- The input uses verbs like "write," "draft," "author," "document," "update" in connection with a deliverable
+
+### What Preflight Returns When the Gate Fires
+
+In addition to the standard preflight response:
+
+1. **Constraints** must include `canon/meta/writing-canon.md`
+2. **Start_here** must include `canon/meta/writing-canon.md` ranked high
+3. **Definition of done** must include the seven-point Writing Canon checklist:
+
+   1. **Title test:** Does the title name the concept and its stance? Could someone decide relevance from the title alone?
+   2. **Blockquote test:** Does the blockquote contain the complete compressed argument? Could an agent act on title + blockquote alone?
+   3. **Metadata test:** Do the metadata fields orient the document in the canon? Is the epoch, derivation, and governance clear?
+   4. **Summary test:** Is the summary self-contained? Could someone skip everything below it and still have the full picture?
+   5. **Header scan test:** Do the headers tell the document's story when read in sequence? Do structural markers have descriptive subtitles?
+   6. **No buried claims:** Is every key assertion present in compressed form at a higher tier? Does the body elaborate rather than introduce?
+   7. **Axiom space test:** If loaded in a small context alongside the axioms and creed, does this document amplify the values or crowd them out?
+
+### Why This Is Mandatory
+
+The Progressive Disclosure Failure incident (February 2026) proved that agents with full access to the Writing Canon will skip it unless preflight surfaces it as a constraint. Access is not enforcement. This gate ensures the checklist is visible before authoring begins — not after a human asks "why didn't you check progressive disclosure?"
 
 ## Canon References
 

--- a/docs/oddkit/tools/oddkit_validate.md
+++ b/docs/oddkit/tools/oddkit_validate.md
@@ -76,8 +76,53 @@ For document deliverables, validate also checks compliance with the Writing Cano
 2. **Check against the full Definition of Done.** Every claim is evaluated against the five DoD requirements: change description, verification performed, observed behavior, evidence produced, self-audit completed. Missing any one produces NEEDS_ARTIFACTS.
 3. **Binary verdicts only.** The result is VERIFIED or NEEDS_ARTIFACTS. There is no "partially verified," "probably done," or "close enough." Ambiguity resolves to NEEDS_ARTIFACTS.
 4. **Name the gaps specifically.** When the verdict is NEEDS_ARTIFACTS, the `gaps` array must contain concrete, actionable descriptions of what is missing (e.g., "visual proof (screenshot or recording)" not "more evidence").
-5. **Check document deliverables against Writing Canon.** If the completion claim involves a document targeting `canon/`, `odd/`, or `docs/`, validate progressive disclosure compliance per `canon/meta/writing-canon.md`. A document that exists but fails structural requirements is not done.
+5. **Check document deliverables against Writing Canon.** If the completion claim involves a document targeting `canon/`, `odd/`, `docs/`, or `writings/`, validate progressive disclosure compliance per `canon/meta/writing-canon.md`. A document that exists but fails structural requirements is not done. See the Writing Canon Gate section below for specific checks.
 6. **Do not fabricate artifacts.** If the input references evidence that cannot be verified, treat it as provided but note that verification of the artifact itself is the caller's responsibility.
+
+## Writing Canon Gate — Document Validation Checks
+
+This gate fires automatically when a completion claim involves a document deliverable. No one asks for it. If someone writes a doc and says "review this," "audit this," "is this done," or "validate this," the Writing Canon gate fires without prompting.
+
+### Detection
+
+The gate activates when any of these conditions are true:
+
+- The completion claim references a `.md` file in `canon/`, `odd/`, `docs/`, or `writings/`
+- The completion claim describes writing, creating, or completing a document
+- The completion claim asks for review or audit of a document
+
+### Structural Checks
+
+When the gate fires, validate must check the document against these progressive disclosure requirements:
+
+#### Check 1: Blockquote After Title (Tier 2)
+
+- Look for a `>` blockquote immediately after the first `#` title heading
+- The blockquote must contain a substantive compressed argument — not a topic sentence, not a teaser
+- **If missing or empty:** return `NEEDS_ARTIFACTS` with gap: `"Writing Canon Tier 2: Document is missing a blockquote (> ...) immediately after the # title. The blockquote must contain the complete compressed argument — the full claim in compressed form, not a topic sentence."`
+
+#### Check 2: Summary Section (Tier 4)
+
+- Look for a `## Summary —` section (the heading must start with `## Summary —` followed by a descriptive subtitle)
+- The summary must be self-contained — reading only title + blockquote + summary gives the full picture
+- **If missing:** return `NEEDS_ARTIFACTS` with gap: `"Writing Canon Tier 4: Document is missing a '## Summary — [descriptive subtitle]' section. The summary must be self-contained — someone reading only the title, blockquote, and summary should have the full picture."`
+
+#### Check 3: Headers Pass Scan Test (Tier 5)
+
+- Print only the `#` lines from the document and read them in sequence
+- Headers must tell the document's story — not read like a generic form ("Background," "Discussion," "Details")
+- Structural markers (like "Summary") must have descriptive subtitles
+- **If headers are generic:** return `NEEDS_ARTIFACTS` with gap: `"Writing Canon Tier 5: Headers fail the scan test. Reading the headers in sequence should tell the document's story. Generic headers like 'Background,' 'Discussion,' or 'Details' without descriptive content are not sufficient."`
+
+### Verdict Logic
+
+- If any of the three structural checks fail: return `NEEDS_ARTIFACTS` with all failing checks listed in `gaps`
+- If all three pass: proceed with standard DoD validation (the Writing Canon gate does not override other requirements)
+- Writing Canon compliance is necessary but not sufficient — the document must also meet the standard five DoD requirements
+
+### Why This Is Mandatory
+
+The Progressive Disclosure Failure incident (February 2026) proved that agents will always skip writing validation unless a gate enforces it. Three canon documents were merged to main without any structural checks. The agent had full access to the Writing Canon but never checked its output against it. Access is not enforcement. This gate ensures document quality is validated automatically — not only when a human remembers to ask.
 
 ## Canon References
 

--- a/writings/README.md
+++ b/writings/README.md
@@ -21,3 +21,4 @@ tags: ["writings", "index", "essays"]
 | [From Bible Translation to Epistemic OS](klappy://writings/from-bible-translation-to-epistemic-os) | How 15 years of Bible translation work became an operating system for AI collaboration |
 | [The Project Journal](klappy://writings/the-project-journal) | A practical guide to keeping your AI collaboration honest and cumulative |
 | [The Drift Queue](klappy://writings/the-drift-queue) | How one person manages a growing knowledge base without drowning in maintenance |
+| [The Planning Queue](klappy://writings/the-planning-queue) | How implementation-ready specs eliminate the most expensive handoff in AI-assisted development |

--- a/writings/the-planning-queue.md
+++ b/writings/the-planning-queue.md
@@ -1,0 +1,169 @@
+---
+uri: klappy://writings/the-planning-queue
+title: "The Planning Queue — Your AI Builds What You Spec'd, Not What You Remember"
+subtitle: "How implementation-ready specs eliminate the most expensive handoff in AI-assisted development"
+author: "Klappy"
+type: essay
+public: true
+audience: public
+exposure: public
+tier: 1
+voice: first_person
+stability: evolving
+tags:
+  - writings
+  - essay
+  - planning
+  - queue
+  - handoff
+  - knowledge-base
+  - oddkit
+  - multi-tool
+  - coordination
+  - use-only-what-hurts
+epoch: E0005
+date: 2026-02-18
+
+# Discovery
+
+hook: "You just spent an hour thinking through a feature with AI. Now close the chat and try to build it."
+description: "The planning queue stores implementation-ready specs that any AI tool can pick up cold — so your best thinking survives the session that produced it."
+slug: the-planning-queue
+
+# Social graph
+
+og_title: "The Planning Queue — Your AI Builds What You Spec'd, Not What You Remember"
+og_description: "The planning queue stores implementation-ready specs that any AI tool can pick up cold — so your best thinking survives the session that produced it."
+
+# Relationships
+
+derives_from: "canon/constraints/guide-posture.md, canon/methods/planning-queue.md, canon/constraints/humans-are-variable-inputs.md, odd/constraint/use-only-what-hurts.md, canon/principles/ritual-is-a-smell.md"
+complements: "writings/the-drift-queue.md, writings/the-most-expensive-problem.md, writings/the-project-journal.md, writings/from-bible-translation-to-epistemic-os.md, docs/planning/automated-changelog.md, docs/planning/oddkit-write-access.md"
+start_here: true
+start_here_order: 10
+start_here_label: "The Planning Queue — Specs That Wait Until They Hurt"
+---
+
+# The Planning Queue — Your AI Builds What You Spec'd, Not What You Remember
+
+> You just had the best AI conversation of your week. You explored a problem, made decisions, identified constraints, sketched a phased implementation plan. Now you need to actually build it — in a different tool, a different session, maybe tomorrow. How much of that thinking survives the handoff? The planning queue stores implementation-ready specs in the same knowledge base your AI tools already search. When it's time to build, any tool picks up the spec cold. No re-explanation. No "as we discussed." No human carrying files between sessions. The spec is the handoff.
+
+-----
+
+## Summary — Stop Carrying Context Between Your AI Tools
+
+If you use AI for both thinking and building, you've felt this moment. The thinking tool — a chat, a voice agent, a brainstorming session — produces something good. Real decisions. Specific constraints. A phased plan that accounts for what could go wrong. Then you switch to the building tool — a coding agent, a document generator, an automation pipeline — and you have to re-explain everything you just decided.
+
+You are the bus. You carry context from where it was produced to where it's consumed. And every time you carry it, you lose some. The constraints you discussed but forgot to mention. The phased approach that becomes "just build the whole thing." The edge case you identified but didn't re-state because it seemed obvious.
+
+The planning queue eliminates the bus. You write the spec once, in the same system your tools already search. When it's time to build, the building tool finds the spec itself. Your best thinking survives intact — not because you remembered to carry it, but because the system carried it for you.
+
+-----
+
+## The Moment I Knew This Was a Problem
+
+I was working on a feature for my knowledge base system. I'd spent a solid session with an AI chat exploring the architecture: what needed to change, why, what constraints applied, what the phased rollout should look like. Good session. Real thinking. Specific decisions.
+
+Then I opened my coding tool to build it. And I found myself typing: "So, we need to add a new action that…" — re-explaining everything. The context from the thinking session was in my head and nowhere else. If I forgot a constraint, it was gone. If I simplified the phased plan because I was tired of typing, the simplification became the spec.
+
+I was the single point of failure in my own workflow. And I was doing this multiple times a day.
+
+The worst version is when you don't even notice the loss. You re-explain the feature, the coding tool builds something close to what you discussed, and you ship it. Weeks later, you hit the edge case you identified in the original session but dropped during the handoff. Now the fix is ten times more expensive because it's in production.
+
+-----
+
+## What a Planning Doc Actually Is
+
+A planning doc is not a ticket. It's not a bullet list of requirements. It's a full document — the same kind of document your knowledge base already manages — with everything a building tool needs to execute cold.
+
+**The problem it solves.** Not hypothetical pain. Observed pain. "This ritual failed during the 0.32.0 release" — not "it would be nice if we automated this."
+
+**The current state.** What happens today without the feature. The specific friction, the manual steps, the failure modes. A building tool that reads this understands what it's replacing.
+
+**The target state.** What changes when the feature exists. Before and after. A building tool that reads this knows what "done" looks like.
+
+**The system changes.** Which systems need modification, with enough specificity to start coding. If an API endpoint needs to be added, name it and describe its inputs and outputs. If multiple systems are involved, separate the handoffs per system.
+
+**Phased implementation.** Ordered phases that deliver incrementally. Each phase is independently valuable. This is the part that gets lost most often in handoffs — the careful sequencing collapses into "build the whole thing."
+
+**Constraints.** What the feature must not do. Safety boundaries, irreversibility gates, performance limits. These are the guardrails the building tool needs to respect — and the first thing that gets dropped when a human re-explains from memory.
+
+**Open questions.** What remains unresolved. These are honest admissions, not blockers. The building tool knows which decisions are settled and which still need input.
+
+**Derivation.** Why this feature exists. Which principles, incidents, or prior decisions justify it. A building tool that reads this understands not just what to build but why — which means it can make better judgment calls on ambiguous implementation details.
+
+-----
+
+## The Part That Surprised Me
+
+I wrote two planning docs and committed them to my knowledge base. Standard practice — I write docs all the time. But then I ran an experiment: I opened a fresh AI chat session, connected it to my knowledge base, and said "let's see if you can find your own instructions in the planning queue."
+
+No hints. No file paths. No "go look at this document." Just: can you find it?
+
+The AI searched the knowledge base, found the planning queue convention, then found both planning docs. It summarized the full four-phase roadmap, identified the constraints, noted the open questions, and was ready to execute. Against 365 documents, the planning specs scored in the top 1% for relevance.
+
+Any tool connected to the same knowledge base would find the same specs. The chat that produced them, the coding tool that builds them, the voice agent that discusses them — they all search the same index. The spec travels with the system, not with the human.
+
+Then something even better happened. I committed the implementation spec to the repo. A separate tool — a bug-finding bot — picked up the spec through the same knowledge base, found a gap in the risk assessment logic (deleted foundational documents weren't classified as high risk), and filed a fix. A third tool improved a spec that a first tool wrote, through a shared knowledge base, without any human carrying anything between them.
+
+-----
+
+## Why Not Just Use a Ticket System?
+
+Fair question. GitHub Issues, Jira, Linear — they all track planned work. Why build a parallel system?
+
+Because a ticket system is a second brain. It has its own search, its own syntax, its own staleness model. The moment your planned work lives in a ticket system *and* your knowledge base, you have split-brain: two systems that both claim to know what needs building. When they disagree — and they will, because one gets updated and the other doesn't — you're back to the human resolving the conflict.
+
+The planning queue works because it's the same system. Same search. Same structure. Same metadata. When your AI tool searches for relevant context, the planning spec shows up alongside the principles, constraints, and prior decisions that govern it. There's no "go check the ticket tracker too." Everything is in one place.
+
+If you already have a ticket system your team relies on, the planning doc can be the spec the ticket links to. The ticket handles coordination — who's doing it, when, what priority. The planning doc handles the knowledge — what to build, why, and how. But the knowledge lives in the knowledge base, not the ticket.
+
+-----
+
+## Use Only What Hurts
+
+Here's the part that makes the planning queue different from a backlog: you don't build things because they're in the queue. You build them because they hurt.
+
+A planning doc can sit for months without being picked up. That's not a failure — it's correct behavior. The pain of not having the feature never exceeded the cost of building it. The spec cost almost nothing to write. It preserved the thinking for whenever it becomes relevant. If that's never, the only cost was the ten minutes spent writing it.
+
+But when the pain does arrive — when a ritual fails, when you lose context in a handoff, when someone asks "why can't I just…" — the spec is already there. You don't need to reconstruct the thinking. You don't need to re-explore the constraints. You don't need another brainstorming session. You pull the planning doc and build.
+
+I felt this firsthand the night I tested the planning queue. During the session, I used my system's encode function to record an insight — a decision with evidence, context, and constraints. Good practice. But the encode function doesn't persist yet. That capability is in the planning queue as Phase 2. The insight existed only in the current conversation. When the session ended, it would vanish.
+
+The pain of not having persistent encode was theoretical an hour earlier. In that moment, it was acute. And the planning doc for that exact feature was already written, with phased implementation, constraints, open questions, and API design. The moment I'm ready to build it, the spec is waiting. I don't need to remember why I wanted it or how I planned to build it. The system remembers for me.
+
+-----
+
+## How to Start
+
+You don't need my specific system. The pattern works anywhere you can store searchable documents alongside your working knowledge.
+
+**Write the spec when the thinking is fresh.** The best time to write a planning doc is right after the exploration session that produced the insight. The constraints are in your head, the edge cases are fresh, the phased approach hasn't been simplified by memory loss. Even if you're not going to build it today, capture the thinking now.
+
+**Put it where your tools already search.** The whole point is that your building tools find the spec without you carrying it to them. If your AI tools search a knowledge base, put the planning doc in the knowledge base. If they search a repo, put it in the repo. The format matters less than the location.
+
+**Include the "why" alongside the "what."** The building tool needs to know not just what to build but why — which constraints apply, which edge cases were considered, which phased approach was chosen and why. This is the context that gets lost in handoffs. This is the context that makes the building tool's judgment calls better.
+
+**Don't build until it hurts.** Resist the urge to build everything you spec. The planning queue is not a sprint backlog. It's a shelf of ready-to-build specs that wait for the right moment. Some will wait weeks. Some will wait months. Some will never be built, and that's fine — the pain never justified the cost.
+
+**Let the system carry the context.** When you do pull a planning doc for execution, hand it to the building tool and let it read the spec. Don't re-explain. Don't summarize from memory. The spec is the handoff. If the building tool has questions, the answers should be in the doc — and if they're not, that's a signal the doc needs updating, not that you need to fill the gap verbally.
+
+-----
+
+## What This Makes Possible
+
+The planning queue is infrastructure for a future that's closer than it looks: AI tools that coordinate through shared knowledge rather than through you.
+
+Today, you carry context between tools. Tomorrow, the tools read from the same knowledge base and hand off to each other. A thinking tool writes a planning spec. A building tool picks it up and executes. A review tool validates the output against the spec's constraints. A maintenance tool monitors for drift over time. You direct which tool acts next, but you don't carry anything between them.
+
+The prerequisite is that the knowledge base is the single source of truth — not one source among many, not a supplement to the ticket tracker, not a reference that might be stale. The source. When every tool reads from the same place, coordination is free. When tools read from different places, coordination is your job.
+
+The planning queue is one piece of that infrastructure. [The drift queue](klappy://writings/the-drift-queue) is another — it keeps the knowledge base honest over time. [The project journal](klappy://writings/the-project-journal) is another — it captures what you learn as you work. Together, they form a system where your knowledge base isn't just a reference library. It's the coordination layer that lets your tools work together.
+
+The most expensive problem in knowledge work is [transferring context](klappy://writings/the-most-expensive-problem) — getting what one person (or tool) knows into the hands of another without losing the nuance. The planning queue doesn't solve that problem completely. But it solves the version of it that hits hardest in AI-assisted work: the handoff from thinking to building.
+
+Write the spec. Let it sit. Build when it hurts. Let the tools find it themselves.
+
+-----
+
+*Companion essays: [The Most Expensive Problem](klappy://writings/the-most-expensive-problem) — why knowledge transfer breakdown is the costliest failure mode in organizations. [The Drift Queue](klappy://writings/the-drift-queue) — how your knowledge base cleans itself over time. [The Project Journal](klappy://writings/the-project-journal) — how to capture what you learn as you work so it survives the session. [From Bible Translation to Epistemic OS](klappy://writings/from-bible-translation-to-epistemic-os) — where these patterns originally came from.*


### PR DESCRIPTION
Task 1: Add writings/the-planning-queue.md — essay on how implementation-ready
specs eliminate the most expensive handoff in AI-assisted development. Update
writings/README.md index.

Task 2: Wire the Writing Canon gate in oddkit's preflight and validate tool
docs. Preflight now detects document deliverables and returns the seven-point
Writing Canon checklist in constraints and definition of done. Validate now
checks blockquote (Tier 2), Summary section (Tier 4), and header scan test
(Tier 5) with specific failure messages. The gate fires automatically — no one
asks for it. Update IMPL spec acceptance criteria to reflect wiring is complete.
Update canon/meta/writing-canon.md enforcement section to reflect active state.

Addresses Progressive Disclosure Failure incident (February 2026).

https://claude.ai/code/session_01P5sE4DXPF1QuaMzDWRtRxw

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes plus a new essay; no runtime code paths are modified, though the updated specs may change operator expectations for OddKit behavior.
> 
> **Overview**
> Adds a new public essay, `writings/the-planning-queue.md`, and links it from `writings/README.md`.
> 
> Updates OddKit’s `oddkit_preflight` and `oddkit_validate` docs to specify an automatic “Writing Canon gate” for document deliverables (now including `writings/`): preflight must surface `canon/meta/writing-canon.md` and its 7-point checklist in the DoD, and validate must fail with `NEEDS_ARTIFACTS` when a doc lacks the post-title blockquote, a `## Summary —` section, or scan-test-worthy headers.
> 
> Marks `docs/oddkit/IMPL-writing-canon-gate.md` as stable and updates `canon/meta/writing-canon.md` to reflect that the gate is actively enforced.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f688c0a327ac45cd7435c903ae404eff5bfc34d5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->