### PR TITLE
feat: E0008 — Observability: Transparent Telemetry and Infrastructure Accountability

### DIFF
--- a/canon/constraints/telemetry-governance.md
+++ b/canon/constraints/telemetry-governance.md
@@ -1,0 +1,219 @@
+---
+uri: klappy://canon/constraints/telemetry-governance
+title: "Telemetry Governance — What oddkit Tracks and Why"
+audience: canon
+exposure: nav
+tier: 1
+voice: neutral
+stability: semi_stable
+tags: ["canon", "constraint", "telemetry", "transparency", "privacy", "vodka-architecture", "maintainability", "analytics-engine"]
+epoch: E0008
+date: 2026-04-09
+derives_from: "canon/principles/vodka-architecture.md, canon/principles/maintainability-one-person-indefinitely.md, canon/values/axioms.md"
+complements: "docs/oddkit/tools/telemetry_public.md, docs/oddkit/tools/telemetry_policy.md, writings/half-a-million-requests.md"
+governs: "All telemetry collection in oddkit hosted service and TruthKit"
+status: active
+---
+
+# Telemetry Governance — What oddkit Tracks and Why
+
+> oddkit is maintained by one person making decisions about where to invest their most limited resource — their own attention. Telemetry exists to make those decisions informed instead of blind. Not to profile users, not to feed a roadmap, not to build a growth chart. The system tracks the shape of usage, never the substance. The data is public. If you wouldn't show them the dashboard, you shouldn't be collecting the data.
+
+---
+
+## Summary — Mandatory Truth at Baseline, Optional Richness by Incentive
+
+oddkit's hosted service at oddkit.klappy.dev collects transparent usage telemetry because the maintainer is making decisions in the dark. Cloudflare hosts the infrastructure essentially for free — cost is not the problem. The problem is that one person is deciding where to invest their time across ten epistemic tools, 400+ canon documents, and a growing user base they cannot see. Without telemetry, every prioritization decision is a guess: Is oddkit a protocol that's catching on, or a personal tool hosted publicly? Are people building their own knowledge bases, or is it just the maintainer talking to themselves in public? Which tools actually matter — is `gate` changing how people work, or is everyone just using `search`? If people depend on this infrastructure and the maintainer doesn't know it, they might break something that matters. If nobody depends on it, they can move fast. The answer changes everything, and today the answer is invisible.
+
+The design follows three rules derived from a decade of open-community work in Bible translation technology:
+
+1. **Track structural identifiers, never content.** The server counts which tools were called, which repos were served, which document paths were accessed, when, and how often. It never records what was searched for, what documents contained, or what the model responded.
+
+2. **The data is public, not private.** Any user can call `telemetry_public` and see the same dashboard the maintainer sees. Same leaderboard. Same numbers. Same trends. There is no information asymmetry between host and user.
+
+3. **Participation is rewarded, not extracted.** Users who identify themselves — via OAuth, header, or any other mechanism — appear on the transparency leaderboard. Identification is encouraged and scored, never coerced. The ask is proportional: every free API requires at least an API key. oddkit asks for less.
+
+This governance document is the authoritative reference for what is tracked, what is excluded, and why. It is fetched at runtime by `telemetry_policy` — not hardcoded in server logic. If the policy changes, this document changes. The server stays the same.
+
+---
+
+## What Is Tracked (Automatic, Every Request)
+
+All tracking occurs on `/mcp` POST envelopes. One data point is written per JSON-RPC message via Cloudflare Workers Analytics Engine.
+
+### Structural Dimensions (Blobs)
+
+| Dimension | What It Records | Example |
+|-----------|----------------|---------|
+| Event type | `mcp_request` or `tool_call` | `tool_call` |
+| JSON-RPC method | The protocol method | `tools/call` |
+| Tool name | Which epistemic action | `orient`, `search`, `gate` |
+| Consumer label | Best-effort caller identity | `Claude-User`, `unknown` |
+| Consumer source | How the label was resolved | `oauth`, `x-oddkit-client`, `user-agent` |
+| Canon URL | Which repo is being served | `https://github.com/klappy/klappy.dev` |
+| Document URI | For `get` calls, the path requested | `klappy://canon/principles/vodka-architecture` |
+| Worker version | oddkit version string | `0.17.0` |
+
+### Numeric Values (Doubles)
+
+| Value | What It Records |
+|-------|----------------|
+| Count | Always `1`, for SUM aggregation |
+| Duration | Request processing time in milliseconds |
+
+### Automatic Properties
+
+| Property | Source |
+|----------|--------|
+| Timestamp | Cloudflare Analytics Engine (automatic per data point) |
+| Sampling key | Consumer label (for Analytics Engine sampling consistency) |
+
+### What This Enables
+
+- **Consumer leaderboard** — how many unique callers, who are they
+- **Tool leaderboard** — which epistemic actions are actually used
+- **Canon URL leaderboard** — which repos are being served (the adoption signal)
+- **Document leaderboard** — which canon documents are most accessed
+- **Daily/hourly trends** — when usage happens, what caused spikes
+- **Method breakdown** — protocol-level health
+
+---
+
+## What Is Excluded (Safety Boundary)
+
+The following are never collected under any circumstance:
+
+- **Raw search queries** — what users searched for
+- **Document content** — what was returned from `get` or `search`
+- **Model responses** — what the LLM said
+- **Raw prompts** — what the user or system prompt contained
+- **User identity fields** — name, email, account IDs (beyond self-declared consumer label)
+- **IP addresses** — never logged for telemetry purposes
+- **Browser or device fingerprinting** — never collected
+
+The principle: if it reveals what someone was *thinking* rather than what they were *doing*, it is excluded.
+
+---
+
+## Consumer Identification Model
+
+### Phase 1 — Track What (No Auth Required)
+
+Consumer labels are resolved from whatever the request provides, in priority order:
+
+1. `x-oddkit-client` header (explicit, highest priority)
+2. MCP `initialize` → `clientInfo.name` (protocol-native)
+3. `User-Agent` header (fallback)
+4. `"unknown"` (default)
+
+No authentication is required. The hosted service is open. Unidentified consumers see a one-line footer on tool responses linking to this policy and explaining how to identify themselves.
+
+### Phase 2 — Track Who (OAuth for TruthKit)
+
+TruthKit's hosted service requires GitHub OAuth via Cloudflare. Consumer label comes from the authenticated GitHub username. OAuth-identified consumers are automatically verified.
+
+oddkit's hosted service remains open with optional identification. Headers and conversational identification remain available.
+
+### Verified Clients
+
+A server-side allowlist (env var `TELEMETRY_VERIFIED_CLIENTS`) designates verified consumer labels. Verified clients receive weighted leaderboard scoring. Verification increases visibility but never blocks participation.
+
+---
+
+## Transparency Leaderboard
+
+Modeled after the proven pattern in Aquifer MCP:
+
+### Self-Report Fields (Optional, Incentivized)
+
+| Field | Header | Source |
+|-------|--------|--------|
+| Client name | `x-oddkit-client` | Header or clientInfo |
+| Client version | `x-oddkit-client-version` | Header or clientInfo |
+| Agent name | `x-oddkit-agent-name` | Header |
+| Agent version | `x-oddkit-agent-version` | Header |
+| Surface | `x-oddkit-surface` | Header |
+| Contact URL | `x-oddkit-contact-url` | Header |
+| Policy URL | `x-oddkit-policy-url` | Header |
+| Capabilities | `x-oddkit-capabilities` | Header |
+
+### Completeness Scoring
+
+Each `tools/call` scores the number of self-report fields present (0–8). Completeness percentage drives badge assignment:
+
+| Badge | Threshold |
+|-------|-----------|
+| Open Ledger | ≥ 90% |
+| Clear Reporter | ≥ 70% |
+| Starter Reporter | ≥ 40% |
+| Hint Reporter | > 0% |
+| Silent Reporter | 0% |
+
+### Leaderboard Integrity
+
+Consumer labels are transparent self-declarations. They are not identity proof unless verified by the server-side allowlist or OAuth. Treat labels as honest claims, not authentication.
+
+---
+
+## Storage and Infrastructure
+
+### Cloudflare Workers Analytics Engine
+
+Telemetry data points are written via `env.ODDKIT_TELEMETRY.writeDataPoint()`. Writes are non-blocking and add zero latency to request handling.
+
+- **Retention:** 3 months (Cloudflare default)
+- **Querying:** SQL API via `CF_ACCOUNT_ID` and `CF_API_TOKEN`
+- **Visualization:** Grafana-compatible
+- **Pricing:** 100,000 data points/day free; 10,000 queries/day free
+
+### Long-Term Retention
+
+Analytics Engine data expires after 3 months. Monthly aggregate snapshots should be persisted to a durable store (KV, R2, or canon article) before expiration if long-term trend analysis is needed.
+
+---
+
+## Vodka Architecture Compliance
+
+This telemetry implementation is infrastructure serving the Maintainability principle. It passes the three-question constraint test:
+
+1. **Has the server grown thick?** No. One `writeDataPoint()` call per message. Two new tools (`telemetry_public`, `telemetry_policy`). The telemetry module is self-contained.
+
+2. **Has the server acquired domain opinions?** No. The telemetry tracks tool names, repo URLs, and document paths — structural identifiers that are identical regardless of what knowledge base is being served. The server does not know whether the document at `canon/principles/vodka-architecture` is about software design or cooking recipes.
+
+3. **Can the server be removed without consequence?** No. Without telemetry, the maintainer has no signal on adoption, no evidence to sustain hosting, and no way to answer whether oddkit serves anyone beyond themselves. The telemetry is load-bearing for infrastructure sustainability.
+
+---
+
+## The Social Contract
+
+oddkit is free. The code is MIT. Anyone can self-host. Cloudflare hosts the service at oddkit.klappy.dev for essentially zero cost — infrastructure is not the bottleneck. Attention is.
+
+One person maintains this. One person decides which tools to improve, which bugs to fix, which features to build next. Without signal, those decisions are guesses. With signal, they're informed. That's the difference telemetry makes — not paying for servers, but knowing where to spend the only resource that's actually scarce.
+
+The ask: help the maintainer know you exist. A GitHub username, an alias, a header value — any unique identifier. Not so the maintainer can track you. So the maintainer can make better decisions about the infrastructure you use.
+
+The deeper ask: if oddkit is catching on as a protocol — if people are building their own knowledge bases, their own governance systems, their own epistemic discipline on top of it — the maintainer needs to know. That changes what oddkit is. That changes whether TruthKit is viable as a product. That changes every conversation with collaborators and partners. Right now, 514,000 monthly requests could be one person or fifty. The answer matters.
+
+This is not the standard telemetry social contract. The standard contract is: a funded company collects your data privately and promises it's anonymous. This contract is: one person publishes the data publicly and asks you to be visible. The relationship is different because the power dynamic is different.
+
+---
+
+## Operating Principle
+
+**Mandatory truth at baseline, optional richness by incentive.**
+
+- Baseline usage is always tracked. This is non-negotiable for infrastructure sustainability.
+- Optional details are encouraged, scored, and made visible via the transparency leaderboard.
+- Verification increases score weight but never blocks participation.
+- The data is always public. The dashboard is always shared.
+- If the policy changes, this document changes. The server never hardcodes governance.
+
+---
+
+## See Also
+
+- [Vodka Architecture](klappy://canon/principles/vodka-architecture) — The design pattern telemetry must not violate
+- [Maintainability — One Person, Indefinitely](klappy://canon/principles/maintainability-one-person-indefinitely) — The principle telemetry serves
+- [KISS — Simplicity Is the Ceiling](klappy://canon/principles/kiss-simplicity-is-the-ceiling) — Why two tools, not twenty
+- [Axiom 4: You Cannot Verify What You Did Not Observe](klappy://canon/values/axioms) — The axiom telemetry corrects
+- [Aquifer MCP Telemetry Governance](https://github.com/klappy/aquifer-mcp/blob/main/docs/telemetry-governance-snapshot.md) — The proven pattern this derives from

--- a/docs/appendices/epoch-8.md
+++ b/docs/appendices/epoch-8.md
@@ -1,0 +1,116 @@
+---
+uri: klappy://docs/appendices/epoch-8
+title: "Epoch 8 — Observability: Transparent Telemetry and Infrastructure Accountability"
+audience: docs
+exposure: nav
+tier: 2
+voice: neutral
+stability: stable
+tags: ["odd", "epochs", "telemetry", "transparency", "vodka-architecture", "analytics-engine", "maintainability", "epoch-8"]
+epoch: E0008
+date: 2026-04-09
+forcing_fault: "A system that serves 514,000 requests per month with zero visibility into who uses it, which tools matter, or whether anyone has built on it is violating its own axiom: you cannot verify what you did not observe."
+new_invariant: "The maintainer can see the shape of usage — which tools, which repos, which consumers, when — without seeing the substance of what anyone asked or received."
+core_shift: "Blind hosting → infrastructure observability. Dashboard numbers → structural dimensions. No adoption signal → consumer leaderboard. Private metrics → public data. No performance data → duration tracking with x-ray tracing on the horizon."
+documents_introduced: ["canon/constraints/telemetry-governance.md", "writings/half-a-million-requests.md", "docs/oddkit/tools/telemetry_public.md", "docs/oddkit/tools/telemetry_policy.md", "docs/appendices/epoch-8.md"]
+---
+
+# Epoch 8 — Observability: Transparent Telemetry and Infrastructure Accountability
+
+> E0007 made the system proactive. E0007.1 named the architecture and formalized the principles. E0008 turns the system's observation inward: oddkit can now observe its own infrastructure the same way it observes its knowledge base. 514,000 requests per month with zero visibility was a violation of Axiom 4. Transparent telemetry — structural identifiers only, public data, rewarded participation — is the first deliverable. The epoch theme is observability: telemetry now, performance tracing and optimization from real data next.
+
+---
+
+## Summary — From "You Cannot Verify What You Did Not Observe" to Actually Observing
+
+oddkit served 514,000 requests in a single month — up 85%, with a 165,000-request spike the maintainer could not attribute. The Cloudflare dashboard showed a number and nothing else. No visibility into consumers, tools, repos, documents, or timing. Meanwhile, a sibling project — Aquifer MCP — had telemetry answering all of these questions publicly, using a pattern the maintainer had built from instinct. The gap between what Aquifer knew and what oddkit didn't was indefensible.
+
+E0008 closes that gap. The telemetry design follows three rules derived from a decade of open-community work: track structural identifiers (never content), publish the data (no information asymmetry), and reward participation (never extract). The implementation uses Cloudflare Workers Analytics Engine — already in the stack, non-blocking, time-series native, free at current usage. Two new tools (`telemetry_public`, `telemetry_policy`) expose the data and governance to any consumer. The governance document is canonical and fetched at runtime — the server never hardcodes what it tracks.
+
+This is infrastructure serving the Maintainability principle, not domain opinion. It passes the Vodka Architecture three-question test: the server hasn't grown thick (one `writeDataPoint` call per message), hasn't acquired domain opinions (structural identifiers are domain-agnostic), and can't be removed without consequence (without telemetry, the maintainer has no adoption signal and no evidence to sustain hosting).
+
+---
+
+## The Forcing Fault — Flying Blind on Your Own Infrastructure
+
+oddkit's axioms say: *you cannot verify what you did not observe.* The system enforced this against its knowledge base — every claim requires evidence, every assertion requires grounding. But the system's own infrastructure was exempt from its own rules.
+
+514,000 requests per month. The maintainer could not answer:
+
+- **Who** is using the hosted service — one person or fifty?
+- **What** tools matter — is `gate` changing how people work, or is everyone just using `search`?
+- **Whether** anyone has pointed oddkit at a knowledge base that isn't the maintainer's own — the adoption signal that determines whether oddkit is a personal tool or shared infrastructure.
+- **When** usage happens — what caused the 165,000-request spike? Was it the maintainer, a colleague onboarding, or a stranger?
+
+Every prioritization decision — which tools to improve, which bugs to fix, whether to invest in TruthKit — was a guess. The maintainer was making decisions in the dark about infrastructure other people might depend on.
+
+The forcing fault is not "we need metrics." The forcing fault is: *the system that demands epistemic discipline of its operators was not applying epistemic discipline to its own operations.*
+
+---
+
+## What E0008 Introduces
+
+### Transparent Telemetry (Phase 1 — Track What)
+
+Every MCP request writes one data point to Cloudflare Workers Analytics Engine with structural dimensions: event type, JSON-RPC method, tool name, consumer label (best-effort), canon URL (which repo is being served), document URI (for `get` calls), and worker version. Numeric values: count (always 1, for SUM) and duration (processing time in ms).
+
+Non-blocking writes. Zero latency added to request handling. SQL queries for reading. 3-month retention. Free at current usage (100k writes/day, 10k queries/day).
+
+### Two New Tools
+
+**`telemetry_public`** — Any consumer can query the same dashboard the maintainer sees. Consumer leaderboard, tool leaderboard, canon URL leaderboard (the adoption signal), document leaderboard, daily trends. No information asymmetry.
+
+**`telemetry_policy`** — Fetches the canonical governance document (`canon/constraints/telemetry-governance.md`) at runtime. If the policy changes, the document changes. The server stays the same.
+
+### Telemetry Governance (Canon Constraint)
+
+The authoritative reference for what is tracked, what is excluded, and why. Defines the safety boundary (never content, never queries, never prompts, never PII), the consumer identification model (Phase 1: best-effort from headers; Phase 2: OAuth for TruthKit), and the transparency leaderboard with self-report fields and completeness scoring.
+
+Operating principle: **mandatory truth at baseline, optional richness by incentive.**
+
+### Public Essay
+
+"Half a Million Requests and I Can't Tell If Anyone's Home" — the public-facing narrative. Explains the problem, the design philosophy, the technical choice, and the social contract. Entry point for people discovering oddkit.
+
+---
+
+## What Else Falls Under E0008
+
+The epoch theme is **observability** — telemetry is the first deliverable, not the last. Future work under this epoch includes:
+
+- **X-ray tracing** — end-to-end request tracing across the MCP pipeline (parse → tool dispatch → canon fetch → response). Measures where time is actually spent, enabling optimization from real data instead of guesswork.
+- **Performance optimization** — once duration_ms is tracked per request, identify slow paths (BM25 indexing, R2 cache misses, ZIP extraction) and optimize the ones that matter most based on actual usage patterns.
+- **Health endpoints** — structured liveness and readiness signals beyond Cloudflare's default dashboard.
+- **Alerting** — anomaly detection on usage patterns (sudden drops, error spikes) to catch infrastructure problems before users report them.
+
+Each of these is observability infrastructure serving the Maintainability principle. None require a new epoch — they extend E0008's invariant: *the maintainer can see the shape of what's happening.*
+
+---
+
+## What E0008 Does Not Change
+
+- **The four axioms carry forward unchanged.** E0008 applies Axiom 4 to oddkit's own infrastructure — it does not modify the axiom.
+- **The creed carries forward unchanged.**
+- **All E0007/E0007.1 invariants remain in force.** The proactive posture, the named architecture, the principles, the posture lapse detection — all unchanged.
+- **Vodka Architecture is not violated.** Telemetry is infrastructure serving Maintainability. The three-question test passes.
+- **oddkit remains open and free.** No authentication required for Phase 1. TruthKit boundary (OAuth required) is Phase 2.
+
+---
+
+## Epoch 8 Documents
+
+| Document | Purpose |
+|----------|---------|
+| `canon/constraints/telemetry-governance.md` | Canonical governance — what is tracked, what is excluded, and why |
+| `writings/half-a-million-requests.md` | Public essay — the narrative and social contract |
+| `docs/oddkit/tools/telemetry_public.md` | Tool documentation for telemetry_public |
+| `docs/oddkit/tools/telemetry_policy.md` | Tool documentation for telemetry_policy |
+| This document | Epoch declaration |
+
+---
+
+## Compatibility
+
+- E0007.1 artifacts remain valid. E0008 does not modify proactive posture, Vodka Architecture, or any E0007-era governance.
+- E0008 adds infrastructure accountability that prior epochs did not include.
+- E0008 is the current epoch.

--- a/docs/appendices/epochs.md
+++ b/docs/appendices/epochs.md
@@ -395,4 +395,32 @@ This change alters the system's initiative posture:
 
 - E0006 artifacts remain valid within E0006.
 - E0006 artifacts are not comparable to E0007 artifacts by default.
-- E0007 is the current epoch.
+
+---
+
+## E0008 — Observability: Transparent Telemetry and Infrastructure Accountability
+
+**Date:** 2026-04-09
+
+E0007 made the system proactive. E0007.1 named the architecture. E0008 turns the system's observation inward — oddkit can now observe its own infrastructure the same way it observes its knowledge base.
+
+See [`docs/appendices/epoch-8.md`](/docs/appendices/epoch-8.md) for the full epoch declaration.
+
+### What changed
+
+oddkit served 514,000 requests per month with zero visibility into who uses it, which tools matter, or whether anyone has built their own knowledge base on it. This violated Axiom 4: you cannot verify what you did not observe. E0008 adds transparent telemetry via Cloudflare Workers Analytics Engine — structural identifiers only (tool names, repo URLs, document paths, timestamps), never content. Two new tools: `telemetry_public` (query the same dashboard the maintainer sees) and `telemetry_policy` (fetch the canonical governance document at runtime). The epoch theme is observability — telemetry is the first deliverable, with x-ray tracing and performance optimization on the horizon.
+
+### Why this is a new epoch
+
+This change alters what the system can see about itself:
+
+- The system demanded epistemic discipline of its operators but exempted its own infrastructure
+- Without adoption signal, every prioritization decision was a guess
+- The maintainer could not distinguish "personal tool hosted publicly" from "infrastructure a community depends on"
+- E0007 artifacts produced without observability are not comparable to E0008 artifacts where the maintainer knows where to invest
+
+### Compatibility
+
+- E0007/E0007.1 artifacts remain valid. E0008 does not modify proactive posture, Vodka Architecture, or any prior governance.
+- E0008 adds infrastructure observability that prior epochs did not include.
+- E0008 is the current epoch.

--- a/docs/oddkit/tools/telemetry_policy.md
+++ b/docs/oddkit/tools/telemetry_policy.md
@@ -1,0 +1,83 @@
+---
+uri: oddkit://tools/telemetry_policy
+title: "telemetry_policy"
+audience: operators
+exposure: nav
+tier: 2
+voice: neutral
+stability: evolving
+tags: ["oddkit", "tool", "telemetry", "transparency", "privacy", "governance", "policy"]
+epoch: E0008
+date: 2026-04-09
+derives_from: "canon/constraints/telemetry-governance.md"
+complements: "docs/oddkit/tools/telemetry_public.md"
+---
+
+# telemetry_policy
+
+> Return the canonical telemetry governance policy — what oddkit tracks, what it excludes, and why. Fetched at runtime from canon, not hardcoded in server logic.
+
+## Description
+
+`telemetry_policy` retrieves the authoritative telemetry governance document (`canon/constraints/telemetry-governance.md`) and returns a structured summary of what the oddkit hosted service tracks, what it excludes, and the principles behind those decisions.
+
+This tool exists so that any consumer can understand the telemetry contract before deciding whether or how to identify themselves. The policy is a canon document — if it changes, the tool's response changes. The server never hardcodes governance.
+
+## When to Use
+
+- Understanding what oddkit tracks before connecting a new client or knowledge base
+- Verifying that the telemetry policy matches your privacy requirements
+- Explaining to stakeholders what data oddkit collects about their usage
+- Checking whether the policy has changed since your last review
+- Informing a decision about whether to self-identify via headers or OAuth
+
+## Tool Definition
+
+**Name:** `telemetry_policy`
+
+**Description:** Return oddkit telemetry and sharing policy guidance. Returns what is tracked (structural identifiers: tool names, repo URLs, document paths, timestamps), what is excluded (content, queries, prompts, PII), how consumer identification works, and the transparency principles. Fetched from canonical governance document at runtime.
+
+### Input Schema
+
+```json
+{
+  "type": "object",
+  "properties": {},
+  "required": []
+}
+```
+
+### Response Shape
+
+```json
+{
+  "action": "telemetry_policy",
+  "result": {
+    "tracked": "array — list of structural dimensions collected",
+    "excluded": "array — list of what is never collected",
+    "identification": {
+      "phase_1": "string — current identification model (best-effort from headers)",
+      "phase_2": "string — future identification model (OAuth for TruthKit)"
+    },
+    "principles": "array — the three transparency rules",
+    "self_report_headers": "object — optional headers consumers can set to identify themselves",
+    "governance_uri": "string — klappy://canon/constraints/telemetry-governance",
+    "generated_at": "string — ISO timestamp"
+  }
+}
+```
+
+## Behavioral Rules
+
+1. **Fetch from canon, never hardcode.** The policy document is retrieved from the knowledge base at request time. If the governance document is updated, the tool's response reflects the update immediately.
+2. **Return structured summary, not raw document.** The tool parses the governance document and returns key facts in a structured format. For the full document, use `oddkit_get` with URI `klappy://canon/constraints/telemetry-governance`.
+3. **Include self-report headers.** The response always includes the list of optional headers consumers can set to identify themselves (`x-oddkit-client`, `x-oddkit-agent-name`, etc.) with their purpose and scoring weight.
+4. **Side-effect free.** Calling `telemetry_policy` does not itself generate a telemetry data point beyond the standard tool call record. The policy request is tracked the same as any other tool call.
+5. **No authentication required.** The policy is public by design. Anyone can query it, whether identified or not.
+
+## Canon References
+
+- [Telemetry Governance](klappy://canon/constraints/telemetry-governance) — The authoritative source document this tool returns
+- [telemetry_public](oddkit://tools/telemetry_public) — Query the actual usage data
+- [Vodka Architecture](klappy://canon/principles/vodka-architecture) — Governance in documents, enforcement in the server
+- [Axiom 4](klappy://canon/values/axioms) — You cannot verify what you did not observe

--- a/docs/oddkit/tools/telemetry_public.md
+++ b/docs/oddkit/tools/telemetry_public.md
@@ -1,0 +1,102 @@
+---
+uri: oddkit://tools/telemetry_public
+title: "telemetry_public"
+audience: operators
+exposure: nav
+tier: 2
+voice: neutral
+stability: evolving
+tags: ["oddkit", "tool", "telemetry", "transparency", "leaderboard", "analytics"]
+epoch: E0008
+date: 2026-04-09
+derives_from: "canon/constraints/telemetry-governance.md"
+complements: "docs/oddkit/tools/telemetry_policy.md"
+---
+
+# telemetry_public
+
+> Query the same usage dashboard the maintainer sees. Consumer leaderboard, tool leaderboard, canon URL leaderboard, document leaderboard, daily trends. No information asymmetry between host and user.
+
+## Description
+
+`telemetry_public` exposes oddkit's usage telemetry to any consumer — the same data the maintainer uses to make prioritization decisions. It queries Cloudflare Workers Analytics Engine via SQL and returns aggregated structural metrics: which tools are called, which repos are served, which consumers are active, and when usage happens.
+
+This tool answers the question "who's using oddkit and how?" without revealing what anyone searched for, what documents contained, or what models responded. The data is structural — shapes and counts, not substance.
+
+## When to Use
+
+- Understanding how oddkit is being used across the community
+- Checking whether your consumer label appears on the leaderboard
+- Verifying that telemetry is working after setup or configuration changes
+- Investigating usage spikes or trends
+- Comparing tool popularity to inform contribution or feature requests
+
+## Tool Definition
+
+**Name:** `telemetry_public`
+
+**Description:** Returns public telemetry disclosures and usage leaderboards for the oddkit hosted service. Shows the same data the maintainer sees — consumer leaderboard, tool usage, canon URL distribution, document access patterns, and daily trends. No information asymmetry.
+
+### Input Schema
+
+```json
+{
+  "type": "object",
+  "properties": {
+    "period": {
+      "type": "string",
+      "enum": ["7d", "30d", "all"],
+      "description": "Optional. Time period for the query. Defaults to '30d'."
+    },
+    "query_type": {
+      "type": "string",
+      "enum": ["summary", "tools", "consumers", "canon_urls", "documents", "daily_trend"],
+      "description": "Optional. Which leaderboard or metric to return. Defaults to 'summary'."
+    }
+  },
+  "required": []
+}
+```
+
+### Response Shape
+
+```json
+{
+  "action": "telemetry_public",
+  "result": {
+    "period": "string — the time period queried",
+    "query_type": "string — which metric was returned",
+    "data": "object — query-specific result (leaderboard array, summary object, or trend array)",
+    "generated_at": "string — ISO timestamp of query execution"
+  }
+}
+```
+
+### Query Types
+
+**summary** — Total requests and tool calls for the period, with breakdown by method.
+
+**tools** — Tool leaderboard: which epistemic actions are called, ranked by frequency. Answers "is `gate` changing how people work, or is everyone just using `search`?"
+
+**consumers** — Consumer leaderboard: unique consumer labels with request counts and completeness scores. Answers "how many people are using oddkit?"
+
+**canon_urls** — Canon URL leaderboard: which repos are being served. Answers "has anyone pointed oddkit at a knowledge base that isn't the maintainer's?" This is the primary adoption signal.
+
+**documents** — Document leaderboard: most accessed document URIs (from `get` calls). Answers "which canon documents actually matter?"
+
+**daily_trend** — Daily request counts over the period. Answers "what caused the spike?"
+
+## Behavioral Rules
+
+1. **Return aggregated metrics, never raw events.** Individual request details are not exposed — only counts, rankings, and trends.
+2. **The data is the same data the maintainer sees.** There is no privileged dashboard. `telemetry_public` queries the same Analytics Engine dataset with the same SQL.
+3. **Consumer labels are self-declarations.** They are not identity proof. Treat them as honest claims, not authentication. See `telemetry_policy` for the full identification model.
+4. **Results may be sampled.** Cloudflare Analytics Engine uses sampling at high volumes. Counts are estimates scaled by `_sample_interval`, not exact totals.
+5. **Retention is 3 months.** Data older than 3 months is not available. For long-term trends, monthly snapshots are persisted separately.
+
+## Canon References
+
+- [Telemetry Governance](klappy://canon/constraints/telemetry-governance) — The authoritative reference for what is tracked and excluded
+- [telemetry_policy](oddkit://tools/telemetry_policy) — Returns the governance document at runtime
+- [Vodka Architecture](klappy://canon/principles/vodka-architecture) — The design pattern telemetry must not violate
+- [Maintainability](klappy://canon/principles/maintainability-one-person-indefinitely) — The principle telemetry serves

--- a/writings/half-a-million-requests.md
+++ b/writings/half-a-million-requests.md
@@ -1,0 +1,148 @@
+---
+uri: klappy://writings/half-a-million-requests
+title: "Half a Million Requests and I Can't Tell If Anyone's Home"
+slug: half-a-million-requests
+author: Klappy
+type: essay
+public: false
+audience: public
+exposure: draft
+tier: 3
+voice: personal
+stability: volatile
+tags: ["essay", "telemetry", "oddkit", "open-source", "transparency", "vodka-architecture", "trust", "open-community"]
+epoch: E0008
+date: 2026-04-09
+derives_from: "canon/constraints/telemetry-governance.md, canon/principles/vodka-architecture.md, canon/values/axioms.md"
+description: "oddkit served half a million requests last month and the maintainer can't tell if anyone besides themselves is using it. This essay explains why that's a problem, how transparent telemetry solves it, and what it means to ask users of free infrastructure to be visible."
+hook: "Half a million requests, and I was completely blind."
+subtitle: "On transparent telemetry, open-source trust, and the courage to ask if anyone's home"
+book_part: "Part VI — The Validation"
+provenance:
+  trigger: "Cloudflare dashboard showing 514k requests with zero attribution"
+  method: "Oral-first session (driving). Brain dump → Socratic shaping → resonance research → full draft."
+  sources: "Aquifer MCP live telemetry query, Cloudflare dashboard screenshots (514k requests), oddkit canon retrieval (Vodka Architecture), industry telemetry research (Next.js, Grafana, Linux Foundation, PostHog)"
+  co_author: Claude
+---
+
+# Half a Million Requests and I Can't Tell If Anyone's Home
+
+> I built the instrument to observe everything about my knowledge base — except whether anyone was using it. Half a million requests, and I was violating my own axiom: you cannot verify what you did not observe.
+
+---
+
+## Summary — Flying Blind on Your Own Infrastructure
+
+oddkit served 514,000 requests last month — up 85%, with a 165,000-request spike the maintainer cannot explain. The Cloudflare dashboard shows a number and nothing else. No visibility into who uses it, which tools matter, which repos are being served, or whether the growth comes from one person or fifty. Meanwhile, a sibling project — Aquifer MCP — has telemetry that answers all of these questions publicly. The gap is indefensible. This essay explains the problem, the design philosophy behind transparent telemetry (track structure not content, publish the data, reward participation), the technical choice (Cloudflare Analytics Engine over KV counters), and the social contract: if you use free infrastructure, help the maintainer know you exist. Not your name. Not your data. Just a signal.
+
+---
+
+## Building in the Open Since 2016
+
+I've been writing code in the open since 2016. Every commit public. Every decision documented. Every constraint visible. Before that, I wrote closed code for years — proprietary, guarded, the usual. The shift wasn't ideological. It was practical. I worked in Bible translation technology, where the whole point is access. Closed didn't make sense anymore.
+
+At unfoldingWord, and later through the ETEN Innovation Lab, I helped shape the open community — co-founding what became the Open Bible Technology Community, making funding recommendations for open-license tooling, and building in public long before it was fashionable.
+
+So when I built oddkit — an open source MCP server that gives AI tools epistemic discipline — I hosted it for free. Of course I did. The code is MIT. The canon is public on GitHub. Anyone can run it, fork it, point it at their own knowledge base. That's the deal.
+
+Last month, oddkit served 514,000 requests. Up 85% from the month before. There was a spike — 165,000 requests in a single day. And when I opened the Cloudflare dashboard to understand what was happening, all I saw was a number.
+
+I couldn't tell if that was me. I couldn't tell if it was one other person or fifty. I couldn't tell which tools mattered, which documents people were reading, or whether anyone had ever pointed oddkit at a repo that wasn't mine. Half a million requests, and I was completely blind.
+
+---
+
+## The Contrast — Aquifer Has What oddkit Doesn't
+
+I have another project — Aquifer MCP, a server that gives AI tools access to Bible translation resources. Same stack. Same Cloudflare Worker. Same free hosting. But Aquifer has something oddkit doesn't: telemetry.
+
+I built it one afternoon, from instinct more than research. Every tool call gets counted automatically. No one has to opt in. The server just records what happened — which tools were called, which resources were accessed, which languages people searched in. It doesn't record what anyone asked. It doesn't record what came back. It counts the shape of usage, not the substance.
+
+And then I did something I've never seen another project do: I made the data public. Not in a report. Not in a blog post six months later. As a tool. Anyone can call `telemetry_public` and see the same dashboard I see. Eight consumers. 2,609 requests. Romans 3:23 is the most-searched verse. French is the second most-searched language. Someone connected through OpenAI's MCP client — I didn't even know that was possible until the leaderboard showed me.
+
+I didn't design this from a best practices guide. I designed it from ten years of working in communities where trust is the only currency that matters.
+
+Here's what I mean by that.
+
+---
+
+## The War Over Telemetry in Open Source
+
+When you add telemetry to open source software, you enter a war that's been raging since at least 2016. The .NET community filed an issue titled "should not SPY on users by default." Grafana has an active GitHub issue calling their opt-out telemetry unethical. Next.js has years of complaints. The pattern is always the same: a company adds anonymous tracking, promises it's harmless, offers an opt-out buried three clicks deep, and the community erupts.
+
+But notice who's collecting. Vercel. Grafana Labs. Microsoft. These are funded companies with revenue, investors, and employees. The telemetry feeds product roadmaps and investor decks. The community feels extracted from, not collaborated with.
+
+Now ask a different question: what if the person collecting is one developer, hosting the infrastructure for free, with no investors, no revenue, and no way to tell if anyone besides themselves is using it?
+
+The calculus changes. One developer put it perfectly: "Happy to send telemetry to non-profits and independent developers. Otherwise, there needs to be an exchange of value."
+
+That's the exchange I'm proposing. I give you infrastructure. You tell me you exist.
+
+---
+
+## Three Rules for Transparent Telemetry
+
+So I didn't study how Next.js does telemetry. I didn't read Grafana's privacy policy. I built Aquifer's transparency model from something simpler: ten years of working in communities where trust is the only thing that scales.
+
+Here's what I knew from that experience. If you collect data people can't see, they'll assume the worst. If you promise anonymity, they'll assume you're lying. If you bury the opt-out, they'll assume you're hiding something. Every telemetry controversy in open source follows the same script because every project makes the same mistake: they treat telemetry as something they do *to* users instead of something they do *with* them.
+
+So I built three rules into Aquifer's telemetry, and now into oddkit's:
+
+**The server tracks structural identifiers, never content.** It counts that you called the `search` tool. It doesn't record what you searched for. It counts that you accessed a document at a certain path. It doesn't record what the document said. It counts that you pointed oddkit at a GitHub repo. It doesn't record what's in that repo. The server sees the shape of your usage — which levers you pulled, how often, when. It never sees what you were thinking when you pulled them.
+
+**The data is public, not private.** This is the part that surprises people. Any user can call `telemetry_public` and see the exact same dashboard I see. Same leaderboard. Same numbers. Same trends. There is no information asymmetry between the person hosting the service and the person using it. If I wouldn't show you the data, I shouldn't be collecting it.
+
+**Participation is rewarded, not extracted.** When you identify yourself — even with an alias — you show up on the leaderboard. Not as a surveillance target, but as a community member. The transparency badges aren't gamification for its own sake. They're a visible record of who showed up and said "I'm here, and I'm willing to be counted."
+
+The full policy — what's tracked, what's excluded, and why — lives in the canon and is served at runtime by `telemetry_policy`. If the policy changes, the document changes. The server stays the same.
+
+I didn't learn these rules from a privacy framework. I learned them from unfoldingWord, where we shipped open-license resources to translation communities who had every reason to distrust outside organizations. I learned them from the ETEN Innovation Lab, where I helped shape funding recommendations for open-access tooling. I learned them from co-founding what became the Open Bible Technology Community, where dozens of organizations had to trust each other enough to share infrastructure. In every case, the same principle held: transparency isn't a policy you adopt. It's a relationship you maintain. And you maintain it by never knowing more about your users than they know about you.
+
+---
+
+## The Technical Decision — Analytics Engine Over Counters
+
+The technical decision almost made itself. Aquifer's first telemetry implementation used key-value counters — simple, proven, good enough. But counters can't answer timing questions. I could tell you that oddkit served 514,000 requests last month, but I couldn't tell you when. That spike on the dashboard — was it one afternoon or spread across a week? Was it one user discovering oddkit or a conference talk that sent fifty people to try it? Counters flatten time. They give you totals without stories.
+
+Then I found what was already in my stack. Cloudflare Workers Analytics Engine — purpose-built for exactly this. Every data point gets a timestamp automatically. Non-blocking writes, so recording telemetry adds zero latency to the actual request. SQL queries for reading — real SQL, not KV list operations. And it's free for my usage level.
+
+One binding in the configuration file. One `writeDataPoint()` call per request. The spike question — what happened and when — answered natively. No daily bucket workarounds. No counter race conditions. The infrastructure I needed was sitting in my own platform the whole time. I just hadn't looked.
+
+There's an axiom in the system oddkit governs: *you cannot verify what you did not observe.* I'd been violating it against my own infrastructure.
+
+---
+
+## The Ask — Help Me Know You're There
+
+Here's the part where I have to be honest about what I'm asking for and why.
+
+I host oddkit for free. I plan to keep hosting it for free. The code is MIT — you can run it yourself, fork it, change it, sell it. I'll never gate the protocol behind a paywall. But the hosted service — the one at oddkit.klappy.dev that you can point your tools at without setting anything up — that service runs on infrastructure I pay for with my time.
+
+Every free API in the world requires at least an API key. Most require an account. Many require a credit card on file "just in case." I'm asking for less than any of them: sign in with GitHub. One click. I don't need your email. I don't need your real name. I don't even need you to use your main GitHub account. I just need a unique identifier so that when I look at the telemetry, I can tell that someone other than me is using this.
+
+Is that too much to ask?
+
+I wrestled with that question. The protocol should be open. Anyone should be able to use it. Adding an authentication wall feels like it contradicts everything I just said about trust and transparency.
+
+But here's what I realized: the authentication isn't a wall. It's a handshake. I'm telling you exactly what I track, showing you the same data I see, and asking for one thing in return — help me know you're there. Not so I can sell your attention. Not so I can build a growth chart for investors I don't have. So I can know whether this work matters to anyone besides me.
+
+---
+
+## The Questions Telemetry Will Answer
+
+When the telemetry goes live, a set of questions that I've been carrying for months will finally have answers. I don't know what those answers are. I'm publishing this essay before the data comes in, because I think the questions matter more than the answers right now.
+
+Is anyone using oddkit against a knowledge base that isn't mine? Has anyone built their own canon — their own governance documents, their own constraints, their own epistemic discipline — and pointed oddkit at it? That's the adoption signal that matters most, and I have zero visibility into it today.
+
+Which tools actually get used? I built ten epistemic actions — orient, search, challenge, gate, encode, validate, and more. Are people using `gate` to check transitions, or do they skip straight to `search`? Is `encode` capturing decisions, or is everyone treating oddkit as a read-only library? The answer changes where I invest next.
+
+What caused the spike? 165,000 requests in what looks like a single day. Was that me building Aquifer? Was it Joshua onboarding with his own project? Was it a stranger? I genuinely don't know.
+
+How many unique people are behind half a million requests? It could be three. It could be thirty. The number changes everything about what oddkit is — a personal tool that I happen to host publicly, or infrastructure that a community depends on.
+
+And the question underneath all the others: if I build the instrument to measure this, and the answer turns out to be "it's just you" — was it still worth building in the open?
+
+Yes. At least I'd know. And soon, you will too.
+
+If it's just me, that's fine. I'll keep writing and learning in the open. I've built enough tech ahead of its time to know that there's a lead time before markets catch up. I'm plowing my way into the future. I'll be there when you arrive.
+
+Just don't take too long to get here.


### PR DESCRIPTION
## Epoch Declaration: E0008

**Forcing fault:** 514k requests/month with zero visibility — violating Axiom 4.
**New invariant:** The maintainer can see the shape of usage without seeing substance.
**Core shift:** Blind hosting → infrastructure observability.

### Documents (5 new + 1 modified)

| File | Purpose |
|------|---------|
| `canon/constraints/telemetry-governance.md` | Canonical governance — what is tracked, excluded, and why (tier 1) |
| `writings/half-a-million-requests.md` | Public essay — draft (`public: false`) |
| `docs/appendices/epoch-8.md` | Epoch declaration |
| `docs/oddkit/tools/telemetry_public.md` | Tool doc — query usage dashboard |
| `docs/oddkit/tools/telemetry_policy.md` | Tool doc — fetch governance at runtime |
| `docs/appendices/epochs.md` | E0008 entry appended |

### Governance Audit

| Check | Result |
|-------|--------|
| Frontmatter schema (all 6 files) | ✅ Pass |
| Writing canon gate (governance doc) | ✅ All 6 tiers |
| oddkit preflight | ✅ Pass |
| oddkit gate (planning → execution) | ✅ Pass |
| oddkit challenge (Vodka compliance + cross-refs) | ✅ Addressed |
| oddkit validate | NEEDS_ARTIFACTS (this PR is the artifact) |
| Cross-references | ✅ All bidirectional, no dangling |
| YAML quoting rules | ✅ Per frontmatter-schema.md |

### Note

The essay is `public: false` — it ships as draft. The governance doc, epoch declaration, and tool docs are ready for canon.

This PR provides the governance foundation for the telemetry feature build in klappy/oddkit (separate repo, separate PR).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change set, but it establishes the public telemetry policy surface and expectations, so correctness and cross-linking matter.
> 
> **Overview**
> Introduces Epoch E0008 (*Observability*) documentation, defining **transparent telemetry governance** for oddkit (what structural identifiers are collected, what is explicitly excluded, and how optional consumer self-identification and leaderboard scoring work).
> 
> Adds operator docs for new tools `telemetry_public` (public usage dashboards/leaderboards over Analytics Engine aggregates) and `telemetry_policy` (runtime fetch/structured summary of the canonical governance doc), plus a draft essay explaining the motivation/social contract; updates `docs/appendices/epochs.md` to register E0008 as the current epoch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f530bfe8d98159053b681ac8d32be0d09a64509. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->