### PR TITLE
update case study: sort_by=path + SHA staleness (E0008)

### DIFF
--- a/canon/case-studies/catalog-observability-gap.md
+++ b/canon/case-studies/catalog-observability-gap.md
@@ -17,7 +17,7 @@ status: active
 
 # Case Study — When the Knowledge Server Cannot See Its Own Knowledge Base
 
-> oddkit serves 500+ documents. The primary public interface for reading those documents could only retrieve 196 of them — not because of a bug, but because oddkit was never designed for a consumer that needed to see everything. The tool that enables epistemic discipline had a blind spot in its own observability. The fix was three lines of substance. The lesson is about what happens when a tool designed for AI consumers meets a human-facing application.
+> oddkit serves 500+ documents. The primary public interface for reading those documents could only retrieve 196 of them — not because of a bug, but because oddkit was never designed for a consumer that needed to see everything. Two fixes shipped the same day: pagination with a raised limit doubled coverage to 389, and a new `sort_by=path` mode closed the remaining gap to 473. Along the way, a second observability failure surfaced: GitHub API rate limiting silently defeated the SHA-based cache, serving a six-day-old index while the system believed it was content-addressed. The fixes were small. The lesson is about what happens when infrastructure works well enough to hide its own blind spots.
 
 ---
 
@@ -27,7 +27,7 @@ klappy.dev is the public website where humans read oddkit's canon — essays, pr
 
 The root cause was not a bug. It was a design assumption: `oddkit_catalog` was built as a discovery menu for AI agents making targeted queries, not as an enumeration surface for programmatic consumers needing completeness. The hard cap of 100 results with no pagination made this assumption structural.
 
-The fix: raise the limit to 500, add an `offset` parameter for pagination, return metadata so consumers know when they have everything. Three lines of substance in the orchestration layer, plus schema updates. PR #74 on klappy/oddkit.
+The fix came in two phases on the same day. First: raise the limit to 500 and add an `offset` parameter for pagination — this doubled coverage from 196 to 389. Second: add `sort_by=path`, which includes all indexed entries regardless of frontmatter presence — this closed the gap to 473. A secondary finding surfaced during verification: GitHub API rate limiting was silently defeating the SHA-based cache, serving a six-day-old index. PRs #74 and #76 on klappy/oddkit.
 
 ---
 
