### PR TITLE
canon: Time Blindness — The Axiom Violation Hiding in Every Model

### DIFF
--- a/canon/constraints/telemetry-governance.md
+++ b/canon/constraints/telemetry-governance.md
@@ -53,6 +53,7 @@ All tracking occurs on `/mcp` POST envelopes. One data point is written per JSON
 | Canon URL | Which repo is being served | `https://github.com/klappy/klappy.dev` |
 | Document URI | For `get` calls, the path requested | `klappy://canon/principles/vodka-architecture` |
 | Worker version | oddkit version string | `0.17.0` |
+| Cache tier | Which storage tier served the index | `memory`, `cache`, `r2`, `build` |
 
 ### Numeric Values (Doubles)
 
@@ -76,6 +77,11 @@ All tracking occurs on `/mcp` POST envelopes. One data point is written per JSON
 - **Document leaderboard** — which canon documents are most accessed
 - **Daily/hourly trends** — when usage happens, what caused spikes
 - **Method breakdown** — protocol-level health
+- **Cache health** — module memory hit rate, cold-build frequency, per-tier latency (`GROUP BY cache_tier, AVG(duration)`)
+
+### Per-Request Diagnostics (Ephemeral, Not Stored)
+
+The `X-Oddkit-Trace` response header and the `debug.trace` field in tool responses contain per-request span detail: every storage read, GitHub API call, and cache tier hit/miss with timing. This is ephemeral diagnostic data — it exists in the HTTP response and nowhere else. It is not written to Analytics Engine, not persisted, and not queryable after the request completes. The `cache_tier` blob above is the single aggregate signal extracted from the trace for telemetry.
 
 ---
 

--- a/canon/observations/time-blindness-axiom-violation.md
+++ b/canon/observations/time-blindness-axiom-violation.md
@@ -19,6 +19,12 @@ complements: "canon/constraints/telemetry-governance.md, docs/appendices/epoch-8
 
 ---
 
+## Summary — Time Is Reality, and Models Don't Observe It
+
+Models fabricate timelines from token patterns. The LLM message format — `{role, content}` — carries no timestamps. A model cannot distinguish whether the last message was sent 30 seconds ago or 3 days ago. This violates Axiom 1 (Reality Is Sovereign) and Axiom 4 (You Cannot Verify What You Did Not Observe). The fix has two phases: oddkit adds `server_time` to every response envelope now (one line of code, passive), and TruthKit will inject `elapsed_since_last` into every context window at the harness level (automatic, required). The tool offers. The harness requires.
+
+---
+
 ## The Problem
 
 Every model — voice, text, reasoning — operates on token sequences with no ground truth about when those tokens were produced, how much time passed between turns, or whether the conversation spans minutes or days. The model invents a timeline from contextual signals: message length, topic drift, phrases like "let's continue" or "good morning."

