### PR TITLE
odd: P1.3.1 closeout ledger + P1.3.2 gate forward handoff

### DIFF
--- a/odd/handoffs/2026-04-20-p1-3-challenge-canary.md
+++ b/odd/handoffs/2026-04-20-p1-3-challenge-canary.md
@@ -12,7 +12,8 @@ date: 2026-04-20
 session_span: "2026-04-19 closed"
 derives_from: "odd/ledger/2026-04-19-p1-2-encode-dolcheo-landed.md, odd/handoffs/2026-04-20-post-closeout.md, odd/handoffs/2026-04-20-p1-2-encode-canary.md, canon/constraints/core-governance-baseline.md"
 governs: "Fresh-session continuation after P1.2 landed. Points the next session at P1.3.1 — retrofit oddkit_challenge to declare governance_source in its envelope, mirroring the encode + telemetry_policy canary shape. First PR in the post-encode sweep."
-status: active
+status: superseded
+superseded_by: "odd/handoffs/2026-04-21-p1-3-2-gate-canary.md"
 supersedes: "odd/handoffs/2026-04-20-post-closeout.md"
 ---
 

--- a/odd/handoffs/2026-04-21-p1-3-2-gate-canary.md
+++ b/odd/handoffs/2026-04-21-p1-3-2-gate-canary.md
@@ -1,0 +1,202 @@
+---
+uri: klappy://odd/handoffs/2026-04-21-p1-3-2-gate-canary
+title: "Handoff — P1.3.2 oddkit_gate Vodka Refactor + governance_source Envelope"
+audience: odd
+exposure: nav
+tier: 3
+voice: neutral
+stability: stable
+tags: ["odd", "handoff", "session", "epoch-8.3", "p1-3-2", "oddkit-gate", "governance-source", "vodka-anti-pattern", "canary", "sweep"]
+epoch: E0008.3
+date: 2026-04-21
+session_span: "2026-04-20 closed"
+derives_from: "odd/ledger/2026-04-20-p1-3-1-challenge-canary-landed.md, canon/constraints/core-governance-baseline.md, canon/principles/vodka-architecture.md"
+governs: "Fresh-session continuation after P1.3.1 landed. Points the next session at P1.3.2 — retrofit oddkit_gate to (a) read transition prerequisites from canon at runtime instead of hardcoding them in source, and (b) declare governance_source in its envelope. Second PR in the post-encode sweep. Larger delta than P1.3.1 because gate currently has zero canon integration — the full vodka anti-pattern is still live in runGateAction."
+status: active
+supersedes: "odd/handoffs/2026-04-20-p1-3-challenge-canary.md"
+---
+
+# Handoff — P1.3.2 oddkit_gate Vodka Refactor + governance_source Envelope
+
+> P1.3.1 shipped clean to prod (PR #116 feat, #117 promotion, prod at 0.19.0). Challenge's envelope now declares `governance_source` and a four-peer `governance_uris` array; smoke 126/126 × 5 consecutive on prod; validator VERIFIED 5/5 zero advisories. **Next work unit is P1.3.2** — retrofit `oddkit_gate` following the same canary pattern, but with a larger scope: gate has not yet been governance-driven at all. `runGateAction` hardcodes transition prerequisites, DoD criteria, and completion checks directly in source. This session refactors gate to read those from canon at runtime AND adds the envelope `governance_source` / `governance_uris` the sweep requires. Estimate 90–150 min including validator, longer than P1.3.1 because canon docs may need to be written before code can reference them.
+
+---
+
+## What shipped since the prior handoff
+
+| PR | Repo | Merged SHA | Purpose |
+|----|------|-----------|---------|
+| #116 | klappy/oddkit | `71ee6ed` | **feat(challenge):** governance_source envelope + peer governance_uris (0.19.0). Squash-merged. |
+| #117 | klappy/oddkit | `1b4fce8` | main → prod promotion for 0.19.0. Merge commit. |
+
+**Production state:** `https://oddkit.klappy.dev/health` returns `{"version":"0.19.0"}`. Smoke 126/126 × 5 consecutive on prod. No regressions.
+
+**Validator record:** `agent_011CaE62pg6jJ7yYpRj1o9Do` / `sesn_011CaE63LZhPUX1UAZPbiV7n`. Disposition: **VERIFIED**, 5/5, zero blockers, zero non-blocking advisories. External corroboration pattern (main-bytes grep, live curl ×3 shapes, canon citation, 9-mode curl, 3× independent smoke) is now the default for the sweep.
+
+## What is cleared from the prior handoff
+
+- **[O-open P1]** Challenge envelope retrofit — closed by #116/#117.
+
+## What remains open
+
+- **[O-open P1]** **P1.3.2 — gate vodka refactor + envelope.** See scope section below. This is the next atomic unit.
+- **[O-open P2]** `getIndex` strict-mode (`skipBaselineFallback`) — now affects telemetry_policy + encode + challenge. Same limitation, one fix. Pull into a later P1.3.x PR if a tool exercises the code path; otherwise standalone PR.
+- **[O-open P3]** **Handoff text corrections on klappy.dev.** Two deferred: (a) P1.2 handoff "bundled baseline" → "minimal fallback"; (b) P1.3 handoff three `discover*` → `fetch*` names. Low priority. Bundle both into a single tiny canon PR at next session's natural PR window.
+- **[O-open P4]** **Canon principle on contract-governs-handoff-drift.** Now standing — three recurrences documented (P1.2 ledger's two + P1.3.1 ledger's one). Principle draft text in the P1.3.1 ledger's §"Canon Principle Now Standing" section. Draft location: `canon/principles/contract-governs-handoff-drift.md`. Bundle into the handoff-text-corrections PR.
+- **[O-open P5]** `workers/baseline/` bundled-tier build pipeline — separate epoch. Deferred until sweep surfaces concrete need or TruthKit forces the question.
+- **[O-open P6]** CHANGELOG render route on klappy.dev + `version_notes_url` on MCP `initialize`. Low priority; slot into a tool-envelope PR window.
+
+---
+
+## P1.3.2 scope — retrofit `oddkit_gate`
+
+### The delta (larger than P1.3.1)
+
+Gate has **zero canon integration today**. `runGateAction` at `workers/src/orchestrate.ts` hardcodes:
+
+- Transition detection (`detectTransition(input)` — regex-based mode recognition)
+- Transition-specific prerequisites (`problem_defined`, `constraints_reviewed`, `decisions_locked`, `dod_defined`, `irreversibility_assessed`, `constraints_satisfied`, `dod_met`, `artifacts_present`)
+- DoD criteria and evidence requirements
+
+All of this is code, not canon. The sweep thesis says: canon defines vocabulary; code must not hardcode interpretation. Gate is currently the most pure vodka-anti-pattern violation of any remaining tool in the sweep.
+
+**Unlike P1.3.1**, the canon governance docs for gate **do not yet exist in the klappy.dev repo** (no `odd/gate/` directory). This session will need to write canon first, then refactor code — preserving the "canon-first rule is absolute" from the bootstrap contract.
+
+### Work to ship — two-phase scope
+
+**Phase 1: write canon (klappy.dev PR, lands first).**
+
+1. Create `odd/gate/transitions.md` — the canonical list of mode transitions (e.g. `exploration → planning`, `planning → execution`, `* → completion`) with a markdown table of detection patterns, prerequisite IDs, and governance references.
+2. Create `odd/gate/prerequisites.md` — the canonical definitions of each prerequisite ID (`problem_defined`, `constraints_reviewed`, etc.), matching the pattern of `odd/challenge/base-prerequisites.md`: each row is `(id, description, check, gap_message)`.
+3. Optionally `odd/gate/completion-criteria.md` — DoD and artifact-presence checks if they are sufficiently distinct from prerequisites to warrant their own file.
+4. Merge the klappy.dev PR first. Canon must be live before the oddkit PR can reference it.
+
+**Phase 2: refactor oddkit_gate (oddkit PR, lands second).**
+
+1. Add `fetchGateTransitions(fetcher, knowledgeBaseUrl)` → `{ transitions, source }` and `fetchGatePrerequisites(fetcher, knowledgeBaseUrl)` → `{ prerequisites, source }` helpers, following the P1.3.1 per-helper domain-noun tuple pattern.
+2. Refactor `runGateAction` to read transitions and prerequisites from canon at runtime; keep the current hardcoded logic as the `"minimal"` fallback (matches encode's soft-fallback pattern, not challenge's hollow-response pattern — gate cannot hollow out without becoming useless, so the minimal tier must preserve today's behavior exactly).
+3. Declare `governance_source` and `governance_uris` in the response envelope. Per D4 principle from P1.3.1: because gate will read two peer governance files (transitions + prerequisites), use `governance_uris` (plural array). Shape parity with challenge.
+4. Echo `debug.knowledge_base_url` on overrides.
+5. Extend `workers/test/canon-tool-envelope.smoke.mjs` with gate assertions matching the P1.3.1 pattern: envelope shape, `governance_source` valid enum, `governance_uris` length 2 (or 3 if completion-criteria ships as separate file), override behavior, and at minimum one assertion per defined transition type.
+6. CHANGELOG `[0.20.0]` entry with Added / Changed / Fixed / Known-limitations. MINOR bump per sweep precedent (encode 0.18.0, challenge 0.19.0).
+7. Tool description update to reference the two governance docs and the envelope signal.
+
+### Known subtleties
+
+- **Canon-first is mandatory.** Unlike P1.3.1, this session cannot write oddkit code and then "update canon as needed" — the oddkit PR references klappy.dev files that must exist at the SHA the worker pins. Standing rule: klappy.dev PR merged to main before oddkit PR is even opened.
+- **Back-compat is critical.** Unlike encode and challenge (where the envelope changes were additive), gate's hardcoded logic is the only behavior callers have today. The minimal fallback must preserve exact current behavior. If a canon doc is missing or malformed, gate must still return the same transitions and prerequisites it does today — just with `governance_source: "minimal"` in the envelope so callers see the degradation.
+- **The `detectTransition` regex may not belong in canon.** Detection patterns are low-level parsing; canon governs vocabulary and policy. Candidate split: keep `detectTransition` in code as the parser, have it emit a transition key, and read the transition-specific prerequisite set from canon by key. Mirrors how challenge's parser stays in code but the per-type vocabulary lives in canon.
+- **Two URIs vs three URIs for `governance_uris`.** If completion-criteria ships as a third file, the array has three entries. If transitions and prerequisites alone cover the contract, the array has two. Either is coherent under D4's peer-array principle; decide during planning based on how the canon docs actually split.
+- **This session may want to split into two sessions.** Phase 1 (canon) + Phase 2 (code) is a lot for one session if canon discussion goes deep. Acceptable to land Phase 1 in session A and Phase 2 in session B. The forward handoff from session A would then be "P1.3.2 Phase 2".
+
+### Out of scope (deferred)
+
+- Any other tool in the sweep (preflight, validate, orient, search, catalog, cleanup, version) — subsequent P1.3.x PRs.
+- `getIndex` strict-mode — still deferred.
+- `workers/baseline/` build pipeline — still deferred.
+- Any edits to existing tools' envelopes — gate only.
+
+### Path 3 workflow
+
+Same shape as P1.3.1, with the Phase 1 canon PR inserted first:
+
+**Phase 1 (klappy.dev):**
+1. Clone `klappy/klappy.dev` into `/home/claude/work/klappy.dev`, cut branch `gate/canon-governance-docs` off main.
+2. Write `odd/gate/transitions.md`, `odd/gate/prerequisites.md` (and possibly `odd/gate/completion-criteria.md`). Follow `canon/meta/frontmatter-schema` — native YAML types only. Use `odd/challenge/base-prerequisites.md` as the structural template.
+3. Commit. Push. Open PR via `urllib.request` + `json.dumps`.
+4. Optional lightweight validation: use `oddkit_preflight` to confirm Writing Canon gate criteria are met before opening PR.
+5. Squash-merge on self-review (canon docs are lower-risk than code — no need for Sonnet 4.6 validator unless the docs encode contract semantics that need pressure-testing).
+
+**Phase 2 (klappy/oddkit):**
+1. Clone `klappy/oddkit`, cut branch `gate/governance-source-envelope` off main.
+2. Apply edits locally (canon discovery helpers + envelope retrofit). Run `npm run typecheck` in `workers/`. Run `node workers/test/governance-parser.test.mjs` — must stay at 105/105 (or grow if gate-specific parser tests are added).
+3. Commit (version bump to 0.20.0, githook enforces sync).
+4. Push. CF auto-deploys to preview. Wait ~25s. Smoke preview with updated script. 3 consecutive clean.
+5. Open PR via `urllib.request` + `json.dumps`.
+6. Dispatch Sonnet 4.6 read-only validator with required external corroborations (template from P1.3.1):
+   - Main-branch `orchestrate.ts` bytes grep confirming gate has no canon integration pre-refactor
+   - Live curl against preview for envelope shape + `governance_source` value
+   - `oddkit_get` citation on `core-governance-baseline` §Runtime Invariants
+   - `oddkit_get` on the new canon files (`odd/gate/transitions`, `odd/gate/prerequisites`) to confirm they landed in Phase 1
+   - 3× independent smoke
+7. Accept VERIFIED. Squash-merge. Main-preview smoke 3× clean. Open main → prod PR. Merge. Prod smoke 3× clean.
+
+Estimate: Phase 1 canon writing 30–60 min, Phase 2 code + validation 90–150 min. Total may warrant split across two sessions.
+
+---
+
+## Standing rules (carried from prior handoffs, unchanged)
+
+- **Call `oddkit_time` first every turn.** Pass the prior `server_time` as `reference`. No inferred timestamps.
+- **Declare epistemic mode out loud.** Planning until PRD is written and contract decisions are named; execution after the gate; validation via Sonnet 4.6 (context-break required, same-session self-review is not validation).
+- **Search canon before asking.** Especially before claiming anything about gate's current state or the core-governance-baseline contract.
+- **Ground framing in code + canon, not in the latest handoff.** Per P1.3.1 ledger §"Canon Principle Now Standing" — three recurrences justify this as a named principle. If a handoff's word choice disagrees with a contract's enum or a live code reality, the contract/code wins.
+- **PRD before code.** Write the plan as a file before touching source. Articulation is the deliverable during planning, not prose in the chat window. P1.3.1 shipped with zero advisories specifically because of PRD-first discipline.
+- **During execution, produce artifacts, not questions.** Reversion requires one sentence naming the specific unknown.
+- **Canon-first is absolute.** This session especially: Phase 1 klappy.dev PR must merge before Phase 2 oddkit PR is opened. Do not write oddkit code that references canon files that do not yet exist.
+- **No force-push without `git fetch` first.** Remote state may have diverged.
+- **GitHub API: `urllib.request` + `json.dumps`, never bash heredoc.** The PAT-in-command footgun and JSON-escaping pitfalls are documented; use the proven path.
+- **`$HOME=/root` in the managed-agent cloud container** (not `/home/user` as the skill doc historically suggested).
+- **Do NOT dispatch Opus 4.7 execution agents to klappy/oddkit.** Safety-layer false-positive blocks them. Sonnet 4.6 read-only validation is fine; orchestrator-applies for writes.
+- **Do NOT run `wrangler deploy` manually.** Githooks + CF auto-deploy handle the pipeline.
+- **Branch preview slug rule:** slashes AND dots → hyphens. `gate/governance-source-envelope` → `gate-governance-source-envelope`.
+- **Prod deploy warmup pattern:** first smoke run immediately after prod flip can flake as isolates serve mixed versions. Accept 3 consecutive clean runs as the "prod clean" gate.
+
+---
+
+## Reference material — read this at session start
+
+Priority order for fresh-session reading:
+
+1. This doc.
+2. `klappy://canon/bootstrap/model-operating-contract` — the evolving operating contract.
+3. `klappy://odd/ledger/2026-04-20-p1-3-1-challenge-canary-landed` — P1.3.1 closeout with the D4 pivot rationale, validator corroboration pattern, and the three-recurrence evidence for the contract-governs-handoff-drift principle.
+4. `klappy://canon/constraints/core-governance-baseline` — the governing contract. Re-read §Runtime Invariants and §What-Ships-in-Baseline (gate's canon docs are candidates for Required-in-Baseline if the build pipeline ever ships).
+5. `klappy://canon/principles/vodka-architecture` — the principle this session is applying. Gate is the tool where the anti-pattern has survived longest; this session ends its run.
+6. `klappy://canon/principles/agent-self-report-under-stress` — for the validator dispatch.
+7. `klappy://canon/meta/frontmatter-schema` — native YAML types only, critical for Phase 1 canon writing.
+8. `klappy://odd/challenge/base-prerequisites` — structural template for `odd/gate/prerequisites.md`.
+9. `klappy://odd/challenge/stakes-calibration` — reference for table-driven canon that tools parse at runtime.
+
+Reference PRs for canary pattern (same-shape):
+
+- `klappy/oddkit#108` / `#109` — telemetry_policy canary (reference envelope).
+- `klappy/oddkit#114` — encode canary completion (P1.2).
+- `klappy/oddkit#116` — challenge canary completion (P1.3.1, most recent precedent).
+
+---
+
+## Thin prompt for the next session
+
+```
+Resume P1.3.2 per klappy://odd/handoffs/2026-04-21-p1-3-2-gate-canary.
+
+Current state: 0.19.0 in prod (oddkit.klappy.dev), challenge envelope now
+declares governance_source + governance_uris (plural array of 4 peer canon
+URIs), gate remains the purest remaining vodka anti-pattern in the sweep.
+P1.3.1 formally closed at klappy://odd/ledger/2026-04-20-p1-3-1-challenge-canary-landed.
+
+Two-phase scope: (1) write canon docs odd/gate/transitions.md and
+odd/gate/prerequisites.md on klappy.dev and merge — canon-first absolute.
+(2) refactor oddkit runGateAction to read from canon via {data, source}
+helpers, add governance_source + governance_uris (plural) to envelope,
+ship as 0.20.0. Orchestrator applies on both repos, Sonnet 4.6 validates
+oddkit Phase 2.
+
+Read the handoff. Run the gauntlet on gate's current state + the
+core-governance-baseline contract + vodka-architecture principle. Write
+the PRD as a file before touching source. May split across two sessions
+if Phase 1 canon discussion goes deep.
+
+Credentials in project instructions. No Opus 4.7 execution agents to
+oddkit.
+```
+
+---
+
+## Provenance
+
+- **Prior session ledger:** `odd/ledger/2026-04-20-p1-3-1-challenge-canary-landed.md` — full retrospective for the P1.3.1 arc.
+- **Prior handoff:** `odd/handoffs/2026-04-20-p1-3-challenge-canary.md` — superseded by this document.
+- **Merged PRs this cycle:** `klappy/oddkit#116` (feat), `klappy/oddkit#117` (promotion).
+- **Target code at current main:** `workers/src/orchestrate.ts` `runGateAction` (currently ~L2097–L2200 post-P1.3.1 edits). Zero canon integration pre-refactor.

--- a/odd/ledger/2026-04-20-p1-3-1-challenge-canary-landed.md
+++ b/odd/ledger/2026-04-20-p1-3-1-challenge-canary-landed.md
@@ -1,0 +1,147 @@
+---
+uri: klappy://odd/ledger/2026-04-20-p1-3-1-challenge-canary-landed
+title: "Session Ledger — P1.3.1 Challenge governance_source Canary Landed (0.19.0)"
+audience: odd
+exposure: nav
+tier: 3
+voice: neutral
+stability: stable
+tags: ["odd", "ledger", "session", "epoch-8.3", "p1-3-1", "oddkit-challenge", "governance-source", "canary", "0.19.0", "sonnet-validator"]
+epoch: E0008.3
+date: 2026-04-20
+session_span: "2026-04-19T21:21Z–2026-04-20T00:59Z"
+derives_from: "odd/handoffs/2026-04-20-p1-3-challenge-canary.md, odd/ledger/2026-04-19-p1-2-encode-dolcheo-landed.md, canon/constraints/core-governance-baseline.md, canon/principles/agent-self-report-under-stress.md"
+governs: "Retrospective record of the 2026-04-19T21:21Z–2026-04-20T00:59Z session that landed P1.3.1 — oddkit_challenge retrofitted to declare governance_source and governance_uris (plural peer array) in its envelope. Shipped as klappy/oddkit#116 (feat) and #117 (main→prod promotion). First canary in the post-encode sweep to apply the contract-grounded, code-first discipline the P1.2 ledger called for."
+status: active
+---
+
+# Session Ledger — P1.3.1 Challenge governance_source Canary Landed (0.19.0)
+
+> P1.3.1 shipped clean to prod. `oddkit_challenge` now declares `governance_source` (`"knowledge_base"` | `"minimal"`) and `governance_uris` (plural array of four peer canon URIs, alphabetical by path-tail) on both return paths (`SUPPRESSED` and `CHALLENGED`), and echoes `debug.knowledge_base_url` on overrides. Four governance helpers return `{<domainNoun>, source}` tuples; `runChallengeAction` aggregates strictly. Sonnet 4.6 validator VERIFIED 5/5 with external corroboration — zero blockers, zero advisories, a rare clean pass that signals the PRD-first discipline front-loaded the review. Prod smoke 126/126 × 5 consecutive runs. The session's more interesting artifact is the D4 decision pivot: the PRD initially proposed single-string `governance_uri` for shape parity with encode; the operator pushed back that challenge's four governance files are peers with no hierarchy, and a single anchor would misrepresent where the other three live. Accurate representation outranks envelope-shape parity.
+
+---
+
+## Summary — What Shipped and What the Session Proved
+
+P1.3.1 delivered the challenge canary completion described in the prior session's handoff: envelope contract compliance (`governance_source`), four peer canon URIs (`governance_uris`), and `debug.knowledge_base_url` echo. Two PRs on klappy/oddkit — #116 (squash-merged at `71ee6ed`), #117 (main→prod merge at `1b4fce8`). Prod at 0.19.0 (`https://oddkit.klappy.dev/health` confirmed). Smoke 126/126 × 5 consecutive on prod after 40s CF warmup; main-preview required two isolate-warmup flakes before settling (the pattern the P1.2 handoff named).
+
+Three patterns deserve naming — each one a test of whether the P1.2 ledger's hard-won lessons actually propagate.
+
+**Code-first discipline caught two handoff errors on first pass.** The P1.3 handoff described four discovery helpers all named `discover*` (recency-as-authority: pattern-matching encode's `discoverEncodingTypes` onto challenge). Direct grep of `workers/src/orchestrate.ts@290dde5` showed only one was `discover*`; the other three are `fetch*`. The PRD called this out in §3.1 and committed to preserving the names (minimizing diff, zero behavioral impact). Second catch: the handoff framed the `bundled` tier as contract aspiration but didn't explicitly note that `workers/baseline/` does not exist in the repo at all. `ls workers/baseline/` returned "NO BASELINE DIR". The two-tier cascade (`knowledge_base` | `minimal`) isn't a classification-specific call for challenge — it's the current reality for every knowledge-base-driven tool. The PRD named this in §3.2 and the risk register called out that the validator would need to see this explicitly, which is exactly what it did when corroborating against `core-governance-baseline`.
+
+**Operator pivot on D4 was load-bearing.** The PRD's first draft proposed `governance_uri: "klappy://odd/challenge/stakes-calibration"` — single string, parity with encode's shape. The operator flagged this: challenge reads four peer governance files (`base-prerequisites`, `challenge-types/`, `normative-vocabulary`, `stakes-calibration`) and `stakes-calibration` doesn't govern or represent the other three. A single anchor pointing at it would mislead callers about where the vocabulary and prerequisite contracts live. Alternative: `governance_uris: [array of four]`, alphabetical. Shape divergence from encode is accepted because the underlying governance reality diverges. The PRD §7 envelope-after diagram was updated, D6 CHANGELOG language specifically named the divergence for consumers reading both tools, and the smoke test asserts `governance_uri` (singular) is NOT emitted on challenge. This decision was the most consequential of the session; every other decision fell in line.
+
+**Validator external-corroboration pattern worked end-to-end.** Per `canon/principles/agent-self-report-under-stress`, terminal self-reports are not authoritative. The validator task explicitly required five external corroborations: main-branch bytes grep (pre-refactor state), live curl ×3 shapes (default, override, voice-dump SUPPRESSED), `oddkit_get` citation on `core-governance-baseline`, all 9 modes curl, and 3× independent smoke runs. Sonnet 4.6 pulled each piece independently — including cloning the repo itself to run the smoke test from its own session, not trusting the orchestrator's preview-smoke output. Disposition VERIFIED 5/5 with zero advisories. Zero advisories is unusual and worth marking — the PRD-first discipline (writing the plan as a file before touching code) appears to front-load the kind of review findings that would otherwise surface at validation time.
+
+---
+
+## What Shipped
+
+| PR | Repo | Merged SHA | Purpose |
+|----|------|-----------|---------|
+| #116 | klappy/oddkit | `71ee6ed` | **feat(challenge):** governance_source envelope + peer governance_uris (0.19.0). Squash-merged. |
+| #117 | klappy/oddkit | `1b4fce8` | main → prod promotion for 0.19.0. Merge commit. |
+
+**Production state:** `https://oddkit.klappy.dev/health` returns `{"version":"0.19.0"}`. Smoke 126/126 × 5 consecutive on prod.
+
+**Validator record:** `agent_011CaE62pg6jJ7yYpRj1o9Do` / `sesn_011CaE63LZhPUX1UAZPbiV7n`. Disposition: **VERIFIED**, 5/5, zero blockers, zero non-blocking advisories.
+
+**Feature delta (files changed):** 6 files, +222 / -19 lines in the feat commit.
+
+- `workers/src/orchestrate.ts` — four helpers retrofitted to `{<domainNoun>, source}` tuples (`discoverChallengeTypes`→`{types, source}`, `fetchBasePrerequisites`→`{prerequisites, source}`, `fetchNormativeVocabulary`→`{vocabulary, source}`, `fetchStakesCalibration`→`{calibration, source}`); `runChallengeAction` aggregates strictly and adds envelope fields on both SUPPRESSED and CHALLENGED paths; `cleanup_storage` extended to reset the three new `cachedXSource` fields
+- `workers/src/index.ts` — `oddkit_challenge` tool description updated to name the four governance surfaces and the two-tier envelope signal
+- `workers/test/canon-tool-envelope.smoke.mjs` — 47 new assertions: envelope shape on both paths, `governance_uris` array of exactly 4 with expected alphabetical ordering, `governance_uri` singular asserted absent, `knowledge_base_url` override behavior, 9-mode parse integrity loop (`voice-dump` asserts SUPPRESSED; others assert CHALLENGED)
+- `CHANGELOG.md` — `[0.19.0]` entry with Added / Changed / Fixed / Known-limitations; divergence-from-encode called out explicitly in the governance_uris Added bullet
+- `package.json` + `workers/package.json` — synced to `0.19.0` (pre-commit hook enforced)
+
+---
+
+## What the Validator Actually Checked
+
+The five corroborations are worth enumerating because the pattern should be the default for subsequent canaries in the sweep.
+
+1. **Main-branch bytes grep.** Validator cloned `klappy/oddkit`, checked out main, grepped `workers/src/orchestrate.ts` for `governance_source` references inside `runChallengeAction`. Confirmed zero hits — pre-refactor state matches the PR's "before" claim. The one match at line 2262 of main is inside `runEncodeAction` (P1.2), which the validator correctly disambiguated.
+2. **Live preview curl, three shapes.** Default KB planning mode → `governance_source: "knowledge_base"`, `governance_uris` length 4, `governance_uri` undefined. Override to `torvalds/linux` → `debug.knowledge_base_url` echoed, `governance_source` within enum. Voice-dump mode → `status: "SUPPRESSED"` with governance fields still present on the early-return envelope (the PRD §10 risk register flagged this branch specifically; validator confirmed it landed).
+3. **Canon citation on `core-governance-baseline`.** Validator used `oddkit_get` to fetch `§Runtime Invariants` and confirmed the three-tier enum is documented, plus fetched the `§What-Ships-in-Baseline` section to confirm `odd/challenge/stakes-calibration.md` is listed as required-in-baseline. Two-tier cascade today is coherent with the contract given `workers/baseline/` is not shipped.
+4. **Nine-mode curl.** Validator iterated all nine modes from `odd/challenge/stakes-calibration` against the preview URL. Each returned a full envelope with valid `governance_source` and `governance_uris` length 4. `voice-dump` returned SUPPRESSED; the other eight returned CHALLENGED. PR #100 regression guard is live.
+5. **Independent smoke runs.** Validator cloned its own copy of the branch and ran the smoke test three consecutive times against the preview URL — not trusting the orchestrator's own smoke output. 126/126 each run.
+
+The disposition block: `VERIFIED / 5/5 / [] blockers / [] advisories`.
+
+---
+
+## Patterns Observed, Worth Carrying Forward
+
+**"PRD as a file before touching source" is a review-cost reducer.** P1.2 landed with 3 non-blocking advisories. P1.3.1 landed with zero. The difference this session was the PRD: 296 lines including 8 explicit decisions (D1–D8) each with alternatives named, a risk register covering the SUPPRESSED early-return gotcha before the first line of code was written, and a §8 validator dispatch protocol naming five corroborations that the validator then faithfully executed. The hypothesis: review findings tend to come from (a) decisions the author didn't realize were decisions, and (b) edge cases the author didn't think about. Writing the PRD surfaces both before code, turning would-be review findings into planning-time clarifications.
+
+**Operator pivot on a design decision is more productive than operator approval of all decisions.** D4 was the only pivot of eight decisions. The PRD's first-draft case for single-string was internally coherent — but the operator caught that it was optimizing for the wrong thing (envelope parity over accurate representation of governance reality). The change took one message, one PRD edit, and zero downstream rework. If the operator had approved D4 as drafted, the validator corroboration on the governance_uri field would have surfaced the same question at validation time, which is 10× more expensive to fix. The session confirms: review pivots during planning are the cheapest kind. "7 of 8 approved, D4 reconsider" is a high-value approval shape.
+
+**Isolate-warmup pattern is real across tiers.** The P1.2 handoff established "3 consecutive clean as prod-ready gate" because CF isolates can serve mixed versions immediately after deploy. This session reproduced the pattern precisely on main-preview: two flakes, then three clean, then two more clean for confidence. Prod took 40s of warmup wait and then five clean in a row. The operational rule generalizes: trust the third-consecutive-clean, not the first.
+
+**Handoff errors are structural, not exceptional.** The P1.2 ledger named recency-as-authority (three recurrences) and proposed a candidate canon principle on contract-governs-handoff-drift, pending one more recurrence before canonization. This session is that recurrence. The P1.3 handoff's claim of four `discover*` helpers was recency-as-authority in the forward-pointing doc itself — the author pattern-matched from the encode helper (`discoverEncodingTypes`) onto the challenge helpers without verifying against code. The fix worked: code-first discipline caught it in the PRD's §3.1 before any edits. Third instance confirmed; the canon principle now has standing.
+
+---
+
+## What Is Cleared from the Prior Handoff
+
+- **[O-open P1]** P1.3.1 challenge `governance_source` retrofit — closed by #116/#117.
+
+## What Remains Open (Carry-Forward O-opens)
+
+- **[O-open P1]** **P1.3.2 — next tool in sweep.** Candidates: `gate`, `preflight`, `validate`, `orient`, `search`, `catalog`, `cleanup`, `version`. Priority to be decided in the next session's handoff. Audit doc at `docs/oddkit/audit/governance-anti-pattern-sweep-2026-04-17.md` has the ranking.
+- **[O-open P2]** **`getIndex` strict-mode (`skipBaselineFallback`).** Inherited from encode 0.18.0; now affects challenge 0.19.0 as well. Same limitation, one fix — natural to pull into a later P1.3.x PR when a tool exercises the code path non-trivially, or as a standalone PR if the sweep doesn't naturally touch it.
+- **[O-open P3]** **Handoff text corrections on klappy.dev.** Two corrections deferred from this session: (a) P1.2 handoff `klappy://odd/handoffs/2026-04-20-p1-2-encode-canary` rename "bundled baseline" → "minimal fallback" to align with the contract's enum; (b) P1.3 handoff `klappy://odd/handoffs/2026-04-20-p1-3-challenge-canary` rename the three `discover*` → `fetch*` for `fetchBasePrerequisites` / `fetchNormativeVocabulary` / `fetchStakesCalibration`. Low priority, archival; bundle both into a single tiny canon PR.
+- **[O-open P4]** **Canon principle on contract-governs-handoff-drift.** P1.2 ledger called for one more recurrence before writing the principle. This session is recurrence #3 (P1.3 handoff's `discover*` naming error). The principle has standing. Draft location: `canon/principles/contract-governs-handoff-drift.md`. Core claim: "when a handoff's word choice disagrees with a governing contract's enum or a live code reality, the contract/code wins — the handoff is a bridging artifact, not a source of truth." Draft in a small canon PR when the next session opens a klappy.dev PR for any reason.
+- **[O-open P5]** **`workers/baseline/` bundled-tier build pipeline.** The contract `§Build-Time-Invariants` describes the regeneration process (fetch canon at pinned SHA, extract required-baseline files, schema-check against canon, fail build on divergence). Nothing in the repo implements this today. Separate epoch's work — not a single-session unit. First step would be writing the MANIFEST.json and the regeneration script; second step would be the schema check; third step would be a `oddkit_baseline_check` probe. Deferred until the sweep surfaces concrete need or TruthKit's TruthKit-specific baseline needs force the question.
+- **[O-open P6]** **CHANGELOG render route on klappy.dev + `version_notes_url` on MCP `initialize`.** Low priority, unchanged from prior handoffs. Slot into a tool-envelope PR window.
+
+## What This Session Added to the Carry List
+
+None beyond the above — the session stayed in scope. No new scope-creep O-opens.
+
+---
+
+## Canon Principle Now Standing: contract-governs-handoff-drift
+
+Three recurrences justify the principle. Named explicitly:
+
+> **When a handoff's word choice or described state disagrees with a governing contract's enum or the target code's live reality, the contract and code win. The handoff is a bridging artifact — useful for session continuity, but not authoritative over the governing documents or the repo state. The fix is always the same: before acting on a handoff's framing, grep the target code and re-fetch the governing contract. Recency is not authority.**
+
+Three recurrences this principle addresses:
+1. P1.2 session: handoff described three-tier cascade; contract's enum for encoding-types is two-tier (`knowledge_base` | `minimal`). Word collision, not design conflict.
+2. P1.2 session: handoff's scope framing treated "bundled DOLCHEO minimum" as a tier name; contract calls that case `"minimal"`. Same pattern at scope-framing level.
+3. P1.3.1 session (this one): handoff described four `discover*` helpers; code has one `discover*` and three `fetch*`. Pattern-matched from encode without verifying.
+
+The principle should be drafted in the next klappy.dev PR (natural to bundle with the handoff text corrections in O-open P3). The candidate doc already has three attestation cases in the ledger — a stronger grounding than most canon principles get at draft time.
+
+---
+
+## Session Mechanics — What Worked and What Didn't
+
+**What worked:**
+- **PRD as a file before code.** 296 lines of planning produced an execution path the validator could corroborate exactly, zero advisories.
+- **Time discipline via `oddkit_time` first each turn** with `server_time` reference. The session's elapsed-time claims in final reporting (3h 25m total wall clock) are observed, not inferred.
+- **Two explicit gates (exploration→planning, planning→execution)** named the mode transitions out loud, even though the session started mid-plan. Cheap tool call; binds the scope lock that follows.
+- **Strict aggregation rule (any helper minimal → aggregate minimal)** matched encode's single-helper precedent trivially and has no edge cases.
+- **Per-helper domain-noun tuples** (`{types, source}`, `{prerequisites, source}`, etc.) read more cleanly at the call site than a generic `{data, source}` would have. Operator's style nit on D3 was right.
+
+**What didn't work as well:**
+- **Initial PRD draft on D4 optimized for parity over accuracy.** Single-string `governance_uri` would have been merged if the operator hadn't pushed back. The review caught it cheaply; the PRD-first discipline is not a substitute for operator design review on non-obvious tradeoffs.
+- **Smoke output pipeline filtering** hid the pass/fail tallies on the first prod-smoke attempt. The fix was trivial (`tail -1` instead of a grep filter), but the lesson is that observability tooling around verification steps should itself be verified before trusting its output.
+- **Two main-preview isolate flakes** before three clean. Not a defect — the P1.2 handoff predicted this — but a reminder that the 3-consecutive-clean gate is doing real work, not ritual.
+
+---
+
+## Handoff
+
+Next session's atomic unit: **P1.3.2** — apply the canary pattern to the next tool in the sweep. Forward handoff at `klappy://odd/handoffs/2026-04-21-p1-3-2-next-tool-canary`. This ledger is `status: active`; a future closeout session will flip it to `status: superseded` with a pointer to that successor.
+
+---
+
+## Provenance
+
+- **Source handoff:** `odd/handoffs/2026-04-20-p1-3-challenge-canary.md` — the instructions this session executed against.
+- **Predecessor ledger:** `odd/ledger/2026-04-19-p1-2-encode-dolcheo-landed.md` — the P1.2 retrospective whose code-first and recency-as-authority observations this session tested.
+- **Merged PRs:** `klappy/oddkit#116` (feat), `klappy/oddkit#117` (promotion).
+- **Validator session:** `sesn_011CaE63LZhPUX1UAZPbiV7n` under agent `agent_011CaE62pg6jJ7yYpRj1o9Do`. Model: `claude-sonnet-4-5`. Event log ephemeral to the validator's container; the VERIFIED 5/5 disposition is summarized above and in the final disposition block retrieved from the session's terminal `agent.message` event.
+- **PRD:** `/home/claude/work/prd-p1-3-1-challenge-canary.md` — local planning artifact in the orchestrator's working directory, not committed to any repo. Referenced in PR #116 commit message and inline orchestrate.ts comments.


### PR DESCRIPTION
## Summary

Closeout artifacts for the P1.3.1 session that landed `oddkit_challenge` governance_source + peer governance_uris (shipped as klappy/oddkit#116 + #117, 0.19.0 in prod, smoke 126/126 x 5 consecutive on prod, validator VERIFIED 5/5 zero advisories).

## Files

- `odd/ledger/2026-04-20-p1-3-1-challenge-canary-landed.md` (new, ~1800 words): full session retrospective covering the D4 single-string-to-peer-array pivot, the external-corroboration validator pattern that's now the sweep default, and the three-recurrence evidence that graduates `contract-governs-handoff-drift` to a standing canon principle.
- `odd/handoffs/2026-04-21-p1-3-2-gate-canary.md` (new): forward handoff pointing the next session at P1.3.2 — gate's vodka anti-pattern refactor. Two-phase scope because gate has zero canon integration today (canon docs must be written first on klappy.dev, then oddkit code references them).
- `odd/handoffs/2026-04-20-p1-3-challenge-canary.md` (modified): frontmatter `status: active` → `superseded`, plus `superseded_by` pointer to the P1.3.2 handoff per `canon/meta/frontmatter-schema` convention.

## Deferred to a subsequent PR

- P1.2 handoff text correction (`bundled baseline` → `minimal fallback` to align with contract enum)
- P1.3 handoff text correction (three `discover*` → `fetch*` name corrections for the challenge helpers)
- `canon/principles/contract-governs-handoff-drift.md` draft (text in the P1.3.1 ledger's "Canon Principle Now Standing" section)

All three are listed as O-opens in the P1.3.2 handoff and bundle naturally into a single small canon PR when the next session opens a klappy.dev PR for any reason.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes (new handoff/ledger markdown and a frontmatter status update) with no runtime or production impact.
> 
> **Overview**
> Adds a new P1.3.1 closeout ledger (`odd/ledger/2026-04-20-p1-3-1-challenge-canary-landed.md`) documenting the shipped `oddkit_challenge` `governance_source`/`governance_uris` canary and validation results.
> 
> Introduces the forward handoff for P1.3.2 (`odd/handoffs/2026-04-21-p1-3-2-gate-canary.md`) outlining the next canary work on `oddkit_gate` (canon-driven refactor + envelope updates), and marks the prior P1.3 handoff as **superseded** via frontmatter (`status` + `superseded_by`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4544edd4ceea14db42716ae6c3850d5607f2e8c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->