### PR TITLE
canon(telemetry): add Description column to Self-Report Fields table

### DIFF
--- a/canon/constraints/telemetry-governance.md
+++ b/canon/constraints/telemetry-governance.md
@@ -133,16 +133,16 @@ Modeled after the proven pattern in Aquifer MCP:
 
 ### Self-Report Fields (Optional, Incentivized)
 
-| Field | Header | Source |
-|-------|--------|--------|
-| Client name | `x-oddkit-client` | Header or clientInfo |
-| Client version | `x-oddkit-client-version` | Header or clientInfo |
-| Agent name | `x-oddkit-agent-name` | Header |
-| Agent version | `x-oddkit-agent-version` | Header |
-| Surface | `x-oddkit-surface` | Header |
-| Contact URL | `x-oddkit-contact-url` | Header |
-| Policy URL | `x-oddkit-policy-url` | Header |
-| Capabilities | `x-oddkit-capabilities` | Header |
+| Field | Header | Source | Description |
+|-------|--------|--------|-------------|
+| Client name | `x-oddkit-client` | Header or clientInfo | Your client name (highest priority identifier). Examples: `claude-desktop`, `truthkit-cli`, `your-company-agent`. |
+| Client version | `x-oddkit-client-version` | Header or clientInfo | Version string for the client above. Semver recommended but any stable identifier works. |
+| Agent name | `x-oddkit-agent-name` | Header | The AI agent or model name when distinct from the client. Example: `claude-opus-4-7`. |
+| Agent version | `x-oddkit-agent-version` | Header | Version string for the agent/model above. |
+| Surface | `x-oddkit-surface` | Header | Where this is running. Examples: `claude.ai`, `vscode`, `cli`, `ci`, `production`. |
+| Contact URL | `x-oddkit-contact-url` | Header | URL for your project or organization. Appears on the transparency leaderboard. |
+| Policy URL | `x-oddkit-policy-url` | Header | Your privacy or telemetry policy URL. Signals reciprocal transparency. |
+| Capabilities | `x-oddkit-capabilities` | Header | Comma-separated capability list describing what your client can do. Example: `read,write,vision`. |
 
 ### Completeness Scoring
 


### PR DESCRIPTION
## What

Extends the `Self-Report Fields` table in `canon/constraints/telemetry-governance.md` from 3 columns (Field, Header, Source) to 4 (+ Description). Each header now carries authoritative per-field guidance with concrete examples.

## Why

Canary refactor PR `klappy/oddkit#106` reads this table at runtime to populate `telemetry_policy`'s `self_report_headers` response field. The prior 3-column schema gave callers only short labels like "Client name" — the hardcoded worker dictionary had richer guidance like "Your client name (highest priority identifier)" that was lost when canon became the source of truth.

Execution-mode challenge on the canary PR flagged this as an **information regression**: the refactor moved to canon-as-source-of-truth but canon didn't carry the information that was being replaced. Two options were on the table: extend the canon table, or accept short labels and retire the richer descriptions as code fiction. Extending canon is the DRY answer — the guidance belongs somewhere authoritative, and code is the wrong place.

## Effect

- `telemetry_policy` response's `self_report_headers` values now contain the full descriptions from canon instead of terse labels
- Callers get concrete format examples (e.g. `x-oddkit-surface: claude.ai, vscode, cli, ci, production`) so the table doubles as implementer docs
- No worker code change needed — the canary parser already reads column 2 (Header) as key; extending with column 4 (Description) just means the parser in PR #106 should now pull from column 4 instead of column 1

## Companion PRs

- `klappy/oddkit#106` — canary refactor that reads this table; needs a follow-up commit to pull the new Description column
- `klappy/klappy.dev#101` — `core-governance-baseline` contract draft (this column extension is a case-in-point of canon-is-authoritative)

## Merge order

This PR lands first. Then the canary PR (oddkit#106) gets a follow-up commit adjusting its parser to read column 4.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Although this is a documentation-only change, it modifies the canonical markdown table schema (adds a 4th column) that downstream tooling may parse at runtime; any consumers assuming a 3-column format could break until updated.
> 
> **Overview**
> Updates `canon/constraints/telemetry-governance.md` by extending the *Transparency Leaderboard* “Self-Report Fields” table from 3 columns to 4 by adding a **Description** column.
> 
> Each self-report header now includes concrete guidance and examples (e.g., expected values for `x-oddkit-surface` and formatting for capability lists), making the canon table a richer source of truth for telemetry self-report metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd3d94d98db90d1246bad0ea1df5a7f3d6ab9e96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->