### PR TITLE
Fix frontmatter rendering bug: remove # section headers from YAML blocks

### DIFF
--- a/docs/book/governance.md
+++ b/docs/book/governance.md
@@ -17,22 +17,14 @@ tags:
   - distribution
 epoch: E0005
 date: 2026-02-20
----
-
-# Discovery
-
 hook: "The complete plan for Nothing New, Even AI — a book of standalone essays that stack into a cohesive argument about the oldest human problem and what the machines revealed about it."
 description: "Master governance document for the book. Contains editorial rules, chapter plan with status, distribution model, definition of done per chapter, draft-zero handling process, and all decisions made during planning."
-
-# Relationships
-
 derives_from:
   - canon/values/axioms.md
   - canon/constraints/guide-posture.md
   - canon/meta/writing-canon.md
 complements: "writings/*, canon/apocrypha/fragments/*"
 governs: "All book chapters in writings/ directory"
-
 ---
 
 # Book Governance — Nothing New, Even AI

--- a/writings/nothing-new-even-ai.md
+++ b/writings/nothing-new-even-ai.md
@@ -21,16 +21,9 @@ tags:
   - humanity
 epoch: E0005
 date: 2026-02-20
----
-
-# Discovery
-
 hook: "I kept solving the same problem — in engineering, in Bible translation, in parenting, in AI — without recognizing it as one problem. The machines finally made it impossible to ignore."
 description: "The preface to Nothing New, Even AI — a personal confession about what collaborating with AI agents revealed about the oldest human problem."
 slug: nothing-new-even-ai
-
-# Social graph
-
 og_title: "Nothing New, Even AI"
 og_description: "I kept solving the same problem everywhere I went. The machines finally made it impossible to ignore."
 og_type: article
@@ -39,9 +32,6 @@ twitter_card: summary_large_image
 twitter_title: "Nothing New, Even AI"
 twitter_description: "I kept solving the same problem everywhere I went. The machines finally made it impossible to ignore."
 twitter_image: /images/nothing-new-even-ai-og.png
-
-# Relationships
-
 derives_from:
   - canon/values/axioms.md
   - canon/values/trust-kernel.md
@@ -52,7 +42,6 @@ related:
     label: "Chapter 1: The Most Expensive Problem"
     relationship: sequel
 complements: "writings/the-most-expensive-problem.md, writings/from-bible-translation-to-epistemic-os.md, canon/apocrypha/fragments/fragment-08-the-image-of-the-image.md, canon/apocrypha/fragments/fragment-09-the-line.md"
-
 ---
 
 # Nothing New, Even AI


### PR DESCRIPTION
Moved # Discovery, # Social graph, and # Relationships content into the main frontmatter block as flat YAML key-value pairs. The # character is a YAML comment, causing parsing inconsistencies and leaking metadata as visible article text on odd.klappy.dev.

Affected files: writings/nothing-new-even-ai.md, docs/book/governance.md Draft-zeros were already clean — no changes needed.

https://claude.ai/code/session_016Eozb6EVr8aBVPyRvmRdWg

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only change that restructures frontmatter without altering runtime code; main risk is unintended metadata parsing changes if downstream expects the old header lines.
> 
> **Overview**
> Removes the markdown-style section headers (`# Discovery`, `# Social graph`, `# Relationships`) that were embedded inside frontmatter in `docs/book/governance.md` and `writings/nothing-new-even-ai.md`.
> 
> Metadata is now expressed purely as YAML keys within the frontmatter block, preventing `#` from being treated as a YAML comment and avoiding inconsistent parsing/visible header leakage in rendered pages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 572d73d2df0bace8553ecdfce3328dab0776eb93. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->