### PR TITLE
odd/handoffs: use Writing Canon Summary — extraction key on P1.2 handoff

### DIFF
--- a/odd/handoffs/2026-04-20-p1-2-encode-canary.md
+++ b/odd/handoffs/2026-04-20-p1-2-encode-canary.md
@@ -21,7 +21,7 @@ status: active
 
 ---
 
-## Where we are — P1.1 is done, P1.2 is next
+## Summary — P1.1 Is Shipped and Live; P1.2 Is the Next Arc
 
 **Shipped to production this session (2026-04-19):**
 


### PR DESCRIPTION
One-line rename on the P1.2 handoff (merged in #114) so the Tier-4 Summary extraction key matches canon/meta/writing-canon. Section='Summary' queries against oddkit_get now resolve. No content change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single documentation-only heading rename to align with the Writing Canon Summary extraction key; no behavioral or content changes.
> 
> **Overview**
> Updates the P1.2 handoff doc (`odd/handoffs/2026-04-20-p1-2-encode-canary.md`) by renaming the first major section header to start with `Summary` so `oddkit_get`/summary extractors can match it consistently.
> 
> No other content or semantics change in the handoff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85a6871df55b0dca13d716dd610bd0dabfb23051. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->