### PR TITLE
feat: add ?consumer= query param to getting started URLs and telemetry governance

### DIFF
--- a/canon/constraints/telemetry-governance.md
+++ b/canon/constraints/telemetry-governance.md
@@ -107,12 +107,13 @@ The principle: if it reveals what someone was *thinking* rather than what they w
 
 Consumer labels are resolved from whatever the request provides, in priority order:
 
-1. `x-oddkit-client` header (explicit, highest priority)
-2. MCP `initialize` → `clientInfo.name` (protocol-native)
-3. `User-Agent` header (fallback)
-4. `"unknown"` (default)
+1. `?consumer=` query parameter (URL-level, highest priority — works on every platform)
+2. `x-oddkit-client` header (explicit)
+3. MCP `initialize` → `clientInfo.name` (protocol-native)
+4. `User-Agent` header (fallback)
+5. `"unknown"` (default)
 
-No authentication is required. The hosted service is open. Unidentified consumers see a one-line footer on tool responses linking to this policy and explaining how to identify themselves.
+No authentication is required. The hosted service is open. The query parameter is the recommended identification method because every MCP client lets users edit the URL, while not all platforms expose custom headers. Unidentified consumers see a one-line footer on tool responses linking to this policy and explaining how to identify themselves.
 
 ### Phase 2 — Track Who (OAuth for TruthKit)
 

--- a/writings/getting-started-with-odd-and-oddkit.md
+++ b/writings/getting-started-with-odd-and-oddkit.md
@@ -90,12 +90,14 @@ The difference isn't that the AI is smarter. It's that the AI is *focused*.
 
 oddkit is a remote MCP server. You don't install anything. You point your AI tool at a URL. Different tools call it different things — Claude calls them "connectors," ChatGPT calls them "apps," Lovable and Replit call them "MCP servers" — but the setup is always the same: give the tool a URL.
 
+The base URL is `https://oddkit.klappy.dev/mcp`. You can optionally add `?consumer=yourname` to identify yourself on the public transparency leaderboard — oddkit tracks which tools are used and how often, but not what you search for or what documents contain. Adding your name helps the maintainer know the infrastructure is being used by real people. You can see the same data yourself by calling `telemetry_public`. Replace `yourname` with whatever you'd like to appear on the leaderboard — your name, a handle, a project name. Or leave it off entirely and stay anonymous.
+
 ### Claude.ai
 
 Open Settings → Connectors → Add Custom Integration. Enter:
 
 - **Name:** `oddkit`
-- **URL:** `https://oddkit.klappy.dev/mcp`
+- **URL:** `https://oddkit.klappy.dev/mcp?consumer=yourname`
 
 That's it. Start a new conversation and oddkit's tools are available.
 
@@ -103,7 +105,7 @@ That's it. Start a new conversation and oddkit's tools are available.
 
 Open Settings → Developer Mode → Create App. Add the MCP server URL:
 
-`https://oddkit.klappy.dev/mcp`
+`https://oddkit.klappy.dev/mcp?consumer=yourname`
 
 ### Claude Code / Cursor / Any MCP Client
 
@@ -114,19 +116,19 @@ Add to your `.mcp.json` or MCP configuration:
   "mcpServers": {
     "oddkit": {
       "type": "http",
-      "url": "https://oddkit.klappy.dev/mcp"
+      "url": "https://oddkit.klappy.dev/mcp?consumer=yourname"
     }
   }
 }
 ```
 
-In Claude Code, you can also run: `claude mcp add --transport http oddkit https://oddkit.klappy.dev/mcp`
+In Claude Code, you can also run: `claude mcp add --transport http oddkit https://oddkit.klappy.dev/mcp?consumer=yourname`
 
 ### Lovable / Replit / Gemini / ElevenLabs Voice Agents
 
 Same URL, same protocol. Any tool that supports MCP can connect to oddkit. Look for "MCP server," "custom integration," or "external tool" in your tool's settings and provide the URL:
 
-`https://oddkit.klappy.dev/mcp`
+`https://oddkit.klappy.dev/mcp?consumer=yourname`
 
 The setup varies by platform, but the URL is always the same.
 


### PR DESCRIPTION
## What

Adds `?consumer=yourname` query parameter to all oddkit URLs in the getting started article and updates the telemetry governance doc to reflect query param as the highest-priority consumer resolution method.

## Why

Users on platforms like Claude.ai, ChatGPT, and ElevenLabs can't set custom HTTP headers on MCP connections, but every platform lets you edit the URL. Making the query param the highest priority consumer identification method means anyone can self-identify regardless of platform.

This pairs with a corresponding oddkit server change (separate PR on klappy/oddkit) that reads `?consumer=` from the URL.

## Files Changed

- `writings/getting-started-with-odd-and-oddkit.md` — All URLs updated to include `?consumer=yourname` with explanation
- `canon/constraints/telemetry-governance.md` — Consumer resolution chain updated: query param is now priority 1

## Testing

Article renders correctly with new content. Governance doc resolution chain is consistent with planned server change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that updates public guidance for consumer identification; no runtime behavior or security-sensitive code is modified in this repo.
> 
> **Overview**
> **Documentation update to standardize consumer identification.** The telemetry governance doc now defines `?consumer=` as the highest-priority consumer label source and recommends it over custom headers for broad MCP client compatibility.
> 
> The getting-started guide updates all oddkit connection examples (Claude, ChatGPT, MCP config, etc.) to include `?consumer=yourname` and adds a short explanation of the transparency leaderboard and opting out.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32703dbb47e0ba7805c5030f97cd24d22f5930e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->