### PR TITLE
Add getting-started index with links to both guides

### DIFF
--- a/odd/getting-started/README.md
+++ b/odd/getting-started/README.md
@@ -1,0 +1,15 @@
+---
+uri: klappy://odd/getting-started
+title: Getting Started
+audience: odd
+exposure: nav
+tier: 2
+voice: neutral
+stability: stable
+tags: ["odd", "getting-started", "onboarding", "oddkit"]
+---
+
+# Getting Started
+
+- [Getting Started with ODD and oddkit](klappy://writings/getting-started-with-odd-and-oddkit) — From zero to structured AI collaboration in five minutes. Connect oddkit, bootstrap your project, see the difference.
+- [Agents & MCP](klappy://odd/getting-started/agents-and-mcp) — Technical reference for oddkit's CLI, local MCP, and remote MCP interfaces.


### PR DESCRIPTION
Adds a README.md to odd/getting-started/ so the page at /notebook/odd/getting-started actually renders. Links to both:
- Getting Started with ODD and oddkit (writings guide)
- Agents & MCP (technical reference)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new documentation index page only; no runtime code or behavior changes.
> 
> **Overview**
> Adds a new `odd/getting-started/README.md` so the `klappy://odd/getting-started` page renders and appears in nav.
> 
> The page provides a short *Getting Started* index linking to the main onboarding guide and the `Agents & MCP` technical reference.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e10de2d15603e41c3a763d38771124b0de3c8fb6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->