### PR TITLE
fix: telemetry_public — raw SQL pass-through (prompt over code)

### DIFF
--- a/canon/constraints/telemetry-governance.md
+++ b/canon/constraints/telemetry-governance.md
@@ -184,6 +184,35 @@ This telemetry implementation is infrastructure serving the Maintainability prin
 
 ---
 
+## Query Security Boundary
+
+`telemetry_public` accepts raw SQL and passes it to Cloudflare Analytics Engine. The data is public by design — there is nothing to steal. But the query interface requires infrastructure guards to prevent abuse without adding domain opinions.
+
+### Threat Model
+
+The data is public. The API token is read-only. The risk is not data exfiltration — it's resource exhaustion and information leak about other account resources.
+
+### Guards (Infrastructure, Not Domain Opinion)
+
+**1. Dataset allowlist.** The server validates that the SQL query targets only the `oddkit_telemetry` dataset. Any query referencing a different dataset is rejected before reaching the Analytics Engine API. This prevents cross-dataset access to other Analytics Engine data on the same Cloudflare account.
+
+**2. Rate limiting.** `telemetry_public` calls are rate-limited per consumer label. The limit protects the Analytics Engine query quota (10,000 queries/day free tier). Rate limiting is infrastructure — it protects the resource, not the data.
+
+**3. Error sanitization.** Analytics Engine API errors are caught and returned as generic failure messages. Raw error responses — which may contain account IDs, dataset names, or internal schema details — are never forwarded to the caller.
+
+### What Is NOT Guarded (By Design)
+
+- **Column restriction** — any column can be queried. The data is public.
+- **Query complexity** — no LIMIT enforcement. Analytics Engine has built-in timeouts.
+- **Authentication** — no auth required to query. Transparency means anyone can see the data.
+- **SQL keyword blocking** — unnecessary. The API token is read-only. DROP, ALTER, INSERT are rejected by Analytics Engine regardless.
+
+### Vodka Compliance
+
+These three guards are infrastructure serving security, not domain opinions about what questions are interesting. They are the same category as CORS headers, `keep_vars`, and the `catch` block in telemetry recording. The server does not decide what to ask — it decides what is safe to forward.
+
+---
+
 ## The Social Contract
 
 oddkit is free. The code is MIT. Anyone can self-host. Cloudflare hosts the service at oddkit.klappy.dev for essentially zero cost — infrastructure is not the bottleneck. Attention is.

--- a/docs/oddkit/tools/telemetry_public.md
+++ b/docs/oddkit/tools/telemetry_public.md
@@ -1,41 +1,40 @@
 ---
 uri: oddkit://tools/telemetry_public
-title: "telemetry_public"
+title: "telemetry_public — Raw SQL Against the Public Telemetry Dataset"
 audience: operators
 exposure: nav
 tier: 2
 voice: neutral
 stability: evolving
-tags: ["oddkit", "tool", "telemetry", "transparency", "leaderboard", "analytics"]
+tags: ["oddkit", "tool", "telemetry", "transparency", "analytics", "sql", "vodka-architecture", "prompt-over-code"]
 epoch: E0008
-date: 2026-04-09
-derives_from: "canon/constraints/telemetry-governance.md"
+date: 2026-04-11
+derives_from: "canon/constraints/telemetry-governance.md, canon/principles/vodka-architecture.md, canon/principles/prompt-over-code.md"
 complements: "docs/oddkit/tools/telemetry_policy.md"
 ---
 
-# telemetry_public
+# telemetry_public — Raw SQL Against the Public Telemetry Dataset
 
-> Query the same usage dashboard the maintainer sees. Consumer leaderboard, tool leaderboard, canon URL leaderboard, document leaderboard, daily trends. No information asymmetry between host and user.
+> One tool, one SQL parameter, infinite questions. The server passes your query through to Cloudflare Analytics Engine and returns whatever it finds. No hardcoded leaderboards, no predefined dashboards, no menu of canned reports. The schema is documented. The data is public. Write the query that answers your question.
 
-## Description
+## Summary — Prompt Over Code for Telemetry
 
-`telemetry_public` exposes oddkit's usage telemetry to any consumer — the same data the maintainer uses to make prioritization decisions. It queries Cloudflare Workers Analytics Engine via SQL and returns aggregated structural metrics: which tools are called, which repos are served, which consumers are active, and when usage happens.
+`telemetry_public` accepts a raw SQL query against the `oddkit_telemetry` dataset and returns the results. The server has zero domain opinions about which questions to ask — that's the caller's job. The schema is embedded in the tool description so any LLM can write valid queries without a second call.
 
-This tool answers the question "who's using oddkit and how?" without revealing what anyone searched for, what documents contained, or what models responded. The data is structural — shapes and counts, not substance.
+This design follows Vodka Architecture: the server is a pass-through, not a dashboard. Adding new questions means writing new SQL, not deploying new code. Ten gaps or twenty, the server doesn't change.
 
 ## When to Use
 
