### PR TITLE
canon/meta: add status / superseded_by / governs / session_span fields to frontmatter schema

### DIFF
--- a/canon/meta/frontmatter-schema.md
+++ b/canon/meta/frontmatter-schema.md
@@ -7,8 +7,8 @@ tier: 1
 voice: neutral
 stability: semi_stable
 tags: ["canon", "meta", "frontmatter", "schema", "YAML", "metadata", "governance", "template", "validation"]
-epoch: E0007.1
-date: 2026-04-04
+epoch: E0008.3
+date: 2026-04-19
 derives_from: "canon/meta/writing-canon.md, canon/values/axioms.md"
 complements: "canon/meta/TEMPLATE.md, docs/TEMPLATE.md, canon/constraints/definition-of-done.md"
 governs: "All YAML frontmatter in all documents across all directories"
@@ -106,8 +106,9 @@ Canon documents define program-level constraints.
 | `derives_from` | recommended | `"path/to/source.md, path/to/other.md"` | What this document is grounded in. Full file paths, not floating names. |
 | `complements` | optional | `"path/to/sibling.md"` | Related documents that work alongside this one |
 | `governs` | optional | `"description of what this constrains"` | What behavior or documents this constrains |
-| `status` | optional | `"active"` `"proposed"` `"final"` | Lifecycle status |
+| `status` | optional | `"active"` `"proposed"` `"final"` `"superseded"` | Lifecycle status |
 | `supersedes` | optional | `"path/to/old.md"` | What this replaces |
+| `superseded_by` | optional | `"path/to/replacement.md"` | The replacement document (back-pointer; pair with `status: superseded`) |
 
 ### audience: "docs"
 
@@ -120,7 +121,9 @@ Docs documents define implementation details, planning, and operational guides.
 | `derives_from` | optional | `"path/to/source.md"` | What this is grounded in |
 | `complements` | optional | `"path/to/sibling.md"` | Related documents |
 | `governs` | optional | `"description"` | What this constrains |
+| `status` | optional | `"active"` `"proposed"` `"superseded"` `"archived"` | Lifecycle status |
 | `supersedes` | optional | `"path or description"` | What this replaces |
+| `superseded_by` | optional | `"path/to/replacement.md"` | The replacement document (back-pointer; pair with `status: superseded`) |
 | `forcing_fault` | epoch docs only | `"description"` | What friction triggered this epoch |
 | `new_invariant` | epoch docs only | `"statement"` | What's now true that wasn't before |
 | `core_shift` | epoch docs only | `"old → new"` | What changed |
@@ -200,6 +203,10 @@ ODD documents define universal philosophy and methodology.
 | `epoch` | optional | `"E0005"` | Which epoch |
 | `date` | optional | `"2026-04-04"` | Date |
 | `derives_from` | optional | `"path/to/source.md"` | Grounding |
+| `complements` | optional | `"path/to/sibling.md"` | Related documents |
+| `governs` | optional | `"description of what this handoff/ledger covers"` | What scope this document governs. Common on handoffs and ledgers. |
+| `status` | optional | `"active"` `"draft"` `"superseded"` `"archived"` | Lifecycle status |
+| `session_span` | optional | `"2026-04-19 closed"` or `"2026-04-19 to 2026-04-20"` | For session ledgers and handoffs: which session(s) the document records |
 | `version` | optional | `"1.0"` (quoted) | Document version |
 | `slug` | if site-rendered | `"kebab-case"` | URL slug for public-facing ODD docs |
 


### PR DESCRIPTION
## What

Adds missing optional fields to the frontmatter schema that recent PRs already use:

- **canon audience**: `status` values now include `"superseded"`; new `superseded_by` row (paired with existing `supersedes`)
- **docs audience**: new `status` row, new `superseded_by` row
- **odd audience**: new `complements`, `governs`, `status`, `session_span` rows

## Why

Closes the single open item from the validator report on PRs #113/#114/#115 (Sonnet 4.6 validation, VERIFIED verdict, advisory findings FM-1 and FM-2). PR #113 used `status: superseded` + `superseded_by` on a docs doc, PR #114 used `status`, `governs`, `session_span` on an odd handoff. Both were semantically correct, but the schema's own rule says update-first-use-second. That sequencing was inverted. This closes the gap.

Tracked in `odd/handoffs/2026-04-20-p1-2-encode-canary.md` as O-open P1.

## Diff scope

Additive only. No existing row was removed, renamed, or restricted. One row extended: `canon.status` now lists `"superseded"` alongside `"active" / "proposed" / "final"`. Bumped `epoch` to E0008.3 and `date` to 2026-04-19 to mark this as the E0008.3-era revision.

## Verification

- Diff is 10+/3-, single file (`canon/meta/frontmatter-schema.md`)
- Frontmatter types remain native (integers unquoted, dates unquoted, simple identifiers unquoted)
- Pattern matches existing rows in style and Notes voice

Merge when green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only changes that expand the allowed frontmatter fields/values; no runtime code paths are modified.
> 
> **Overview**
> Updates the authoritative frontmatter schema to cover recently-used metadata: expands `canon.status` to include `superseded` and adds `superseded_by`, adds lifecycle (`status`, `superseded_by`) rows for `docs`, and adds `complements`, `governs`, `status`, and `session_span` for `odd` documents.
> 
> Bumps the schema document’s own `epoch`/`date` to reflect the new revision.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5222d400f27711cce4eaf149836b33d7ba44adde. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->