@@ -87,21 +87,33 @@ Three changes to the oddkit Worker (`workers/src/orchestrate.ts` and `workers/sr
 
 The Zod schemas on both the unified `oddkit` tool and the standalone `oddkit_catalog` tool were updated to reflect the new parameter and the raised cap.
 
-What the edge function can now do:
-
-```
-oddkit_catalog({ sort_by: "date", limit: 500 })
-```
-
-One call. All documents. The eighteen-call fan-out becomes unnecessary.
+This immediately doubled coverage — from ~196 documents to 389 in a single call. But 84 documents were still missing. They were indexed by oddkit's build pipeline, present in the category counts, but invisible to `sort_by=date` because they had no date in their frontmatter.
 
 ---
 
-## What Remains
+## Closing the Last Gap
 
-The fix addresses enumeration but leaves one known gap: `sort_by=date` still requires documents to have frontmatter. Documents without any frontmatter — raw markdown files with no YAML header — are indexed by oddkit's build pipeline but excluded from the catalog's article mode. They appear in category counts but not in the articles array.
+The original version of this case study noted the remaining gap and predicted the fix: a `sort_by=path` mode that returns all indexed entries regardless of frontmatter presence. That prediction shipped the same day.
 
-A future `sort_by=path` mode that returns all indexed entries regardless of frontmatter presence would close this gap. For now, any document worth serving to readers should have frontmatter — and if it does not, that is a signal to add it, not a reason to build infrastructure around its absence.
+**Add `sort_by=path`.** Where `sort_by=date` filters to documents with frontmatter and sorts by date, `sort_by=path` includes every indexed entry — regardless of whether it has frontmatter, a date, or any metadata at all — and sorts alphabetically by path. Undated documents get empty metadata but their paths and titles are discoverable.
+
+What the edge function can now do:
+
+```
+oddkit_catalog({ sort_by: "path", limit: 500 })
+```
+
+One call. All 473 documents. The eighteen-call fan-out becomes unnecessary. Consumers needing rich metadata on dated documents can use `sort_by=date`; consumers needing completeness use `sort_by=path`; consumers needing both can merge the two.
+
+---
+
+## A Second Observability Gap: SHA Resolution Under Rate Limiting
+
+During verification, the production index reported 411 documents with a `generated_at` timestamp six days old — despite the cache being content-addressed by commit SHA. Investigation revealed a second Axiom 4 violation in the SHA resolution logic.
+
+The Worker resolves the current commit SHA via an unauthenticated GitHub API call (60 requests/hour limit). When rate-limited, `getLatestCommitSha` returns `null`. The cache match logic then evaluates `!baselineSha || cached.commit_sha === baselineSha` — and since `baselineSha` is null, the condition is trivially true. Any cached index matches, regardless of age.
+
+The system believed its cache was content-addressed. Under rate limiting, it silently degraded to a TTL-free stale cache with no expiration. The index served was truthful for the commit it was built from, but the system had no way to know it was six days behind. This is the same pattern as the catalog gap: not an error, not a crash — silent incompleteness where everything appears to be working.
 
 ---
 
@@ -113,8 +125,15 @@ This is the most dangerous kind of infrastructure gap: one that produces a plaus
 
 ---
 
+## What Remains
+
+The SHA resolution vulnerability identified above has not yet been fixed. Options include authenticating GitHub API calls (raising the limit from 60 to 5,000 requests/hour) or treating a null SHA as a cache miss rather than a universal match. Either fix is small; the hard part was noticing the degradation.
+
+---
+
 ## See Also
 
 - `canon/values/axioms.md` — Axiom 4: You cannot verify what you did not observe
 - `docs/appendices/epochs.md` — E0008 epoch declaration (Observability)
-- oddkit PR #74 — Implementation of catalog pagination
+- oddkit PR #74 — Catalog pagination and limit raise
+- oddkit PR #76 — `sort_by=path` for complete enumeration

--- a/docs/oddkit/tools/oddkit_catalog.md
+++ b/docs/oddkit/tools/oddkit_catalog.md
@@ -11,13 +11,15 @@ tags: ["oddkit", "tool", "epistemics", "catalog", "discovery", "navigation"]
 
 # oddkit_catalog
 
-> List all available documentation with counts, categories, and start-here suggestions.
+> List all available documentation with counts, categories, and start-here suggestions. Supports temporal discovery and complete enumeration via sort modes and pagination.
 
 ## Description
 
-`oddkit_catalog` provides a high-level map of the entire documentation corpus. It returns total document counts, a breakdown between canon and baseline, the full set of categories (derived from tags), and a curated list of start-here entry points for new users or agents.
+`oddkit_catalog` provides a high-level map of the entire documentation corpus. In its default mode, it returns total document counts, a breakdown between canon and baseline, the full set of categories (derived from tags), and a curated list of start-here entry points.
 
-This tool answers the question "what exists?" without returning any document content. It is the right starting point when orienting in an unfamiliar repo or verifying corpus shape after structural changes. For actual document content, follow up with `oddkit_search` (by topic) or `oddkit_get` (by URI).
+When `sort_by` is provided, catalog also returns an `articles` array with per-document metadata — paths, URIs, and full frontmatter. Two sort modes are available: `date` (newest first, includes only documents with frontmatter) and `path` (alphabetical, includes all indexed documents regardless of frontmatter presence). Pagination via `limit` and `offset` supports both single-call retrieval (`limit=500`) and incremental consumption.
+
+This tool answers both "what exists?" (default mode) and "give me everything" (with `sort_by`). For actual document content, follow up with `oddkit_search` (by topic) or `oddkit_get` (by URI).
 
 ## When to Use
 
@@ -26,12 +28,15 @@ This tool answers the question "what exists?" without returning any document con
 - Verifying document counts after structural changes or migrations
 - Discovering available categories before running a targeted search
 - Orienting a new agent to the repo's documentation landscape
+- Enumerating all documents for a programmatic consumer (use `sort_by: "path", limit: 500`)
+- Retrieving recent documents with full metadata (use `sort_by: "date"`)
+- Filtering documents by epoch (use `filter_epoch`)
 
 ## Tool Definition
 
 **Name:** `oddkit_catalog`
 
-**Description:** Lists available documentation with categories, counts, and start-here suggestions. Returns total document counts (canon vs. baseline), category distribution from tags, and curated entry points. Use to understand corpus shape, find starting points, or verify doc counts. Does not return document content — use search or get for that.
+**Description:** Lists available documentation with categories, counts, and start-here suggestions. Supports temporal discovery: use `sort_by='date'` to get recent articles with full frontmatter metadata, or `sort_by='path'` for complete enumeration of all indexed documents.
 
 ### Input Schema
 
@@ -42,6 +47,26 @@ This tool answers the question "what exists?" without returning any document con
     "canon_url": {
       "type": "string",
       "description": "Optional. GitHub repo URL for canon override. Defaults to the configured baseline."
+    },
+    "sort_by": {
+      "type": "string",
+      "enum": ["date", "path"],
+      "description": "Sort articles. 'date' returns newest first (requires frontmatter). 'path' returns all docs alphabetically, including undated."
+    },
+    "limit": {
+      "type": "number",
+      "minimum": 1,
+      "maximum": 500,
+      "description": "Max articles to return when sort_by is provided. Default: 10, max: 500."
+    },
+    "offset": {
+      "type": "number",
+      "minimum": 0,
+      "description": "Skip this many articles before returning results. Use with limit for pagination. Default: 0."
+    },
+    "filter_epoch": {
+      "type": "string",
+      "description": "Filter to articles with this epoch value in frontmatter (e.g. 'E0007')."
     }
   },
   "required": []
@@ -50,6 +75,8 @@ This tool answers the question "what exists?" without returning any document con
 
 ### Response Shape
 
+Default mode (no `sort_by`):
+
 ```json
 {
   "action": "catalog",
@@ -57,25 +84,79 @@ This tool answers the question "what exists?" without returning any document con
     "total": "number — total documents in the corpus",
     "canon": "number — documents classified as canon",
     "baseline": "number — documents from the baseline (remote main branch)",
-    "categories": [
-      "string — category names derived from document tags"
-    ],
-    "start_here": [
-      "string — file paths recommended as entry points"
-    ]
+    "categories": ["string — category names derived from document tags"],
+    "start_here": ["string — file paths recommended as entry points"]
   }
 }
 ```
 
+With `sort_by` provided:
+
+```json
+{
+  "action": "catalog",
+  "result": {
+    "total": "number",
+    "canon": "number",
+    "baseline": "number",
+    "categories": ["string"],
+    "start_here": ["string"],
+    "articles": [
+      {
+        "path": "string — file path relative to repo root",
+        "uri": "string — klappy:// URI",
+        "metadata": "object — full parsed frontmatter (title, date, tags, epoch, etc.)"
+      }
+    ],
+    "pagination": {
+      "offset": "number — current offset",
+      "limit": "number — current limit",
+      "total_candidates": "number — total articles matching filters",
+      "has_more": "boolean — whether more articles exist beyond this page"
+    }
+  }
+}
+```
+
+## Usage Examples
+
+Complete enumeration in a single call:
+
+```
+oddkit_catalog({ sort_by: "path", limit: 500 })
+```
+
+Recent documents with full metadata:
+
+```
+oddkit_catalog({ sort_by: "date", limit: 20 })
+```
+
+Paginated retrieval:
+
+```
+oddkit_catalog({ sort_by: "date", limit: 100, offset: 0 })
+oddkit_catalog({ sort_by: "date", limit: 100, offset: 100 })
+```
+
+Filter by epoch:
+
+```
+oddkit_catalog({ sort_by: "date", limit: 500, filter_epoch: "E0008" })
+```
+
 ## Behavioral Rules
 
-1. **Return counts and categories, not content.** Catalog provides structural metadata only. For document content, use `oddkit_search` or `oddkit_get`.
-2. **Start-here docs are curated entry points.** These are documents explicitly marked as starting points for new users or agents. They represent the recommended reading order for orientation.
-3. **Categories reflect tag distribution.** The categories list is derived from frontmatter tags across all indexed documents. It represents what the corpus covers, not a fixed taxonomy.
-4. **Report canon vs. baseline breakdown.** The distinction between canon (immutable governing documents) and baseline (all indexed documents from remote main) is always surfaced.
-5. **Lightweight and side-effect free.** Catalog reads index metadata only. It does not modify state, fetch document content, or trigger reindexing.
+1. **Without `sort_by`, return counts and categories only.** Default mode provides structural metadata. No `articles` array, no pagination.
+2. **With `sort_by=date`, include only documents with frontmatter.** Documents without frontmatter or without a date field are excluded. Sorted newest first; undated documents sort last.
+3. **With `sort_by=path`, include all indexed entries.** Every document in the index appears regardless of frontmatter presence. Sorted alphabetically by path. This is the mode for complete enumeration.
+4. **Pagination metadata is always present when `sort_by` is provided.** Consumers should check `has_more` to know whether additional pages exist.
+5. **Start-here docs are curated entry points.** These are documents explicitly marked as starting points for new users or agents.
+6. **Categories reflect tag distribution.** The categories list is derived from frontmatter tags across all indexed documents.
+7. **Report canon vs. baseline breakdown.** The distinction between canon and baseline is always surfaced.
+8. **Lightweight and side-effect free.** Catalog reads index metadata only. It does not modify state, fetch document content, or trigger reindexing.
 
 ## Canon References
 
 - `klappy://canon/README` — Canon root document, typically appears in start-here suggestions
-- `klappy://canon/epistemic-modes` — Epistemic modes that inform how agents orient using catalog results
+- `klappy://canon/case-studies/catalog-observability-gap` — Case study documenting the design evolution of this tool


### PR DESCRIPTION
Updates the catalog observability gap case study with:
- Phase 2 fix: `sort_by=path` closes the remaining 84-doc gap
- SHA rate-limiting vulnerability documented as second observability finding
- Companion to oddkit PR #76

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only updates; no runtime behavior changes, but could mislead operators if the described behavior diverges from the implementation.
> 
> **Overview**
> Updates the catalog observability case study to describe the second-phase fix (`sort_by=path`) that enables complete document enumeration (closing the remaining gap after `limit`/`offset` pagination), and adds a new section documenting a separate observability issue where GitHub API rate limiting can cause SHA-based caching to serve stale indexes.
> 
> Refreshes `oddkit_catalog` tool documentation to define `sort_by` (`date` vs `path`), `limit`/`offset` pagination, optional `filter_epoch`, updated response shapes (including `pagination` metadata), and adds usage examples and behavioral rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 400334ff9ce901b7b0907c3e18a3bd05c08fe453. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->