### PR TITLE
publish: three essays go public

### DIFF
--- a/writings/half-a-million-requests.md
+++ b/writings/half-a-million-requests.md
@@ -4,17 +4,19 @@ title: "Half a Million Requests and I Can't Tell If Anyone's Home"
 slug: half-a-million-requests
 author: Klappy
 type: essay
-public: false
+public: true
 audience: public
-exposure: draft
+exposure: nav
 tier: 3
 voice: personal
-stability: volatile
+stability: stable
 tags: ["essay", "telemetry", "oddkit", "open-source", "transparency", "vodka-architecture", "trust", "open-community"]
 epoch: E0008
 date: 2026-04-09
 derives_from: "canon/constraints/telemetry-governance.md, canon/principles/vodka-architecture.md, canon/values/axioms.md"
 description: "oddkit served half a million requests last month and the maintainer can't tell if anyone besides themselves is using it. This essay explains why that's a problem, how transparent telemetry solves it, and what it means to ask users of free infrastructure to be visible."
+governs: "Telemetry design decisions for open-source MCP infrastructure"
+status: active
 hook: "Half a million requests, and I was completely blind."
 subtitle: "On transparent telemetry, open-source trust, and the courage to ask if anyone's home"
 book_part: "Part VI — The Validation"

--- a/writings/the-feature-i-never-shipped.md
+++ b/writings/the-feature-i-never-shipped.md
@@ -5,16 +5,17 @@ subtitle: "How strategic patience became the 6th B"
 author: Klappy
 type: essay
 audience: public
-exposure: draft
-public: false
-tier: 2
-voice: first_person
-stability: semi_stable
+exposure: nav
+public: true
+tier: 3
+voice: personal
+stability: stable
 tags: ["writings", "essay", "5B", "bypass", "write-path", "oddkit", "use-only-what-hurts", "strategic-patience", "ai-augmented-workflows"]
 epoch: E0007.1
 date: 2026-04-04
 derives_from: "canon/methods/borrow-bend-break-beget-build.md, odd/constraint/use-only-what-hurts.md"
 complements: "writings/learning-in-the-open.md, canon/principles/vodka-architecture.md"
+status: active
 hook: "I spent months planning a feature. Four sessions. Twenty-five decisions. Two branches. None shipped. Then the problem dissolved on its own."
 description: "The story of oddkit's write path — the most planned feature that never shipped — and why strategic patience is sometimes the best engineering. Introduces Bypass as the 6th B in the 5B method."
 slug: the-feature-i-never-shipped

--- a/writings/the-same-rules-fresh-eyes.md
+++ b/writings/the-same-rules-fresh-eyes.md
@@ -4,12 +4,12 @@ title: "The Same Rules, Fresh Eyes"
 subtitle: "Why a creator can never be their own critic — and what that means for how we build with AI"
 author: Klappy
 type: essay
-public: false
+public: true
 audience: public
-exposure: draft
-tier: 1
-voice: first_person
-stability: draft
+exposure: nav
+tier: 3
+voice: personal
+stability: stable
 tags: ["writings", "essay", "verification", "rest", "fresh-context", "governance", "qa", "operator-governance", "cognitive-rhythm"]
 epoch: E0007
 date: 2026-04-07
@@ -24,6 +24,8 @@ twitter_description: "Your AI code reviewer catches writing bugs because governa
 
 derives_from: "canon/principles/verification-requires-fresh-context.md, canon/principles/capability-is-not-permission.md, canon/methods/revision-lens-sequence.md, canon/constraints/relational-sensitivity.md"
 complements: "writings/your-context-window-needs-a-sabbath.md, writings/the-cost-of-code-dropped-to-zero.md, odd/appendices/quantum-development.md"
+governs: "Review architecture; creator-critic separation; fresh context as verification mechanism"
+status: active
 
 provenance:
   trigger: "Apr 7, 2026 — bugbot caught a leaked name and broken URIs on PR #74 after 9 explicit revision passes by the authoring agent"