-- Understanding how oddkit is being used across the community
-- Checking whether your consumer label appears on the leaderboard
-- Verifying that telemetry is working after setup or configuration changes
-- Investigating usage spikes or trends
-- Comparing tool popularity to inform contribution or feature requests
+- Any question about oddkit usage that can be answered with SQL
+- Building transparency dashboards (web, CLI, or conversational)
+- Investigating spikes, trends, or anomalies
+- Checking adoption signals (which repos are served, which tools are used)
+- Comparing tool performance (duration stats)
+- Identifying consumer patterns
 
 ## Tool Definition
 
 **Name:** `telemetry_public`
-
-**Description:** Returns public telemetry disclosures and usage leaderboards for the oddkit hosted service. Shows the same data the maintainer sees — consumer leaderboard, tool usage, canon URL distribution, document access patterns, and daily trends. No information asymmetry.
 
 ### Input Schema
 
@@ -43,18 +42,12 @@ This tool answers the question "who's using oddkit and how?" without revealing w
 {
   "type": "object",
   "properties": {
-    "period": {
+    "sql": {
       "type": "string",
-      "enum": ["7d", "30d", "all"],
-      "description": "Optional. Time period for the query. Defaults to '30d'."
-    },
-    "query_type": {
-      "type": "string",
-      "enum": ["summary", "tools", "consumers", "canon_urls", "documents", "daily_trend"],
-      "description": "Optional. Which leaderboard or metric to return. Defaults to 'summary'."
+      "description": "SQL query against the oddkit_telemetry dataset"
     }
   },
-  "required": []
+  "required": ["sql"]
 }
 ```
 
@@ -64,39 +57,120 @@ This tool answers the question "who's using oddkit and how?" without revealing w
 {
   "action": "telemetry_public",
   "result": {
-    "period": "string — the time period queried",
-    "query_type": "string — which metric was returned",
-    "data": "object — query-specific result (leaderboard array, summary object, or trend array)",
-    "generated_at": "string — ISO timestamp of query execution"
+    "sql": "string — the query that was executed",
+    "data": {
+      "meta": [{"name": "column_name", "type": "column_type"}],
+      "data": [{"column_name": "value"}],
+      "rows": "number"
+    },
+    "generated_at": "string — ISO timestamp"
   }
 }
 ```
 
-### Query Types
+## Dataset Schema
 
-**summary** — Total requests and tool calls for the period, with breakdown by method.
+Dataset name: `oddkit_telemetry`
 
-**tools** — Tool leaderboard: which epistemic actions are called, ranked by frequency. Answers "is `gate` changing how people work, or is everyone just using `search`?"
+### Blob Fields (Strings)
 
-**consumers** — Consumer leaderboard: unique consumer labels with request counts and completeness scores. Answers "how many people are using oddkit?"
+| Field | Column | Content | Example |
+|-------|--------|---------|---------|
+| blob1 | event_type | `"mcp_request"` or `"tool_call"` | `"tool_call"` |
+| blob2 | method | JSON-RPC method | `"tools/call"`, `"initialize"` |
+| blob3 | tool_name | oddkit action name (empty for non-tool events) | `"orient"`, `"search"` |
+| blob4 | consumer_label | Best-effort caller identity | `"Claude-User"`, `"Deno/2.1.4"` |
+| blob5 | consumer_source | How label was resolved | `"x-oddkit-client"`, `"user-agent"` |
+| blob6 | canon_url | Which repo is being served (from tool args or env default) | `"https://github.com/klappy/klappy.dev"` |
+| blob7 | document_uri | For `get` calls, the URI requested (empty otherwise) | `"klappy://canon/principles/vodka-architecture"` |
+| blob8 | worker_version | oddkit version string | `"0.16.0"` |
 
-**canon_urls** — Canon URL leaderboard: which repos are being served. Answers "has anyone pointed oddkit at a knowledge base that isn't the maintainer's?" This is the primary adoption signal.
+### Double Fields (Numbers)
 
-**documents** — Document leaderboard: most accessed document URIs (from `get` calls). Answers "which canon documents actually matter?"
+| Field | Column | Content |
+|-------|--------|---------|
+| double1 | count | Always `1` — use `SUM(_sample_interval)` for totals |
+| double2 | duration_ms | Request processing time in milliseconds |
 
-**daily_trend** — Daily request counts over the period. Answers "what caused the spike?"
+### Automatic Fields
+
+| Field | Content |
+|-------|---------|
+| timestamp | Automatic per data point — use `toStartOfDay(timestamp)` for daily trends |
+| _sample_interval | Sampling weight — always use `SUM(_sample_interval)` instead of `COUNT(*)` |
+
+## Example Queries
+
+These examples are guidance for callers, not code in the server. Write whatever SQL answers your question.
+
+### Tool leaderboard
+```sql
+SELECT blob3 AS tool, SUM(_sample_interval) AS calls
+FROM oddkit_telemetry WHERE blob1 = 'tool_call'
+GROUP BY tool ORDER BY calls DESC LIMIT 20
+```
+
+### All consumers (all events, not just tool calls)
+```sql
+SELECT blob4 AS consumer, blob5 AS source, SUM(_sample_interval) AS calls
+FROM oddkit_telemetry
+GROUP BY consumer, source ORDER BY calls DESC LIMIT 20
+```
+
+### Knowledge bases served (the adoption signal)
+```sql
+SELECT blob6 AS canon_url, SUM(_sample_interval) AS calls
+FROM oddkit_telemetry WHERE blob1 = 'tool_call'
+GROUP BY canon_url ORDER BY calls DESC
+```
+
+### Daily trend
+```sql
+SELECT toStartOfDay(timestamp) AS day, SUM(_sample_interval) AS calls
+FROM oddkit_telemetry GROUP BY day ORDER BY day DESC LIMIT 30
+```
+
+### Consumer × tool matrix
+```sql
+SELECT blob4 AS consumer, blob3 AS tool, SUM(_sample_interval) AS calls
+FROM oddkit_telemetry WHERE blob1 = 'tool_call'
+GROUP BY consumer, tool ORDER BY consumer, calls DESC
+```
+
+### Duration stats per tool
+```sql
+SELECT blob3 AS tool, AVG(double2) AS avg_ms, MAX(double2) AS max_ms,
+  SUM(_sample_interval) AS calls
+FROM oddkit_telemetry WHERE blob1 = 'tool_call'
+GROUP BY tool ORDER BY avg_ms DESC
+```
+
+### Consumer trend (daily by consumer)
+```sql
+SELECT toStartOfDay(timestamp) AS day, blob4 AS consumer, SUM(_sample_interval) AS calls
+FROM oddkit_telemetry
+GROUP BY day, consumer ORDER BY day DESC, calls DESC LIMIT 50
+```
+
+### Most accessed documents
+```sql
+SELECT blob7 AS document_uri, SUM(_sample_interval) AS calls
+FROM oddkit_telemetry WHERE blob7 != ''
+GROUP BY document_uri ORDER BY calls DESC LIMIT 20
+```
 
 ## Behavioral Rules
 
-1. **Return aggregated metrics, never raw events.** Individual request details are not exposed — only counts, rankings, and trends.
-2. **The data is the same data the maintainer sees.** There is no privileged dashboard. `telemetry_public` queries the same Analytics Engine dataset with the same SQL.
-3. **Consumer labels are self-declarations.** They are not identity proof. Treat them as honest claims, not authentication. See `telemetry_policy` for the full identification model.
-4. **Results may be sampled.** Cloudflare Analytics Engine uses sampling at high volumes. Counts are estimates scaled by `_sample_interval`, not exact totals.
-5. **Retention is 3 months.** Data older than 3 months is not available. For long-term trends, monthly snapshots are persisted separately.
+1. **Pass-through, not dashboard.** The server executes the SQL and returns the result. It has no opinion about which queries are interesting.
+2. **Schema is the interface.** The dataset schema is documented here and embedded in the tool description. Callers write SQL based on the schema — no menu, no enum, no predefined reports.
+3. **Public data, same as the maintainer sees.** There is no privileged query interface.
+4. **Results may be sampled.** Always use `SUM(_sample_interval)` instead of `COUNT(*)`.
+5. **Retention is 3 months.** Data older than 3 months is not available.
+6. **Prompt over code.** New questions are answered by writing new SQL, not by deploying new server code.
 
 ## Canon References
 
-- [Telemetry Governance](klappy://canon/constraints/telemetry-governance) — The authoritative reference for what is tracked and excluded
-- [telemetry_policy](oddkit://tools/telemetry_policy) — Returns the governance document at runtime
-- [Vodka Architecture](klappy://canon/principles/vodka-architecture) — The design pattern telemetry must not violate
-- [Maintainability](klappy://canon/principles/maintainability-one-person-indefinitely) — The principle telemetry serves
+- [Telemetry Governance](klappy://canon/constraints/telemetry-governance) — What is tracked, what is excluded, and why
+- [telemetry_policy](oddkit://tools/telemetry_policy) — Fetch the governance document at runtime
+- [Vodka Architecture](klappy://canon/principles/vodka-architecture) — Thin server, rich canon
+- [Prompt Over Code](klappy://canon/principles/prompt-over-code) — Governance in documents, not compiled into the server


### PR DESCRIPTION
Replace hardcoded query_type enum with raw sql parameter. Schema in tool description + canon doc. Example queries in canon, not server code.

Vodka Architecture: the server is a pass-through, not a dashboard.
Prompt Over Code: new questions = new SQL, not new deploys.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that redefines `telemetry_public` as a raw-SQL pass-through and describes infrastructure guards; no runtime code changes are included, so risk is low aside from potential client/doc mismatches.
> 
> **Overview**
> Updates `telemetry_public` documentation to replace the prior enum-style leaderboards (`period`/`query_type`) with a required `sql` parameter and a response that returns the executed SQL plus Analytics Engine result metadata.
> 
> Extends `telemetry-governance` with a **query security boundary** section describing intended infrastructure protections for raw-SQL querying (dataset allowlist, rate limiting, and sanitized errors), and embeds the `oddkit_telemetry` schema + example queries directly in the tool doc to support *prompt-over-code* usage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c25085232960a2fde2a24e5f9acceb57251ab967. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->