### PR TITLE
canon: DOLCHEO cleanup — supersede DOLCHE doc, note O/O-open intentional collision

### DIFF
--- a/docs/oddkit/proactive/dolche-vocabulary.md
+++ b/docs/oddkit/proactive/dolche-vocabulary.md
@@ -13,10 +13,15 @@ supersedes: "docs/oddkit/proactive/oldc-h-vocabulary.md"
 derives_from: "canon/values/axioms.md, docs/oddkit/proactive/continuous-encoding.md, docs/oddkit/proactive/encode-does-not-persist.md"
 complements: "docs/oddkit/proactive/posture-lapse.md, docs/oddkit/proactive/proactive-session-close.md, odd/ledger/project-journal-best-practices.md"
 governs: "All session capture, project journal entries, and encode invocations"
-status: active
+status: superseded
+superseded_by: "canon/definitions/dolcheo-vocabulary.md"
 ---
 
 # DOLCHE — Six Dimensions of Session Capture
+
+> **Superseded by [DOLCHEO](klappy://canon/definitions/dolcheo-vocabulary)** (2026-04-19). DOLCHEO extends DOLCHE with a seventh artifact type — Open, the forward-pointing thread that stays with the current owner — and promotes the vocabulary to canon at tier 2. This document remains for historical reference and as the canonical description of the six-dimension pattern. New work should reference the DOLCHEO umbrella.
+
+---
 
 > Decisions, Observations, Learnings, Constraints, Handoffs, Encodes. Five artifact types and one meta-level action that tracks the crystallization of all the others. DOLCHE supersedes OLDC+H by adding Encode — not as a sixth category of content, but as the act of encoding itself made visible. The E closes the loop: when you encode a Decision, the Encode tracks *that you did it*, when you did it, what quality it achieved, and whether it was persisted. Without the E, you can't distinguish between "this was discussed" and "this was captured."
 

--- a/odd/encoding-types/how-to-write-encoding-types.md
+++ b/odd/encoding-types/how-to-write-encoding-types.md
@@ -247,7 +247,7 @@ With frontmatter tag `encoding-type`, a Type Identity table with `Letter: P`, a 
 
 **Conventions for custom types:**
 
-- Letter should not collide with existing types (D, O, L, C, H, E)
+- Letter should not collide with existing types (D, O, L, C, H, E). One intentional exception exists in the default set: Observation and Open both register letter `O` and disambiguate by facet (`facet: open` on the Open doc) plus section placement in ledgers (`## Open items` sections). See `odd/encoding-types/open.md` and the DOLCHEO umbrella (`canon/definitions/dolcheo-vocabulary.md`) for how the collision is resolved. Custom types should not introduce new collisions unless they follow the same facet-based disambiguation pattern.
 - Letter should be a single uppercase character
 - Including all recommended sections produces the best results
 - Custom types are scoped to the knowledge base that defines them — they don't affect other KBs


### PR DESCRIPTION
Two small follow-ups after PR #112 landed the DOLCHEO umbrella. Both items were captured as open threads (`[O-open P3]` and `[O-open P4]`) in the PR #112 validation ledger.

## 1. Supersede the DOLCHE doc

`docs/oddkit/proactive/dolche-vocabulary.md` was showing `status: active` despite being explicitly superseded by `canon/definitions/dolcheo-vocabulary.md`. The umbrella's `supersedes:` field established the relationship from the authoritative side but the older doc had no matching signal.

Changes:
- `status: active` → `status: superseded`
- Adds `superseded_by: canon/definitions/dolcheo-vocabulary.md` (inverse pointer to the umbrella's `supersedes:`)
- Adds a banner blockquote at the top of the body pointing readers at the DOLCHEO umbrella while preserving the doc as the canonical description of the six-dimension pattern

Note: `status: superseded` and the `superseded_by` field are newly exercised in this repo. The current frontmatter schema (`canon/meta/frontmatter-schema`) lists `status: active | proposed | final` and documents `supersedes` but not `superseded_by`. If this becomes the standard pattern, a follow-up should update the schema. For now, these are the logical inverse of existing fields and self-describing.

## 2. Acknowledge the intentional O/O-open collision

`odd/encoding-types/how-to-write-encoding-types.md` tells custom-type authors: "Letter should not collide with existing types (D, O, L, C, H, E)." That's been correct for the default set until DOLCHEO introduced the intentional collision between Observation (closed) and Open (forward-pointing), both registered under letter `O` with facet-based disambiguation.

Changes:
- One-line-expanded convention that flags the O/O-open case as the one allowed exception, explains how it's resolved (facet field plus section placement), and tells custom-type authors they can follow the same pattern if their domain genuinely needs a collision.

## Verification

- `git diff --stat`: 2 files, +7/-2 lines
- Frontmatter native YAML types preserved
- No other content changed

Ready to merge once CI is green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only updates that don’t affect runtime behavior; the only potential issue is tooling that assumes a limited `status`/frontmatter schema.
> 
> **Overview**
> Marks `docs/oddkit/proactive/dolche-vocabulary.md` as **superseded** (adds `superseded_by` and a top-of-doc banner) to direct readers to the `canon/definitions/dolcheo-vocabulary.md` umbrella.
> 
> Updates `odd/encoding-types/how-to-write-encoding-types.md` to explicitly document the intentional `O` letter collision between *Observation* and *Open* and how it is disambiguated (via `facet: open` and ledger section conventions).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6c1e4f150e85a29b90aa06b05a337d1aa0e8c08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->