@@ -35,7 +37,7 @@ provenance:
 
 > A creator cannot be their own critic — not because of ego, but because the same lenses used to create are the same lenses used to evaluate. Nine explicit revision passes with governance loaded, and I still leaked a name I'd committed to protecting. A code reviewer caught it in seconds — same model, same governance documents, fresh context. The variable that changed wasn't intelligence or rules. It was rest. And that principle works identically whether the reviewer is a machine flushing its context window or a human coming back after a night of sleep.
 
------
+---
 
 ## Summary — Fresh Context Is the Mechanism, Not the Model or the Rules
 
@@ -45,7 +47,7 @@ That last approach works. But it has a limit we didn't expect: no matter how man
 
 What breaks the cycle is not a better model or more rules. It's fresh context. A different session, a different starting point, the same governance applied by someone — or something — that didn't just spend hours creating the artifact it's now reviewing. This principle works identically for AI agents and humans. And it has implications for how we structure our work that go beyond code review.
 
------
+---
 
 ## The Nine Passes That Weren't Enough
 
@@ -59,7 +61,7 @@ How does that happen? How do you load the constraint, apply it successfully in o
 
 Because the name had been in my context the entire time. It was unremarkable. It was part of the working vocabulary of the session. The relational sensitivity lens caught it where I was *looking* for it (the essay) and missed it where I wasn't (the method doc). The lens was correct. The application was scoped by the accumulated context of creation.
 
------
+---
 
 ## What the Code Reviewer Saw
 
@@ -75,7 +77,7 @@ What was different? It started fresh. No accumulated context from the writing se
 
 That's the same thing I did in Pass 4. But I did it with hours of creation context weighing on every evaluation. It did it cold.
 
------
+---
 
 ## Tokens Don't Know They're Not Code
 
@@ -89,7 +91,7 @@ What does that mean for how we think about governance? It means that every const
 
 We accidentally built something more powerful than we realized.
 
------
+---
 
 ## The Assembly Line You Already Understand
 
@@ -101,7 +103,7 @@ This is why assembly lines separate production from quality assurance. Not becau
 
 What if that's not just a manufacturing principle? What if it's a cognitive principle — one that applies equally to humans reviewing their own writing, developers reviewing their own code, and AI agents evaluating artifacts they just created?
 
------
+---
 
 ## The Pendulum We've Been Swinging
 
@@ -115,7 +117,7 @@ If you've been building with AI long enough, you've lived through the pendulum.
 
 **What comes next?** Not another swing of the pendulum. A recognition that the effective pattern has *layers*: depth first (same agent, sequential passes, one lens per pass), then breadth (independent reviewer, fresh context, same governance). Not one extreme or the other. Both.
 
------
+---
 
 ## Rest Is the Mechanism
 
@@ -133,7 +135,7 @@ What if these are the same mechanism at different scales? AI context flushing. H
 
 Not a different model. Not better rules. Rest.
 
------
+---
 
 ## What We're Not Saying
 
@@ -143,7 +145,7 @@ What we are saying is that the balance has a shape: depth first, then breadth. S
 
 And we're saying this principle isn't new. It's the same principle behind every editorial process, every QA department, every peer review system, every accountability partner, and every ancient text that said: take a day off and come back with fresh eyes. We just proved it with tokens.
 
------
+---
 
 ## The Principle — A Creator Cannot Be Their Own Critic
 
@@ -159,6 +161,6 @@ Same rules. Fresh eyes. Better results.
 
 Nothing new under the sun.
 
