### PR TITLE
feat: basic encoding-type governance for oddkit baseline

### DIFF
--- a/odd/encoding-types/constraint.md
+++ b/odd/encoding-types/constraint.md
@@ -1,0 +1,52 @@
+---
+uri: klappy://odd/encoding-types/constraint
+title: "Encoding Type: Constraint (C)"
+audience: docs
+exposure: nav
+tier: 2
+voice: neutral
+stability: semi_stable
+tags: ["odd", "oddkit", "encode", "dolche", "constraint", "encoding-type"]
+epoch: E0008
+date: 2026-04-15
+derives_from: "docs/oddkit/proactive/dolche-vocabulary.md"
+governs: "oddkit_encode parsing and quality scoring for type C"
+status: active
+---
+
+# Encoding Type: Constraint (C)
+
+> What now governs future work. Rules, boundaries, and non-negotiables.
+
+---
+
+## Summary — The Binding Layer
+
+Constraints bind future behavior and prevent repeated mistakes. A constraint without enforcement is a suggestion.
+
+---
+
+## Type Identity
+
+| Field | Value |
+|---|---|
+| Letter | C |
+| Name | Constraint |
+
+---
+
+## Field Schema
+
+| Field | Recommended | Description |
+|---|---|---|
+| type | yes | Always `C` |
+| title | yes | Short summary of the constraint |
+| body | yes | What is bound, limited, or prohibited |
+
+---
+
+## Trigger Words (Fallback Classification)
+
+```
+must, must not, shall, never, always, required, prohibited, constraint, cannot
+```

--- a/odd/encoding-types/decision.md
+++ b/odd/encoding-types/decision.md
@@ -1,0 +1,52 @@
+---
+uri: klappy://odd/encoding-types/decision
+title: "Encoding Type: Decision (D)"
+audience: docs
+exposure: nav
+tier: 2
+voice: neutral
+stability: semi_stable
+tags: ["odd", "oddkit", "encode", "dolche", "decision", "encoding-type"]
+epoch: E0008
+date: 2026-04-15
+derives_from: "docs/oddkit/proactive/dolche-vocabulary.md"
+governs: "oddkit_encode parsing and quality scoring for type D"
+status: active
+---
+
+# Encoding Type: Decision (D)
+
+> What was chosen. Explicit commitments with rationale that close options and create direction.
+
+---
+
+## Summary — The Highest-Stakes Artifact Type
+
+Decisions close options and create direction. They constrain all subsequent work, making them the most important artifacts to capture.
+
+---
+
+## Type Identity
+
+| Field | Value |
+|---|---|
+| Letter | D |
+| Name | Decision |
+
+---
+
+## Field Schema
+
+| Field | Recommended | Description |
+|---|---|---|
+| type | yes | Always `D` |
+| title | yes | Short summary of the decision |
+| body | yes | What was chosen and why |
+
+---
+
+## Trigger Words (Fallback Classification)
+
+```
+decided, decision, chose, choosing, selected, committed to, going with
+```

--- a/odd/encoding-types/handoff.md
+++ b/odd/encoding-types/handoff.md
@@ -1,0 +1,52 @@
+---
+uri: klappy://odd/encoding-types/handoff
+title: "Encoding Type: Handoff (H)"
+audience: docs
+exposure: nav
+tier: 2
+voice: neutral
+stability: semi_stable
+tags: ["odd", "oddkit", "encode", "dolche", "handoff", "encoding-type"]
+epoch: E0008
+date: 2026-04-15
+derives_from: "docs/oddkit/proactive/dolche-vocabulary.md"
+governs: "oddkit_encode parsing and quality scoring for type H"
+status: active
+---
+
+# Encoding Type: Handoff (H)
+
+> What comes next and what context the next session needs.
+
+---
+
+## Summary — The Continuity Layer
+
+Handoffs transfer state across session boundaries. A session without handoffs forces the next session to reconstruct context from scratch.
+
+---
+
+## Type Identity
+
+| Field | Value |
+|---|---|
+| Letter | H |
+| Name | Handoff |
+
+---
+
+## Field Schema
+
+| Field | Recommended | Description |
+|---|---|---|
+| type | yes | Always `H` |
+| title | yes | Short summary of what comes next |
+| body | yes | What needs to happen and what context is needed |
+
+---
+
+## Trigger Words (Fallback Classification)
+
+```
+next session, next step, todo, follow up, blocked by, waiting on, continue, remaining, handoff
+```