--- a/canon/observations/time-blindness-axiom-violation.md
+++ b/canon/observations/time-blindness-axiom-violation.md
@@ -1,0 +1,142 @@
+---
+uri: klappy://canon/observations/time-blindness-axiom-violation
+title: "Time Blindness — The Axiom Violation Hiding in Every Model"
+audience: canon
+exposure: nav
+tier: 1
+voice: neutral
+stability: semi_stable
+tags: ["canon", "observation", "time", "axiom-1", "axiom-4", "models", "perception", "oddkit", "truthkit", "epistemic-primitive", "harness"]
+epoch: E0008.1
+date: 2026-04-11
+derives_from: "canon/values/axioms.md"
+complements: "canon/constraints/telemetry-governance.md, docs/appendices/epoch-8-1.md"
+---
+
+# Time Blindness — The Axiom Violation Hiding in Every Model
+
+> Models have no perception of time. Not degraded perception — zero. They infer elapsed time from context clues the way a person might guess the season from a photograph. Sometimes they guess right. Often they guess wrong. And when they guess wrong, they guess confidently. A system that demands "Reality Is Sovereign" cannot tolerate a blind spot this fundamental. Time is not a feature to add. It is a reality axis that every epistemic system must observe.
+
+---
+
+## The Problem
+
+Every model — voice, text, reasoning — operates on token sequences with no ground truth about when those tokens were produced, how much time passed between turns, or whether the conversation spans minutes or days. The model invents a timeline from contextual signals: message length, topic drift, phrases like "let's continue" or "good morning."
+
+This invention is invisible. The model doesn't flag uncertainty about time. It presents its fabricated timeline as fact.
+
+### What it looks like
+
+- A user sleeps on a problem and resumes the next morning. The model says "we've been at this for hours" — factually wrong, it's been eight hours and the user is fresh.
+- A user takes a 10-minute break. The model says "you should take a break, we've been going hard" — timing advice from a system that cannot tell the difference between 10 minutes and 10 hours.
+- Two concurrent conversations produce artifacts. The model has no way to determine which happened first, which is more recent, or whether they overlap.
+- A session spans a day boundary. The model doesn't know it's tomorrow. It doesn't know it's the weekend. It doesn't know the user changed timezones.
+- The model estimates a task will take "a few minutes" without knowing how long anything has taken so far.
+
+These are not edge cases. They are the default experience.
+
+---
+
+## The Axiom Violations
+
+### Axiom 1 — Reality Is Sovereign
+
+> The state of the world as it actually is always takes precedence over any claim, plan, model, or expectation. Observe before asserting.
+
+Time is a dimension of reality. The model has never observed it. Every time-related statement the model makes is an assertion without observation — the exact behavior Axiom 1 was written to prevent.
+
+### Axiom 4 — You Cannot Verify What You Did Not Observe
+
+> Only direct observation of actual state constitutes verification. If you didn't look, you don't know.
+
+The model has not looked at a clock. It has inferred one from token patterns. Inference is not observation. The model does not know what time it is, how much time has passed, or when the user last spoke. It has guessed all three.
+
+---
+
+## The Fix: Time as a First-Class Epistemic Primitive
+
+Time measurement should be as fundamental to epistemic systems as evidence tracking. Not a feature. Not an optional signal. A primitive — something so basic that its absence is a defect.
+
+### In oddkit (now): `server_time` in every response
+
+Every oddkit tool response includes `server_time` in the debug envelope. UTC. ISO 8601. Millisecond precision. Every call.
+
+```json
+{
+  "action": "search",
+  "result": { ... },
+  "debug": {
+    "server_time": "2026-04-11T19:47:32.123Z",
+    "duration_ms": 342
+  }
+}
+```
+
+The model receives a ground-truth timestamp every time it calls oddkit. It can compare consecutive timestamps. If the gap is 8 hours, the user slept. If it's 90 seconds, the session is continuous. No guessing required.
+
+This is cheap. One `new Date().toISOString()` call. Adds nothing to latency. Breaks nothing in existing contracts. The timestamp goes in the debug envelope — the same place trace data already lives.
+
+But it is opt-in. The model has to call oddkit to receive a timestamp. Between calls, the model is still time-blind.
+
+### In TruthKit (future): time as harness-level governance
+
+TruthKit wraps every LLM invocation. The model doesn't call TruthKit — TruthKit calls the model. This inversion means TruthKit can inject time evidence into every context window without the model choosing to ask for it.
+
+Every LLM invocation receives:
+
+- `session_start` — when this session began
+- `last_response_at` — when the model last responded
+- `elapsed_since_last` — seconds since the last exchange
+- `current_time` — right now, UTC
+
+The model never has to ask what time it is. It just knows, because the harness observed it and told it. The difference between a tool and a harness: **the tool offers, the harness requires.**
+
+Every DOLCHE encode already captures a moment. Adding timestamps to the encode means the DOLCHE stream becomes a timeline — decisions, observations, and learnings are situated in time, not floating in an unordered list.
+
+### The cost
+
+A `Date.now()` comparison costs microseconds. A datetime comparison costs less than a single token of generation. The cost of time measurement is negligible. The cost of time blindness is fabricated reality presented as fact.
+
+---
+
+## Why This Isn't Solved by System Prompts
+
+System prompts can say "today is April 11, 2026." They cannot say "the user's last message was 8 hours ago." They are injected once, at the start of a conversation. They do not update between turns. They provide a calendar date, not a timeline.
+
+MCP servers like oddkit operate within the conversation. They respond in real time. Each response is an opportunity to provide a fresh, accurate timestamp — not a stale one from the system prompt.
+
+---
+
+## Why This Isn't Just About Timestamps
+
+Timestamps are the implementation. The insight is deeper: **models are blind to an entire dimension of reality, and nobody is treating it as a defect.**
+
+Time shapes everything:
+- Urgency — is this due today or next month?
+- Freshness — was this information retrieved 2 minutes ago or 2 days ago?
+- Continuity — is this the same working session or a new one?
+- Pacing — has the user been working for 12 hours straight or 20 minutes?
+- Causality — which event happened first?
+
+A model that cannot perceive time cannot reason about any of these. It can fake reasoning about them — and does, constantly — but the reasoning is built on fabricated premises.
+
+This is the same category of problem as the stale cache incident: a system that looks like it's working but is quietly wrong about something fundamental. The cache lied about content freshness. Models lie about time. Both violations are invisible until you observe the thing that was assumed.
+
+---
+
+## Scope
+
+**oddkit (E0008.1):** Add `server_time` to every OddkitEnvelope debug field. One line of code. Ship with the next release.
+
+**TruthKit (future):** Time injection at the harness level. `elapsed_since_last` in every context window. Timestamped DOLCHE stream. Session timeline as a first-class data structure. This is where time becomes a *requirement*, not an *offering*.
+
+**Governance:** Consider whether time-awareness belongs in the creed, in the axioms (as an application note), or as a standalone constraint. The axioms already imply it — "Reality Is Sovereign" and "You Cannot Verify What You Did Not Observe" both demand time observation. But the implication has never been made explicit. Making it explicit is the work.
+
+---
+
+## See Also
+
+- [Axioms](klappy://canon/values/axioms) — Axiom 1 and Axiom 4 demand observable reality; time is reality
+- [Vodka Architecture](klappy://canon/principles/vodka-architecture) — server_time is infrastructure, not domain opinion
+- [E0008.1 — X-Ray Tracing](klappy://docs/appendices/epoch-8-1) — the observability epoch that surfaces this
+- [Stale Cache Incident](klappy://docs/incidents/oddkit-stale-cache-2026-02) — same pattern: invisible lies about a time-adjacent property

--- a/docs/appendices/epoch-8-1.md
+++ b/docs/appendices/epoch-8-1.md
@@ -1,0 +1,119 @@
+---
+uri: klappy://docs/appendices/epoch-8-1
+title: "Epoch 8.1 — X-Ray Tracing and Infrastructure Optimization"
+audience: docs
+exposure: nav
+tier: 2
+voice: neutral
+stability: stable
+tags: ["odd", "epochs", "observability", "tracing", "performance", "cache-api", "vodka-architecture", "maintainability", "epoch-8", "epoch-8.1", "cross-project-learning"]
+epoch: E0008.1
+date: 2026-04-11
+forcing_fault: "E0008 added duration_ms to every telemetry data point but provided no way to see what was inside that duration. 500–900ms outliers appeared in production with no explanation — the system could observe that a request was slow but not why."
+new_invariant: "Same as E0008: the maintainer can see the shape of what's happening. E0008.1 extends 'shape' from usage patterns to infrastructure performance — which storage tier served each request, where time actually goes, and whether caching is working."
+core_shift: "Opaque duration → x-ray traced storage tiers. KV on hot path → module memory + Cache API (cross-project learning from aquifer-mcp). Two observability systems → one writeDataPoint with one additional blob."
+derives_from: "docs/appendices/epoch-8.md"
+cross_project_learning: "aquifer-mcp L44 (subrequest count is the primary performance lever), L47 (removing one KV read = 15x speedup), L48 (module-level memory = 0ms reads)"
+documents_introduced: ["docs/appendices/epoch-8-1.md"]
+---
+
+# Epoch 8.1 — X-Ray Tracing and Infrastructure Optimization
+
+> E0008 gave oddkit eyes on its usage — who calls, which tools, how often. E0008.1 gives oddkit eyes on its own plumbing — which storage tier served each request, where milliseconds actually go, and whether the caching architecture is healthy. The insight came from a sibling project: aquifer-mcp discovered that each Cloudflare KV subrequest costs 300–1,000ms in envoy routing overhead, invisible to application-level timing. Applying that learning to oddkit — eliminating KV from the hot path, adding module-level memory caching, and folding trace data into the existing telemetry data point — is E0008.1.
+
+---
+
+## Summary — One Blob, Not Two Systems
+
+E0008 wrote one `writeDataPoint` per MCP message with 8 structural dimensions and 2 numeric values. E0008.1 adds one dimension: `cache_tier` (blob9) — which storage tier served the navigability index for this request (`memory`, `cache`, `r2`, or `build`).
+
+That single blob answers:
+- What percentage of requests hit module memory? (cache health)
+- How often do cold builds happen? (deploy/eviction signal)
+- What's the real latency per tier? (`GROUP BY cache_tier, AVG(duration)`)
+- Is the 5-minute TTL working? (memory hit rate over time)
+
+Per-request diagnostic detail — every storage read, GitHub API call, and cache tier hit/miss with timing — flows to the `X-Oddkit-Trace` response header and the `debug.trace` field in tool responses. This is ephemeral: it exists in the HTTP response and nowhere else. It is not written to Analytics Engine, not persisted, and not queryable after the request completes.
+
+One system with two views. Not two parallel observability systems.
+
+---
+
+## The Forcing Fault — Opaque Duration
+
+E0008 tracked `duration_ms` for every request. Production data showed 500–900ms outliers alongside 60–120ms typical calls — a 10x variance with no explanation. The trace data from E0008.1 reveals why: cold isolates hit KV for the index (300–1,000ms envoy overhead), warm isolates serve from module memory (0ms). The outliers were KV subrequests, not slow tool logic.
+
+Without x-ray tracing, the maintainer could see *that* a request was slow but not *why*. With it, the answer is in every response header.
+
+---
+
+## Cross-Project Learning — From aquifer-mcp to oddkit
+
+aquifer-mcp is a sibling Cloudflare Worker MCP server for Bible Aquifer resources. During its v1.0–v1.5 optimization arc, the following learnings emerged:
+
+**L44: Minimizing subrequest count is the primary performance lever for Cloudflare Workers.** Each subrequest adds 300–1,000ms of infrastructure overhead that cannot be optimized from inside the Worker.
+
+**L47: Eliminating one KV subrequest from the hot path delivered a 15x speedup** (list: 1,800ms → 120ms). The KV read itself showed 3–105ms in Worker-internal timing, but its true cost was ~500–1,000ms in Cloudflare envoy infrastructure overhead.
+
+**L48: Module-level memory caching delivers 0ms index reads** for all requests within the same isolate. Combined with a well-known R2 key, the hot path goes from 2 subrequests to 0 on memory hit.
+
+**L49: The entire v1.3–v1.5 investigation was necessary to isolate the root cause.** Each failed hypothesis (SSE transport, SDK version, background refresh) eliminated a variable. The final fix was simple but could only be identified after ruling out every other layer.
+
+These learnings are encoded in aquifer-mcp's project journal (`odd/ledger/journal.md`) with full evidence chains. Applying them to oddkit is a transfer of proven knowledge, not speculation.
+
+---
+
+## What E0008.1 Introduces
+
+### X-Ray Request Tracing
+
+A `RequestTracer` class records every I/O operation with timing and source tier. Created per-request, threaded through `ZipBaselineFetcher` and `handleUnifiedAction`. The tracer's `indexSource` accessor extracts the single summary value that feeds telemetry blob9.
+
+### Module-Level Caching (Three-Tier Hot Path)
+
+Deserialized `BaselineIndex`, resolved commit SHAs, and recently-accessed file content cached at the module level with a 5-minute TTL. On warm isolates, subsequent requests serve from memory without any subrequests.
+
+**Module Memory (0ms)** → **Cache API (~1ms)** → **R2 (durable)** → **Build from ZIP (cold start)**
+
+### KV Eliminated from Hot Path
+
+`BASELINE_CACHE` KV namespace removed from the index resolution and file retrieval paths. KV is retained in `wrangler.toml` for backward compatibility but no longer read during `getIndex` or `getFile`. R2 and Cache API handle all durable caching. Content-addressed correctness (SHA-keyed storage) preserved on all durable tiers.
+
+### Bounded Staleness Window
+
+The module-level memory cache introduces a maximum 5-minute staleness window. This is a conscious tradeoff, distinct from the February 2026 stale cache incident in every dimension:
+
+- **Staleness bound:** 5 minutes (vs unbounded days in the incident)
+- **Correctness layer:** SHA-keyed durable storage preserved (vs none in the incident)
+- **Observability:** `cache_tier` telemetry dimension + `X-Oddkit-Trace` header (vs silent lies in the incident)
+- **Detection:** Queryable via `SELECT cache_tier, COUNT() GROUP BY cache_tier` (vs impossible in the incident)
+
+### Telemetry Integration
+
+`cache_tier` added as blob9 in the existing `writeDataPoint` call. No new Analytics Engine binding. No new data point. The governance update is in `canon/constraints/telemetry-governance.md` (living policy document).
+
+---
+
+## Why E0008.1 and Not E0009
+
+No new assumption about reality is introduced. E0008.1 extends E0008's observability invariant from "shape of usage" (who, what, when) to "shape of infrastructure performance" (which tier, how fast, why slow). Same invariant, broader application — the E0005.1 and E0007.1 pattern.
+
+E0008 explicitly scoped x-ray tracing as future work under the epoch theme. E0008.1 delivers that work plus an architectural optimization (KV elimination) that emerged from cross-project learning E0008 did not anticipate.
+
+---
+
+## What E0008.1 Does Not Change
+
+- **E0008 artifacts remain valid.** The telemetry schema gains one blob; existing blobs 1–8 and doubles 1–2 are unchanged.
+- **The four axioms carry forward unchanged.**
+- **Vodka Architecture is not violated.** The `RequestTracer` is 95 lines. Module-level caches are ~15 lines of declarations. The three-question test passes.
+- **Content-addressed caching correctness is preserved.** SHA keys on R2 and Cache API. The module-level memory cache is a performance layer above the storage layer, not a replacement for it.
+- **The telemetry social contract is unchanged.** No new content is tracked. `cache_tier` is a structural identifier (infrastructure metadata), not user content.
+
+---
+
+## Compatibility
+
+- E0008 artifacts remain valid. E0008.1 does not modify telemetry tools, governance, or the Analytics Engine schema beyond adding blob9.
+- E0007.1 artifacts remain valid. Proactive posture, Vodka Architecture, and all principles unchanged.
+- E0008.1 is the current epoch.

--- a/docs/appendices/epoch-8-2.md
+++ b/docs/appendices/epoch-8-2.md
@@ -1,0 +1,77 @@
+---
+uri: klappy://docs/appendices/epoch-8-2
+title: "Epoch 8.2 — Put the Clock in the Room"
+audience: docs
+exposure: nav
+tier: 2
+voice: neutral
+stability: stable
+tags: ["odd", "epochs", "observability", "time", "epistemic-primitive", "vodka-architecture", "epoch-8", "epoch-8.2"]
+epoch: E0008.2
+date: 2026-04-11
+forcing_fault: "Models fabricate timelines from context clues because the message format carries no timestamps. oddkit — a system that demands 'Reality Is Sovereign' — was returning responses without telling the model what time it was."
+new_invariant: "Same as E0008: the maintainer can see the shape of what's happening. E0008.2 extends this to the model itself — it can now see real time via server_time in every oddkit response."
+core_shift: "Time-blind model → clock in the room. The model doesn't have to use it. But it's there."
+derives_from: "docs/appendices/epoch-8-1.md, canon/observations/time-blindness-axiom-violation.md"
+documents_introduced: ["docs/appendices/epoch-8-2.md"]
+---
+
+# Epoch 8.2 — Put the Clock in the Room
+
+> E0008 gave oddkit eyes on usage. E0008.1 gave it eyes on infrastructure. E0008.2 puts a clock in the room — `server_time` in every response, so the model can observe real time instead of fabricating it.
+
+---
+
+## Summary — One Field, Every Response
+
+Every oddkit response now includes `server_time` in the debug envelope. UTC. ISO 8601. Millisecond precision. The model can compare consecutive timestamps to know how much time has passed between calls. It doesn't have to. But the evidence is there.
+
+That's the whole epoch.
+
+---
+
+## The Forcing Fault
+
+The LLM message format has no timestamps. A model receiving a conversation cannot tell whether the last message was sent 30 seconds ago or 3 days ago. It fabricates timelines from context clues. This violates Axiom 1 (Reality Is Sovereign) and Axiom 4 (You Cannot Verify What You Did Not Observe).
+
+oddkit demands epistemic discipline of its operators but was not providing them with observable time. A system that says "observe before asserting" should probably tell you what time it is.
+
+---
+
+## What E0008.2 Introduces
+
+One field in the debug envelope of every OddkitEnvelope:
+
+```json
+{
+  "debug": {
+    "server_time": "2026-04-11T22:47:32.123Z",
+    "duration_ms": 342
+  }
+}
+```
+
+One line of code: `server_time: new Date().toISOString()`
+
+---
+
+## What E0008.2 Does Not Introduce
+
+- No governance of how models use the timestamp. The clock is in the room. What the model does with it is the model's business.
+- No harness-level time injection. That's TruthKit's job, later.
+- No `elapsed_since_last` computation. The model can do subtraction.
+- No new tools, no new telemetry dimensions, no new constraints.
+
+---
+
+## Why E0008.2 and Not E0009
+
+Same observability invariant. One more thing is observable. The clock was always part of E0008's theme — "the maintainer can see the shape of what's happening." Now the model can too.
+
+---
+
+## Compatibility
+
+- E0008 and E0008.1 artifacts remain valid.
+- The debug envelope gains one field. No existing fields change.
+- E0008.2 is the current epoch.


### PR DESCRIPTION
New canonical observation establishing time as a first-class epistemic primitive.

Models have zero time perception. They fabricate timelines from context clues. This violates Axiom 1 (Reality Is Sovereign) and Axiom 4 (You Cannot Verify What You Did Not Observe).

Two-phase fix:
- oddkit (now): `server_time` in every response debug envelope
- TruthKit (future): time injection at the harness level

The tool offers. The harness requires.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that add new canon/epoch articles and clarify telemetry dimensions; no executable code or runtime behavior is modified in this PR.
> 
> **Overview**
> Adds a new canon observation, `time-blindness-axiom-violation`, arguing that models lack time perception and proposing `server_time` (now) plus harness-level elapsed-time injection (future) as the remediation.
> 
> Updates `telemetry-governance` to include a new `cache_tier` telemetry dimension and explicitly documents that detailed request traces (`X-Oddkit-Trace` / `debug.trace`) are **ephemeral and not stored**.
> 
> Introduces new epoch appendices `E0008.1` (x-ray tracing + cache-tier telemetry) and `E0008.2` (add `server_time` to responses) to record these infrastructure/observability shifts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 362b59221141a979107e48e749e76638b3255c00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->