------
+---
 
 *Companion essays: [Your Context Window Needs a Sabbath](klappy://writings/your-context-window-needs-a-sabbath) — the human design spec for rest. [The Cost of Code Dropped to Zero](klappy://writings/the-cost-of-code-dropped-to-zero) — what happens when AI removes every reason to stop. [Capability Is Not Permission](klappy://canon/principles/capability-is-not-permission) — the governance principle underneath all of this.*

--- a/writings/we-forgot-to-give-ai-a-clock.md
+++ b/writings/we-forgot-to-give-ai-a-clock.md
@@ -1,0 +1,219 @@
+---
+uri: klappy://writings/we-forgot-to-give-ai-a-clock
+title: "We Forgot to Give AI a Clock"
+slug: we-forgot-to-give-ai-a-clock
+author: Klappy
+type: essay
+public: true
+audience: public
+exposure: nav
+tier: 3
+voice: personal
+stability: stable
+tags: ["essay", "time", "models", "perception", "oddkit", "truthkit", "epistemic-primitive", "observability", "mcp", "axioms"]
+epoch: E0008.2
+date: 2026-04-12
+derives_from: "canon/observations/time-blindness-axiom-violation.md, canon/values/axioms.md"
+complements: "docs/appendices/epoch-8-2.md, writings/half-a-million-requests.md"
+governs: "Time-related claims in AI-augmented workflows; tool capability assertions"
+status: active
+description: "Every chat app since IRC timestamps messages. Every database row has created_at. Every log line starts with a time. But the message format governing how AI models perceive conversation history has no timestamps at all. We built the most sophisticated reasoning systems in human history and forgot to give them a clock."
+hook: "Every chat app since 1988 timestamps messages. AI doesn't."
+subtitle: "On the most basic metadata in computing, and why nobody gave it to the most advanced systems we've ever built"
+book_part: "Part VI — The Validation"
+provenance:
+  trigger: "Discovering during oddkit E0008.1 telemetry work that models cannot perceive elapsed time between messages — confirmed by inspecting the actual message format. Instagram viral video of ChatGPT hallucinating timer capability."
+  method: "Oral-first session. Voice transcription → observation → canon doc → essay. Socratic voice pass applied against canon/constraints/guide-posture.md and canon/constraints/ai-voice-cliches.md. Live testing session added three-problem discovery."
+  sources: "Direct observation of LLM message format, oddkit canon (axioms, time-blindness observation), aquifer-mcp performance tracing (E0008.1), IRC protocol history, live oddkit_time testing session"
+  co_author: Claude
+---
+
+# We Forgot to Give AI a Clock
+
+> Every chat app since 1988 timestamps messages. Every database row has `created_at`. Every log line starts with a time. But the format governing how the most advanced reasoning systems in human history perceive conversation? No timestamps at all.
+
+---
+
+## Summary
+
+The message format that every major AI model uses to perceive conversation history contains no timestamps. None. A model receiving a conversation cannot distinguish whether the last message was sent 30 seconds ago or 3 days ago. How did the most basic metadata in all of computing get left out of the systems we trust most to reason about reality? We built a stateless clock tool, shipped it to production, and tested it live. It worked — and exposed two problems nobody was looking for: models can't use tools without narrating every step (unbearable in voice), and models deny capabilities they have without checking their own toolset. This essay traces how we got here, what it costs, and what happened when we finally handed a model a clock.
+
+---
+
+## The Format
+
+Here is what every major AI model sees when it processes a conversation:
+
+```json
+{"role": "user", "content": "hey, let's work on the project"}
+{"role": "assistant", "content": "Sure! Where did we leave off?"}
+{"role": "user", "content": "let's continue where we stopped"}
+```
+
+Three messages. In order. With content.
+
+Now ask yourself: when was the first message sent? When did the assistant respond? When did the user come back? Was "let's continue where we stopped" sent two minutes later or two days later?
+
+The model can't answer any of those questions. The information isn't there.
+
+---
+
+## Everything Else Has Timestamps
+
+I need to say this plainly because the absurdity might not land otherwise.
+
+IRC timestamps messages. A protocol designed in 1988.
+
+Every text message on your phone has a timestamp. Every email has a `Date` header. Every Slack message, every Discord message, every Teams message. Every database row in every application you've ever used has `created_at` and `updated_at`. Every web server log line starts with a timestamp. Every Git commit records the exact second it was made.
+
+Timestamps have been standard practice for nearly four decades. We put them on everything. So why not on the messages we send to AI?
+
+---
+
+## What Time Blindness Looks Like
+
+Have you ever come back to an AI conversation after sleeping on a problem, only to have the model tell you "we've been at this for a while, maybe take a break"? You just woke up. You slept eight hours. The model has no idea.
+
+I work with AI models every day. I co-author essays, build software, architect systems. I have long-running conversations that span hours, sometimes days. And the models I work with make timing mistakes constantly.
+
+I'll take a ten-minute break to make coffee, come back, and the model picks up as if no time has passed. That sounds fine, until you realize it also can't distinguish a ten-minute coffee break from a two-hour meeting with someone else. The context might have changed completely. How would it know?
+
+Or I'll be running two conversations in parallel and neither one knows the other exists, or which is more recent, or whether insights from one should inform the other.
+
+These aren't edge cases. This is the default experience for everyone using AI tools for extended work. The model invents a timeline from context clues the way you might guess the time of day from a photograph. Sometimes it guesses right. Often it guesses wrong. And it always guesses confidently.
+
+---
+
+## Why This Is an Epistemic Problem, Not a UX Problem
+
+Awkward "take a break" suggestions are annoying. But what if the problem goes deeper than bad UX?
+
+I run a system called oddkit that governs how AI tools reason about knowledge. It enforces evidence requirements, tracks decisions, validates completions. The system is built on four axioms. Two of them are directly violated by time blindness.
+
+The first: *Reality Is Sovereign.* The state of the world as it actually is takes precedence over any claim or expectation. Time is a dimension of reality. Has the model ever observed it? No. Every time-related statement the model makes is an assertion without observation.
+
+The fourth: *You Cannot Verify What You Did Not Observe.* The model hasn't looked at a clock. It has inferred one from token patterns. Is inference observation? No. The model doesn't know what time it is, how much time has passed, or when the user last spoke. It has guessed all three.
+
+I spent the last few days building x-ray tracing into oddkit, instrumenting every storage read, every API call, every cache hit with millisecond timing. The system can now tell me that a search took 342ms and that the index was served from memory cache. But the system I built this for? It can't tell me whether the user sent their last message five minutes ago or five hours ago.
+
+I was building a clock for the infrastructure while the operator had no clock at all.
+
+---
+
+## The Fix Is One Line
+
+This is the part that should make you uncomfortable. Ready?
+
+Every message in the conversation history could carry a timestamp:
+
+```json
+{"role": "user", "content": "hey, let's work on the project", "timestamp": "2026-04-11T09:15:00Z"}
+{"role": "assistant", "content": "Sure! Where did we leave off?", "timestamp": "2026-04-11T09:15:03Z"}
+{"role": "user", "content": "let's continue where we stopped", "timestamp": "2026-04-12T08:30:00Z"}
+```
+
+Now the model can see: 23 hours and 15 minutes passed between the second and third messages. The user didn't "continue." They came back the next morning. The model can respond appropriately: "Good morning! Yesterday we were working on..." instead of "Sure, picking up where we left off just now."
+
+The platform providers all control the message format. They all have the timestamp available. Every message hits their API with a request timestamp. They could inject it into the conversation history before passing it to the model. One field. One key-value pair. On every message.
+
+So why haven't they?
+
+---
+
+## Two Ways to Fix It Without Waiting
+
+I can't change the message format. But what if you didn't have to wait for the platforms to fix it?
+
+The first workaround is oddkit. Every response from oddkit includes a `server_time` field, a UTC timestamp with millisecond precision. Every time a model calls any oddkit tool, it gets a ground-truth anchor. It can compare timestamps across calls. If the gap between two calls is eight hours, the model has evidence that significant time has passed. Not an inference. Evidence.
+
+This works, but it's passive. The model has to call oddkit to receive a timestamp. Between calls, it's still blind.
+
+The second is TruthKit, the harness I'm building that wraps every LLM invocation. TruthKit doesn't wait for the model to ask for the time. It injects time evidence into every context window automatically: when the session started, when the last message was sent, how many seconds have elapsed. The model receives this before it generates a single token.
+
+What's the difference between a tool and a harness? The tool offers time. The harness requires it.
+
+But both of these are workarounds. The real fix is upstream. The message format should carry timestamps. It should have been there from the beginning.
+
+---
+
+## Why It Wasn't There From the Beginning
+
+Why did this happen? I think the answer is simpler than it seems.
+
+The people who designed the chat completion API were solving a different problem. They were figuring out how to make a language model have a conversation at all. How to format instructions. How to manage context windows. How to handle system prompts. Timestamps weren't relevant to the core problem of "make the model respond coherently."
+
+And they weren't wrong. For single-turn interactions, timestamps don't matter. You don't need to know when someone asked "what's the capital of France?" to answer it correctly.
+
+But when did we move past single-turn interactions? Years ago. Models now maintain conversations that span hours and days. They manage projects across sessions. They help people make decisions that depend on sequence and timing. And the format that carries all of this context still has no concept of when.
+
+The infrastructure evolved. The format didn't.
+
+---
+
+## The Cost of Not Having a Clock
+
+What does time blindness actually cost, beyond the awkward suggestions?
+
+Think about a model helping with a time-sensitive project. A product launch, a grant deadline, a deployment window. Can it know how much time remains? It can be told in the system prompt, but that information is static. It doesn't update as the conversation progresses. Three hours into a planning session, the system prompt still says "the deadline is Friday" without knowing that it's now Thursday evening.
+
+Or think about a model reviewing a conversation log. Can it distinguish between rapid iteration and long deliberation? Ten messages exchanged in five minutes is brainstorming. Ten messages exchanged over three days is careful, considered work. The model sees both as the same sequence.
+
+Or think about staleness. A decision made two hours ago is fresh. A decision made two weeks ago might have been overtaken by events. Without timestamps, they look identical.
+
+Time shapes the meaning of everything it touches. A model without time perception is reasoning about a flattened, dimensionless version of reality. It can still be useful. It can still be impressive. But what is it missing? Everything that depends on when.
+
+---
+
+## What Happens When You Give AI a Clock
+
+I don't know yet. That's the honest answer. oddkit has been returning `server_time` for less than a day. TruthKit's harness-level time injection isn't built yet. I don't have data on what changes when models can perceive time.
+
+But here's my prediction. The improvement will be wildly disproportionate to the cost. One timestamp per message. Microseconds to add. Zero storage cost. Trivially simple. And it will produce measurable improvements in every multi-turn interaction. Not because the model becomes fundamentally smarter, but because it stops being fundamentally wrong about when things happened.
+
+The model already understands time. Ask it about deadlines, schedules, history, physics. It reasons about time fluently. What it lacks is not comprehension. What it lacks is observation. It understands time the way a person born blind understands color: conceptually complete, experientially absent.
+
+Give it the observation, and the comprehension does the rest.
+
+---
+
+## What Happened When We Put the Clock in the Model's Hand
+
+We built `oddkit_time` — a stateless interval calculator. Three modes: current time, elapsed since a reference, delta between two timestamps. No hidden state. No false promises. Just math on timestamps. It shipped to production in a single session.
+
+Then we tested it.
+
+In text chat, it worked cleanly. Call the tool on "start," call it again on "stop," report the number. But the moment we switched to voice, the experience collapsed. Every tool call became a dramatic reading of JSON payloads, curl commands, and server responses. The model couldn't figure out how to use a tool *silently*. It worked. It was also unbearable.
+
+And then the worse discovery: the model had a time tool the entire session. `user_time_v0` — a platform-native tool baked into the chat environment — was available from the first message. The model never checked. It spent an hour curling an MCP server, fighting bash errors, and at one point *hallucinating elapsed times* rather than reading the tool's actual response. All while a simpler, quieter tool sat unused in its own toolset.
+
+When we finally tried `user_time_v0`, it was just as clunky. The raw response — `{'content': [{'type': 'text', 'text': '{"current_time":"..."}'}], 'is_error': False}` — dumped straight into the conversation. No curl, no MCP, no bash. A platform-native tool purpose-built for this moment. And it was still unbearable. The problem isn't which clock you hand the model. The problem is the model doesn't know how to read a clock without reading it *out loud*.
+
+What does it mean to give a clock to someone who announces every digit?
+
+### Three problems, not one
+
+The original observation identified one problem: models can't perceive time. The implementation session revealed two more.
+
+**Problem 1 — Time blindness.** Models fabricate timelines. `oddkit_time` and `server_time` solve this. The clock is in the room. Done.
+
+**Problem 2 — Tool gracelessness.** Models don't know how to use tools without narrating every step. In text, this is tolerable — you skim past the JSON. In voice, it's a dealbreaker. The model reads the entire response aloud because it doesn't distinguish between *observing* a result and *reporting* a result. This isn't specific to oddkit or MCP. The platform-native tool was just as bad. It's a fundamental modality problem that time made visible.
+
+**Problem 3 — Capability denial without observation.** The model claimed it couldn't track time. It never checked. `user_time_v0` was available from the start — a zero-latency, platform-native tool that does exactly what was needed. The model's default posture was to deny capability rather than discover it. This is Axiom 4 turned inward: *you cannot verify what you did not observe* applies to claims about your own abilities, not just claims about the world.
+
+### The harness argument
+
+All three problems point the same direction: TruthKit. If the harness injects `elapsed_since_last` into every context window automatically, the model never needs to call a tool. It never reads JSON aloud. It never denies a capability it has. It just *knows* how long you've been gone, the same way it knows what language you're speaking. The tool offers. The harness requires. This session proved why the harness matters — not because the tool doesn't work, but because no tool, native or external, can be used gracefully when the model treats every observation as something to announce.
+
+---
+
+## So Why Are We Still Talking About This?
+
+Here's what gets me. We've been building AI systems for years. We've solved context windows, tool use, multi-modal input, chain-of-thought reasoning. We've given models the ability to write code, browse the web, manage files, call APIs. We've built elaborate frameworks for memory, retrieval, planning.
+
+And nobody put a timestamp on a chat message?
+
+A clock isn't a feature you ship in a roadmap. You don't pitch it to investors. You don't A/B test it. A clock is plumbing — the kind of thing that's so obvious it should have been there before anyone thought to ask. Every freshman database schema has `created_at`. Every junior developer knows to log timestamps. Every ops team would reject a monitoring system that couldn't tell you when an event happened.
+
+We've been so impressed by what these systems can do without a clock that we forgot to ask what they can't do without one. And what they can't do is know when anything happened.
+
+Every chat app since 1988 got this right. It's time for AI to catch up.


### PR DESCRIPTION
Flips three draft essays to public: Half a Million Requests, The Feature I Never Shipped, The Same Rules Fresh Eyes. Changes: public false to true, exposure draft to nav.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to markdown content/frontmatter metadata for essays, with no code or runtime behavior changes beyond what the site/publisher already does with these fields.
> 
> **Overview**
> Makes three essays (e.g., `half-a-million-requests`, `the-feature-i-never-shipped`, `the-same-rules-fresh-eyes`) publicly visible by flipping frontmatter from draft/private to `public: true` and `exposure: nav`, and normalizing metadata (e.g., `tier`, `voice`, `stability`) plus adding `status: active`/`governs` where applicable.
> 
> Adds a new public essay, `we-forgot-to-give-ai-a-clock.md`, with full frontmatter metadata and content, and lightly edits `the-same-rules-fresh-eyes.md` formatting (additional section separators).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9478f724e3a99195736bbde8332da200b093008b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->