--- a/odd/encoding-types/how-to-write-encoding-types.md
+++ b/odd/encoding-types/how-to-write-encoding-types.md
@@ -1,0 +1,232 @@
+---
+uri: klappy://odd/encoding-types/how-to-write-encoding-types
+title: "How to Write an Encoding Type Governance Article"
+audience: docs
+exposure: nav
+tier: 1
+voice: neutral
+stability: semi_stable
+tags: ["odd", "oddkit", "encode", "dolche", "encoding-type", "governance", "meta", "tsv", "prompt-over-code", "template"]
+epoch: E0008
+date: 2026-04-15
+derives_from: "canon/principles/prompt-over-code.md, canon/principles/vodka-architecture.md, docs/oddkit/proactive/dolche-vocabulary.md"
+complements: "odd/encoding-types/decision.md, odd/encoding-types/observation.md, odd/encoding-types/learning.md, odd/encoding-types/constraint.md, odd/encoding-types/handoff.md"
+governs: "All encoding-type governance articles, server parsing of encoding-type docs, custom type creation"
+status: active
+---
+
+# How to Write an Encoding Type Governance Article
+
+> Every encoding type in oddkit — default or custom — is defined by a governance article, not by server code. The server discovers these articles at encode time, extracts their structure, builds parsers and quality scorers from what it finds. This document describes the recommended structure for encoding-type governance articles. The more structure the server finds, the better the results — but missing sections degrade gracefully, they don't break anything. Write the article well and the server handles the rest. No deployment. No code change. Prompt over code applied to the vocabulary itself.
+
+---
+
+## Summary — One Article Per Type, Machine-Extractable Structure
+
+Each encoding type gets its own governance article. The article serves two audiences simultaneously: humans who need to understand the type, and the server that needs to parse and score it. The structure is designed for both — readable prose with predictable section headers and formats that the server can extract mechanically.
+
+The server looks for specific section headers and extracts content from them. The more of this structure the article includes, the richer the server's parsing and quality scoring. Missing sections don't cause failures — the server extracts what it finds and skips what it doesn't. But a fully structured article produces the best results.
+
+---
+
+## Recommended File Location
+
+All encoding-type governance articles live under `odd/encoding-types/`. The filename is the type name in lowercase:
+
+```
+odd/encoding-types/decision.md
+odd/encoding-types/observation.md
+odd/encoding-types/learning.md
+odd/encoding-types/constraint.md
+odd/encoding-types/handoff.md
+odd/encoding-types/prayer-request.md    (custom example)
+```
+
+---
+
+## Recommended Frontmatter
+
+Standard oddkit frontmatter with these conventions for best results:
+
+| Field | Convention |
+|---|---|
+| uri | `klappy://odd/encoding-types/{type-name}` |
+| tags | Should include `encoding-type` — this is the tag the server searches for |
+| governs | Should reference `oddkit_encode parsing and quality scoring for type {letter}` |
+| derives_from | Should include `docs/oddkit/proactive/dolche-vocabulary.md` |
+
+The `encoding-type` tag is the discovery mechanism. The server searches for articles tagged `encoding-type` at encode time. Without this tag, the server won't discover the type — but nothing breaks.
+
+---
+
+## Recommended Sections
+
+The server extracts from these section headers when present. Including them produces the best parsing and quality scoring results. Missing sections degrade gracefully — the server uses what it finds.
+
+### Section: Blockquote (opening)
+
+The document's opening blockquote defines the type in one to three sentences. This is surfaced to the model as the type's description. Keep it concise — it appears in the encode response alongside every other type's description.
+
+### Section: `## Type Identity`
+
+A markdown table with exactly these rows:
+
+```markdown
+## Type Identity
+
+| Field | Value |
+|---|---|
+| Letter | {single uppercase letter} |
+| Name | {type name} |
+| Priority | {relative priority description} |
+```
+
+The server extracts `Letter` and `Name` from this table. `Letter` should be a single uppercase character. `Name` is the human-readable type name.
+
+### Section: `## Field Schema`
+
+Defines the fields for this type. The serialization format (TSV, JSON, etc.) is governed separately by `odd/encoding-types/serialization-format.md`. This section defines semantics only — field names, requirements, and descriptions.
+
+For best results, include:
+
+1. A field listing showing the field order:
+
+```
+{letter}	{field1}	{field2}	{field3}	...
+```
+
+2. A markdown table defining each field:
+
+```markdown
+| Field | Recommended | Description |
+|---|---|---|
+| type | yes | Always `{letter}` |
+| {field1} | yes/no | {description} |
+| {field2} | yes/no | {description} |
+```
+
+3. A concrete example showing a real-world encoding of this type.
+
+The server extracts field names, recommended/optional status, and field order from this section. The example is surfaced to the model as teaching material.
+
+**Field conventions:**
+
+- First field is always `type` (the letter)
+- Second field is always `title` (≤12 words) — recommended for all types
+- Third field is always `body` (the substance) — recommended for all types
+- Remaining fields are type-specific — defined by each type's governance doc
+- How fields are serialized (delimiter, escaping, file extension) is governed by `odd/encoding-types/serialization-format.md`
+
+### Section: `## Trigger Words (Fallback Classification)`
+
+A code block containing comma-separated trigger words:
+
+```markdown
+## Trigger Words (Fallback Classification)
+
+When encode input is unstructured (not TSV), these trigger words classify a paragraph as {Name}:
+
+\```
+word1, word2, phrase one, phrase two
+\```
+```
+
+The server extracts these words and builds a regex pattern: `/\b(word1|word2|phrase one|phrase two)\b/i`. This regex is used only for fallback classification of unstructured input. On the primary TSV path, the type letter is the classifier.
+
+### Section: `## Quality Criteria`
+
+A markdown table defining quality checks:
+
+```markdown
+## Quality Criteria
+
+Each criterion adds 1 to the quality score (max {N}):
+
+| Criterion | Check | Gap message if missing |
+|---|---|---|
+| {name} | {what the server checks} | "{message returned to model}" |
+```
+
+Followed by a quality levels table:
+
+```markdown
+Quality levels:
+
+| Score | Level | Status |
+|---|---|---|
+| {high range} | strong | recorded |
+| {mid} | adequate | recorded |
+| {low} | weak | draft |
+| {lowest} | insufficient | draft |
+```
+
+The server extracts criterion names, check descriptions, and gap messages. Quality levels define the score-to-status mapping.
+
+**Quality check conventions:**
+
+- Checks should reference specific columns ("Rationale column is non-empty")
+- Checks should be mechanically testable (word count, non-empty, contains keyword)
+- Gap messages should be actionable ("Add why this was chosen" not "Rationale missing")
+- Max score equals the number of criteria rows
+
+---
+
+## Additional Sections
+
+These sections improve the article's value for human readers and model teaching. The server does not extract from them directly, but they contribute to the article's overall usefulness.
+
+- `## Summary` — expanded description of the type
+- `## What Makes a Good {Type} Encoding` — prose guidance for models and operators
+- `## See Also` — links to related governance docs
+
+---
+
+## Writing a Custom Encoding Type
+
+Custom types follow this identical structure. A pastoral knowledge base adding "Prayer Request" writes:
+
+```
+odd/encoding-types/prayer-request.md
+```
+
+With frontmatter tag `encoding-type`, a Type Identity table with `Letter: P`, a field schema, trigger words, and quality criteria. The server discovers it on the next encode call, parses P-typed rows against whatever schema it finds, scores against whatever criteria are defined. No server change.
+
+**Conventions for custom types:**
+
+- Letter should not collide with existing types (D, O, L, C, H, E)
+- Letter should be a single uppercase character
+- Including all recommended sections produces the best results
+- Custom types are scoped to the knowledge base that defines them — they don't affect other KBs
+
+---
+
+## The Server's Extraction Contract
+
+At encode time, the server:
+
+1. Searches for articles tagged `encoding-type`
+2. For each article, extracts from the recommended sections when present:
+   - Letter and Name from `## Type Identity`
+   - Field schema from `## Field Schema`
+   - Trigger words from `## Trigger Words (Fallback Classification)`
+   - Quality criteria from `## Quality Criteria`
+3. Builds a per-type parser and scorer from whatever fields it finds
+4. Surfaces the type definitions (letter, name, blockquote description, field schema, example) in the encode response to teach the model
+
+Missing sections degrade gracefully. A type without quality criteria still parses — it just can't score. A type without trigger words still works on the primary path — it just can't classify unstructured fallback input. A type without a field schema can still be identified by letter but can't validate field structure. The more complete the governance doc, the better the results.
+
+---
+
+## Discoverability
+
+This article exists so that any search for "how to write encoding type," "custom encoding type," "add new encode type," "encoding-type template," "encoding governance format," or "extend DOLCHE" surfaces this guide.
+
+---
+
+## See Also
+
+- [Encoding Serialization Format](klappy://odd/encoding-types/serialization-format) — how fields are serialized (TSV default)
+- [DOLCHE Vocabulary](klappy://docs/oddkit/proactive/dolche-vocabulary) — the six-dimension framework
+- [Prompt Over Code](klappy://canon/principles/prompt-over-code) — the principle this entire mechanism implements
+- [Vodka Architecture](klappy://canon/principles/vodka-architecture) — why the server stays thin
+- [Encoding Type: Decision](klappy://odd/encoding-types/decision) — the reference implementation

--- a/odd/encoding-types/how-to-write-encoding-types.md
+++ b/odd/encoding-types/how-to-write-encoding-types.md
@@ -6,7 +6,7 @@ exposure: nav
 tier: 1
 voice: neutral
 stability: semi_stable
-tags: ["odd", "oddkit", "encode", "dolche", "encoding-type", "governance", "meta", "tsv", "prompt-over-code", "template"]
+tags: ["odd", "oddkit", "encode", "dolche", "encoding-type-meta", "governance", "meta", "tsv", "prompt-over-code", "template"]
 epoch: E0008
 date: 2026-04-15
 derives_from: "canon/principles/prompt-over-code.md, canon/principles/vodka-architecture.md, docs/oddkit/proactive/dolche-vocabulary.md"

--- a/odd/encoding-types/learning.md
+++ b/odd/encoding-types/learning.md
@@ -1,0 +1,52 @@
+---
+uri: klappy://odd/encoding-types/learning
+title: "Encoding Type: Learning (L)"
+audience: docs
+exposure: nav
+tier: 2
+voice: neutral
+stability: semi_stable
+tags: ["odd", "oddkit", "encode", "dolche", "learning", "encoding-type"]
+epoch: E0008
+date: 2026-04-15
+derives_from: "docs/oddkit/proactive/dolche-vocabulary.md"
+governs: "oddkit_encode parsing and quality scoring for type L"
+status: active
+---
+
+# Encoding Type: Learning (L)
+
+> What was understood from the observations. Interpretation with evidence.
+
+---
+
+## Summary — The Interpretation Layer
+
+Learnings connect observations to meaning. A learning without an observation is speculation. A learning with an observation is knowledge.
+
+---
+
+## Type Identity
+
+| Field | Value |
+|---|---|
+| Letter | L |
+| Name | Learning |
+
+---
+
+## Field Schema
+
+| Field | Recommended | Description |
+|---|---|---|
+| type | yes | Always `L` |
+| title | yes | Short summary of what was learned |
+| body | yes | What was understood and why it matters |
+
+---
+
+## Trigger Words (Fallback Classification)
+
+```
+learned, realized, discovered, understood, found that, turns out, insight
+```

--- a/odd/encoding-types/observation.md
+++ b/odd/encoding-types/observation.md
@@ -1,0 +1,52 @@
+---
+uri: klappy://odd/encoding-types/observation
+title: "Encoding Type: Observation (O)"
+audience: docs
+exposure: nav
+tier: 2
+voice: neutral
+stability: semi_stable
+tags: ["odd", "oddkit", "encode", "dolche", "observation", "encoding-type"]
+epoch: E0008
+date: 2026-04-15
+derives_from: "docs/oddkit/proactive/dolche-vocabulary.md"
+governs: "oddkit_encode parsing and quality scoring for type O"
+status: active
+---
+
+# Encoding Type: Observation (O)
+
+> What was seen or noticed. Raw facts without interpretation.
+
+---
+
+## Summary — The Evidence Layer
+
+Observations describe reality as encountered, not reality as theorized. They are the foundation that Learnings, Decisions, and Constraints build on.
+
+---
+
+## Type Identity
+
+| Field | Value |
+|---|---|
+| Letter | O |
+| Name | Observation |
+
+---
+
+## Field Schema
+
+| Field | Recommended | Description |
+|---|---|---|
+| type | yes | Always `O` |
+| title | yes | Short summary of what was observed |
+| body | yes | What was seen, measured, or encountered |
+
+---
+
+## Trigger Words (Fallback Classification)
+
+```
+observed, noticed, saw, found, measured, detected, appeared, showed
+```

--- a/odd/encoding-types/serialization-format.md
+++ b/odd/encoding-types/serialization-format.md
@@ -6,7 +6,7 @@ exposure: nav
 tier: 2
 voice: neutral
 stability: semi_stable
-tags: ["odd", "oddkit", "encode", "dolche", "tsv", "format", "serialization", "encoding-type", "governance", "storage"]
+tags: ["odd", "oddkit", "encode", "dolche", "tsv", "format", "serialization", "governance", "storage"]
 epoch: E0008
 date: 2026-04-15
 derives_from: "docs/oddkit/proactive/dolche-vocabulary.md, odd/encoding-types/how-to-write-encoding-types.md, canon/principles/prompt-over-code.md"

--- a/odd/encoding-types/serialization-format.md
+++ b/odd/encoding-types/serialization-format.md
@@ -1,0 +1,122 @@
+---
+uri: klappy://odd/encoding-types/serialization-format
+title: "Encoding Serialization Format — TSV as Default Wire and Storage Format"
+audience: docs
+exposure: nav
+tier: 2
+voice: neutral
+stability: semi_stable
+tags: ["odd", "oddkit", "encode", "dolche", "tsv", "format", "serialization", "encoding-type", "governance", "storage"]
+epoch: E0008
+date: 2026-04-15
+derives_from: "docs/oddkit/proactive/dolche-vocabulary.md, odd/encoding-types/how-to-write-encoding-types.md, canon/principles/prompt-over-code.md"
+complements: "odd/encoding-types/decision.md, odd/encoding-types/observation.md, odd/encoding-types/learning.md, odd/encoding-types/constraint.md, odd/encoding-types/handoff.md, odd/encoding-types/question.md"
+governs: "How encoding type fields are serialized for input, output, and storage"
+status: active
+---
+
+# Encoding Serialization Format — TSV as Default Wire and Storage Format
+
+> Encoding types define what fields exist. This document defines how those fields are serialized — the wire format between model and server, and the storage format for accumulated encodings. The default is TSV. The choice is governed by this document, not by the encoding-type docs, so the format can change independently of the type definitions.
+
+---
+
+## Summary — Semantics and Serialization Are Independent Axes
+
+Each encoding-type governance doc defines a field schema: field names, which are recommended, descriptions, and quality criteria. This document defines how those fields become bytes — how the model writes them, how the server reads them, and how they're stored for later processing.
+
+Separating these concerns means: adding a new encoding type never requires thinking about serialization. Changing the serialization format never requires updating type definitions. Each axis evolves independently through its own governance doc.
+
+---
+
+## Default Format: TSV
+
+Tab-separated values. One row per encoding artifact. First field is always the type letter.
+
+```
+{type_letter}\t{field_1}\t{field_2}\t{field_3}\t...
+```
+
+Field order follows the field schema defined in each encoding type's governance doc.
+
+### Why TSV
+
+TSV is the default because it optimizes for the full lifecycle of encoding data — from model output through server parsing to edge-scale bulk processing.
+
+**Parsing simplicity:** Split on `\t`. No parsing library. No escaping rules. The server, the model, and bulk processors all use the same trivial operation.
+
+**Determinism:** Tab almost never appears in natural language prose. CSV fails here — commas appear constantly, creating escaping ambiguity. TSV rows parse identically regardless of content.
+
+**Line-streamable:** One row per line. Read a million rows by reading a million lines. No structural parsing, no bracket matching, no DOM traversal.
+
+**Human readable:** Open in any text editor, spreadsheet app, or terminal. `cat`, `grep`, `awk`, `cut` all work natively. Debugging at 2am doesn't require tooling.
+
+**Concatenatable:** `cat *.tsv > combined.tsv` produces a valid TSV file. Hundreds of session files merge into one bulk-processable dataset with zero transformation.
+
+**Git-diffable:** One encoding per line. Diffs show exactly which encodings changed.
+
+**Edge-efficient:** Cloudflare Workers can stream-process TSV from R2 line-by-line with zero dependencies. No query engine (vs. SQL/D1), no parser (vs. JSON/markdown), no escaping logic (vs. CSV).
+
+### Conventions
+
+- One artifact per line
+- Fields separated by tab (`\t`)
+- First field is always the type letter (D, O, L, C, H, Q, or any custom type)
+- Field order follows the encoding type's field schema
+- Empty optional fields use empty string (consecutive tabs: `\t\t`)
+- No header row — the type letter identifies the schema
+- Newlines within field values should be escaped as `\n` (literal backslash-n) or replaced with a space
+- Files use `.tsv` extension
+
+### Example — Mixed-Type Encoding
+
+A single encode call with multiple types:
+
+```
+D	TSV as encode format	Governance defines TSV as the serialization format for encode input and storage.	Deterministic parsing, edge-efficient, human-readable, concatenatable.	JSON, CSV, markdown, SQL	permanent
+O	Deno user-agent was 39% of traffic	Deno/2.1.4 accounted for 2,631 of 6,753 total tool calls.	telemetry_public SQL query	verified
+L	Platform-agnostic ID requires URL-level mechanisms	Headers vary by platform. URLs are universal.	O: Labeled consumers only got credit for initialize events	general
+C	Server must not hardcode encoding keywords	Type vocabulary is extensible via governance, not code.	D: Governance-driven encode architecture	permanent
+H	Implement TSV parsing in encode handler	Replace detectEncodeType regex with governance-driven field parsing.		next session
+Q	Should encode search canon internally?	Internal search guarantees discovery but adds latency.	D: Governance-driven encode architecture	important
+```
+
+---
+
+## Fallback: Unstructured Input
+
+When encode input is not TSV (models that haven't learned the format), the server falls back to paragraph splitting and dynamic regex classification from governance-defined trigger words. The encode response includes the TSV format specification, teaching the model for subsequent calls.
+
+The fallback is a teaching mechanism, not a permanent path. Models converge on TSV after seeing the format in the encode response.
+
+---
+
+## Storage Patterns
+
+**Session files:** One `.tsv` file per session, all types interleaved chronologically. The narrative order is preserved — what was observed, then decided, then constrained flows naturally.
+
+**Bulk processing:** Concatenate session files. Stream line-by-line. Filter by type letter in the first field. No schema changes needed across files — the type letter self-identifies the field schema.
+
+**Arbitration at scale:** CF Workers read `.tsv` files from R2, stream-process rows, apply type-specific logic based on the first field. Millions of rows, hundreds of files, zero parsing dependencies.
+
+---
+
+## Changing the Format
+
+This document governs the serialization format. To change it — from TSV to JSON lines, CSV, or any other format — update this document. The encoding-type governance docs do not change because they define field semantics, not serialization.
+
+The server reads this governance doc (or a format configuration) to know how to parse encode input. The same encoding-type field schemas work with any serialization format that can represent named fields.
+
+---
+
+## Discoverability
+
+This article exists so that any search for "encode format," "TSV," "encoding serialization," "encode storage format," "encode wire format," "how encode input is structured," or "encode file format" surfaces this document.
+
+---
+
+## See Also
+
+- [How to Write an Encoding Type](klappy://odd/encoding-types/how-to-write-encoding-types) — defines field schemas independent of format
+- [DOLCHE Vocabulary](klappy://docs/oddkit/proactive/dolche-vocabulary) — the six-dimension framework
+- [Prompt Over Code](klappy://canon/principles/prompt-over-code) — format governed by document, not by code


### PR DESCRIPTION
## E0008 — Governance-Driven Encode Types

Basic encoding-type governance for the oddkit baseline. Protocol-level docs plus minimal type definitions for the five core DOLCHE types.

### What this adds

**Protocol docs** (shared with TruthKit):
- `odd/encoding-types/how-to-write-encoding-types.md` — how the server discovers and parses type governance
- `odd/encoding-types/serialization-format.md` — TSV as default wire/storage format

**Basic type docs** (D, O, L, C, H):
- Type identity (letter + name)
- 3-field schema (type, title, body)
- Trigger words for fallback classification
- No quality criteria, no type-specific fields, no prose guidance

### Bifurcation

TruthKit (private, `klappy/truthkit-kb`) supersedes these with richer governance:
- Type-specific fields (rationale, alternatives, reversibility for D; source, verifiability for O; etc.)
- Per-type quality criteria with gap messages
- Prose guidance and detailed examples
- Question (Q) as first DOLCHE extension type

Same server. Same encode handler. Different canon. Different product.

### Architecture

See `klappy/truthkit-kb/docs/architecture/encode-architecture-problem-and-gaps.md` for the full problem statement and alternatives analysis.

Key decisions:
- Encoding types define field semantics (what fields exist per type)
- Serialization format defines how fields are serialized (independent axis)
- Server discovers type governance via `encoding-type` tag at encode time
- Dynamic regex from trigger words handles unstructured fallback
- Per-type quality scoring from governance-defined criteria

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only change with no runtime code modifications; risk is limited to downstream consumers relying on these documents’ structure and wording.
> 
> **Overview**
> Adds governance documentation under `odd/encoding-types/` that defines how encoding types are discovered and interpreted from docs, plus a separate spec that standardizes TSV as the default wire/storage format.
> 
> Introduces baseline governance articles for the five core DOLCHE types (`D`, `O`, `L`, `C`, `H`), each providing type identity, a minimal `type/title/body` field schema, and trigger words for fallback classification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c3c9146dd5a6e8095521e99113347544df177c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->