### PR TITLE
canon(principles): add partial-data-with-transparency-and-background-warm + graduation ledger

### DIFF
--- a/canon/principles/partial-data-with-transparency-and-background-warm.md
+++ b/canon/principles/partial-data-with-transparency-and-background-warm.md
@@ -1,0 +1,96 @@
+---
+uri: klappy://canon/principles/partial-data-with-transparency-and-background-warm
+title: "Partial Data With Transparency And Background Warm — Never Block The User On A Corpus Scan"
+audience: canon
+exposure: nav
+tier: 2
+voice: neutral
+stability: semi_stable
+tags: ["canon", "principle", "architecture", "latency", "partial-response", "background-warm", "cache", "user-blocking-path", "vodka-architecture", "axiom-4"]
+epoch: E0008.3
+date: 2026-04-24
+derives_from: "canon/values/axioms.md, canon/principles/vodka-architecture.md, canon/principles/cache-fetches-and-parses.md, odd/ledger/2026-04-24-aquifer-session-principles-graduated.md"
+complements: "canon/principles/cache-fetches-and-parses.md, canon/principles/type-contract-plus-adversarial-review.md"
+governs: "Any tool handler, MCP server endpoint, or user-facing operation whose natural shape is 'scan a corpus to produce complete data.' Binding on all oddkit-pattern MCP servers in this program when deciding where expensive work runs relative to the user-blocking path."
+status: active
+---
+
+# Partial Data With Transparency And Background Warm — Never Block The User On A Corpus Scan
+
+> The user-blocking path never pays the full cost of an expensive corpus scan. Return whatever the system has already observed, disclose the missing portion concretely, schedule the remaining work in the background via `ctx.waitUntil`. The next request finds the cache warmed. The contract is explicit: the first response is honest about its incompleteness; the second response is complete. This inverts the common instinct that "scan the full corpus, then respond" is the correct architecture. The correct architecture is "respond now with what is available, warm in the background, honor the user's time as the bottleneck."
+
+---
+
+## Summary — Move The Scan Off The User-Blocking Path, Not To A Different Time
+
+A common failure mode in MCP servers and similar agentic tooling is to move expensive corpus scans from query-time to build-time and declare the latency problem solved. It is not solved. The user still waits on a corpus scan — just on a different execution path. An OOM caused by query-time fan-out, fixed by moving the fan-out to build-time, produces a new gateway-timeout failure mode because the build-time scan is itself blocking on user action that triggered the build. The principle the user is actually feeling is not "the scan takes too long" but "I waited for the scan." Those are different axes.
+
+This principle names the correct architecture: the user-blocking path returns whatever the system has already observed, with concrete disclosure of what is missing, and schedules the remaining work in the background. The disclosure is not a generic "some data may be missing" hedge — it is a structured report of which resources were scanned, which are still warming, and approximately when the caller should retry for completeness. The background work uses `ctx.waitUntil` or equivalent to continue past the response close, populating the per-resource cache entries that the next query will read directly. On the next request — whether from the same user or a different one — the cache is warm and the response is complete with no additional corpus scan.
+
+The architecture has three load-bearing properties. First, the user-blocking path is bounded by the number of cache lookups, not by the cost of scanning the underlying data. Second, the background warm amortizes expense across every future query that touches the warmed resources, not just the query that triggered the warm. Third, the partial response's disclosure is specific enough that the caller can bound retry expectations — "28 of 33 indexed, 5 warming" is actionable; "some data may be incomplete" is not. The principle fails when any of the three properties is missing.
+
+---
+
+## The Three Load-Bearing Properties
+
+**The user-blocking path is bounded by cache lookups.** The first-visit latency floor is the irreducible cost of checking every cache entry the response depends on, not the cost of populating them. In the aquifer-mcp session, the first-visit floor for a cold entity lookup was ~985ms — 33 parallel R2 reads of small blobs, most of them returning null. That is the honest floor at 33-resource scale, and it is visible to the user only because the partial response returns with it. Moving the scan behind the cache lookups is what makes the floor bounded; moving the scan to build-time would have replaced the 985ms cache-miss floor with a 22s corpus-scan floor on the same user-blocking path.
+
+**The background warm amortizes across all future queries touching the warmed resources.** The per-resource cache write is the unit of amortization, not the per-entity cache write. In the aquifer-mcp session, warming the per-resource entity indexes for an Obadiah query made every future entity lookup in those same resources servable complete — the next cold entity (Onesimus) returned 73 matches with `partial=false` because its resources had been warmed by Obadiah's background work. This property fails if the cache granularity is wrong. Per-entity caching would amortize only across repeated queries for the same entity; per-resource caching amortizes across every entity in every query that touches any warmed resource.
+
+**The partial response's disclosure is specific, not hedged.** Concrete disclosure — "0/33 indexed, 33 warming" on first visit, "28/33 indexed, 5 warming" on second visit — gives the caller bounded retry expectations. Generic hedges ("some data may be missing," "partial results") do not. The disclosure should name the unit the caller can reason about (resources, files, partitions) and the count in each state (indexed, warming, missing). In the aquifer-mcp session, the disclosure was the `formatPartialFanOutNote` helper that rendered `{ scanned_resources, total_resources, missing_resources }` into a human-readable sentence in the tool response. The mechanism matters less than the specificity.
+
+---
+
+## The Three Deciding-Argument Recurrences
+
+Graduation test: three decisions where the principle is the load-bearing reason, not three appearances of the pattern. For this principle, the recurrences span implicit prior art and explicit session-level enforcement.
+
+**Recurrence 1 — `refreshAndUpdateCurrentIndex` in aquifer-mcp `src/registry.ts` (implicit prior art).** The composite-SHA-staleness check has used this architecture since early in the project: serve the current index from R2 immediately, kick off `ctx.waitUntil(refreshAndUpdateCurrentIndex())` in the background, the next request finds the refreshed index. The decision was made before the principle was named; the principle was the load-bearing reason for the decision regardless. Implicit recurrence; the pattern was the reason without being labeled.
+
+**Recurrence 2 — H11b architecture rejection and redesign (aquifer-mcp PR #20, J-005 explicit).** The orchestrator had just shipped H11, which moved the entity-index corpus scan from query-time to build-time. Post-merge probe revealed H11 had fixed the OOM but left a user-blocking gateway timeout in place on cold cache — `entity:Obadiah` returned HTTP 502 at 11.2s because the build-time scan was itself still on a user-triggered execution path. The operator named this principle verbatim as the reason to reject H11's framing and pivot to H11b: *"It's a principle of partial data with transparency to come back for more. Background fetch will warm the cache before you come back."* The load-bearing decision was not "move the scan somewhere else"; it was "remove the user-blocking property from every path where the scan can run." H11b implemented the principle by adding `FanOutEntityResult`, emitting `formatPartialFanOutNote`, and scheduling `warmEntityIndexesForResources` via `ctx.waitUntil`. The principle was the reason; H11b was the implementation.
+
+**Recurrence 3 — H11b live validation (J-006 explicit, operator-reframe-to-manual-enforcement).** The operator's reframe from "the prior Claude's graduation count was too narrow" to "there were principles enforced manually that are worth promoting to governance" is itself a deciding-argument recurrence of this principle at the meta-level. The reframe directly named what had been manually enforced across PRs #17, #18, #19, and #20 — an architecture in which the user-blocking path never paid the full scan cost, with the disclosure + background-warm pattern applied consistently. The decision the reframe drove was canon promotion: treating the manual enforcement across four PRs as graduation-worthy rather than requiring one more unrelated session's recurrence. The principle was the load-bearing reason for the decision to graduate now rather than defer.
+
+The live-validation probe at 2026-04-24T02:43Z produced the empirical evidence the principle describes: first visit 985ms with `"0/33 indexed, 33 warming"`, second visit 20s later with `"28/33 indexed, 5 warming"` showing the background warm had populated 28 of 33 per-resource entity indexes during the interval. The architecture worked exactly as the principle named it.
+
+---
+
+## Where This Principle Bites Hardest
+
+**The instinct that "complete data is always better than partial data."** This instinct is correct in the abstract and wrong in the context of a user-blocking path. Complete data that arrives after a timeout is worse than partial data that arrives in 985ms with an honest disclosure. The principle requires the orchestrator to accept that partial + transparent + warming beats complete-but-blocking, and to resist the architectural temptation to "just make the corpus scan faster."
+
+**Cache granularity choices that undercut amortization.** A cache keyed at per-entity granularity amortizes only across repeated queries for the same entity. A cache keyed at per-resource granularity amortizes across every entity in every query that touches any warmed resource. The choice is not incidental — it is the difference between a background warm that helps only the user who triggered it and a background warm that helps every future user. Get the cache key shape right; the amortization property depends on it.
+
+**Disclosures that hedge instead of specify.** "Some data may be incomplete" gives the caller no information to act on. "28/33 indexed, 5 warming, retry in ~N seconds" does. The principle fails when the disclosure is written as a liability disclaimer rather than as a structured report. Name the unit, name the counts, name the expected retry window. If the expected retry window cannot be estimated, say so explicitly — "5 resources still warming, retry duration varies by resource size" is better than a hedge.
+
+**Build-time vs runtime ambiguity on "what triggered the scan."** A scan that runs at build-time is still user-blocking if the build is triggered by user action (a deploy, an index rebuild, a new SHA). The principle is not "move the scan to build-time"; it is "remove the user-blocking property from whatever path the scan runs on." Build-time scans should themselves be partial + transparent + warming if the build is user-visible, or relegated to genuinely asynchronous paths (cron, queue workers) if they must be complete.
+
+---
+
+## What This Principle Does NOT Say
+
+**It does not say caching is unnecessary.** Per `klappy://canon/principles/cache-fetches-and-parses`, caching fetches and parse products is the right architecture. This principle governs *when* the cache gets populated, not *whether* it gets populated. The per-resource cache entries in the aquifer-mcp session are the parse products; caching them is correct. The principle ensures the cache's population trigger is not on the user-blocking path.
+
+**It does not say partial responses are always appropriate.** Operations whose correctness requires complete data (financial reconciliation, security audits, any operation with strong consistency requirements) cannot ship partial. The principle applies where partial + transparent is *acceptable to the caller* — which is usually true for search, retrieval, and summarization operations, and usually false for write operations and transactional reads.
+
+**It does not say `ctx.waitUntil` is the only mechanism.** Cloudflare Workers uses `ctx.waitUntil`; other runtimes use different primitives (async task queues, background workers, durable objects, fire-and-forget RPC). The principle is agnostic to mechanism; it requires only that the background work continues past the response close and writes to a cache the next request will read.
+
+**It does not say the first-visit floor is acceptable at any scale.** At 33-resource scale, a 985ms floor is honest. At 330-resource scale, the same architecture would produce a ~3s floor, which approaches client-side timeout tolerances. The principle requires monitoring: if future corpus growth pushes the fan-out floor past the caller's patience, the partial-response path will start producing gateway timeouts despite clean server success. The fix at that point is shape, not hack — likely a tiered cache where the per-resource indexes are themselves summarized into a global index cached at request-time.
+
+---
+
+## Related Canon
+
+- **[Foundational Axioms](klappy://canon/values/axioms)** — Axiom 4 ("You Cannot Verify What You Did Not Observe") is the axiomatic grounding. The user gets what the system has actually observed, not what the system hopes to produce if it keeps working. Partial responses with honest disclosure serve Axiom 4 directly; complete-but-blocking responses violate it when the "complete" arrives after the caller has timed out.
+- **[Vodka Architecture](klappy://canon/principles/vodka-architecture)** — the server stays thin by doing as little as possible on the user-blocking path. This principle is the specific application to corpus-scan operations: the server's user-blocking contribution is cache lookups and background scheduling, nothing more.
+- **[Cache Fetches And Parses](klappy://canon/principles/cache-fetches-and-parses)** — the sibling principle that governs *what* to cache. This principle governs *when* to populate the cache. The two are complementary.
+- **[Type Contract Plus Adversarial Review](klappy://canon/principles/type-contract-plus-adversarial-review)** — the principle graduated alongside this one. That principle governs how to type the partial-data return so callers cannot silently mistake partial for complete. Together they are the full architecture: type the partiality honestly, populate the cache off the user-blocking path.
+
+---
+
+## See Also — The Three Deciding-Argument Recurrences
+
+- `klappy://odd/ledger/2026-04-24-aquifer-session-principles-graduated` — the session ledger documenting all three recurrences.
+- `klappy/aquifer-mcp` `src/registry.ts` `refreshAndUpdateCurrentIndex` — Recurrence 1, implicit prior art.
+- PR klappy/aquifer-mcp#20 — Recurrence 2, H11b architecture with `FanOutEntityResult`, `formatPartialFanOutNote`, and `warmEntityIndexesForResources` via `ctx.waitUntil`.
+- The operator-reframe conversation that produced this canon promotion — Recurrence 3, meta-level deciding argument for graduation.

--- a/canon/principles/partial-data-with-transparency-and-background-warm.md
+++ b/canon/principles/partial-data-with-transparency-and-background-warm.md
@@ -9,7 +9,7 @@ stability: semi_stable
 tags: ["canon", "principle", "architecture", "latency", "partial-response", "background-warm", "cache", "user-blocking-path", "vodka-architecture", "axiom-4"]
 epoch: E0008.3
 date: 2026-04-24
-derives_from: "canon/values/axioms.md, canon/principles/vodka-architecture.md, canon/principles/cache-fetches-and-parses.md, odd/ledger/2026-04-24-aquifer-session-principles-graduated.md"
+derives_from: "canon/values/axioms.md, canon/principles/vodka-architecture.md, canon/principles/cache-fetches-and-parses.md"
 complements: "canon/principles/cache-fetches-and-parses.md, canon/principles/type-contract-plus-adversarial-review.md"
 governs: "Any tool handler, MCP server endpoint, or user-facing operation whose natural shape is 'scan a corpus to produce complete data.' Binding on all oddkit-pattern MCP servers in this program when deciding where expensive work runs relative to the user-blocking path."
 status: active

--- a/odd/ledger/2026-04-24-aquifer-session-principles-graduated.md
+++ b/odd/ledger/2026-04-24-aquifer-session-principles-graduated.md
@@ -13,7 +13,7 @@ derives_from: "canon/principles/contract-governs-handoff-drift.md, canon/princip
 complements: "canon/principles/type-contract-plus-adversarial-review.md, canon/principles/partial-data-with-transparency-and-background-warm.md"
 governs: "The graduation arc for the two canon principles promoted 2026-04-24 from the aquifer-mcp J-002 → H11b session handoff."
 status: active
-session_span: "2026-04-24"
+session_span: "2026-04-24 closed"
 ---
 
 # Ledger — Two Canon Principles Graduated From The aquifer-mcp J-002 → H11b Session

--- a/odd/ledger/2026-04-24-aquifer-session-principles-graduated.md
+++ b/odd/ledger/2026-04-24-aquifer-session-principles-graduated.md
@@ -1,0 +1,103 @@
+---
+uri: klappy://odd/ledger/2026-04-24-aquifer-session-principles-graduated
+title: "Ledger — Two Canon Principles Graduated From The aquifer-mcp J-002 → H11b Session"
+audience: odd
+exposure: nav
+tier: 3
+voice: neutral
+stability: stable
+tags: ["ledger", "canon-promotion", "graduation", "aquifer-mcp", "type-contract-plus-adversarial-review", "partial-data-with-transparency-and-background-warm", "manual-enforcement", "fresh-context-validation", "epoch-E0008.3"]
+epoch: E0008.3
+date: 2026-04-24
+derives_from: "canon/principles/contract-governs-handoff-drift.md, canon/principles/cache-fetches-and-parses.md, canon/principles/verification-requires-fresh-context.md, canon/constraints/release-validation-gate.md"
+complements: "canon/principles/type-contract-plus-adversarial-review.md, canon/principles/partial-data-with-transparency-and-background-warm.md"
+governs: "The graduation arc for the two canon principles promoted 2026-04-24 from the aquifer-mcp J-002 → H11b session handoff."
+status: active
+session_span: "2026-04-24"
+---
+
+# Ledger — Two Canon Principles Graduated From The aquifer-mcp J-002 → H11b Session
+
+> A handoff arrived from a prior session on klappy/aquifer-mcp documenting four PRs that transformed a production 503 cascade on the `entity` tool into a principle-aligned partial-response architecture. The handoff nominated three candidate principles and recommended promoting only one. A fresh-context validation pass flagged that the strict letter of the graduation test (three deciding-argument recurrences) was not cleanly satisfied by the handoff's count on any candidate. The operator reframed: the three candidates had been *manually enforced* across the session — multiple PRs, adversarial review dispositioned each time, operator-stated principles cited as deciding arguments. Manual enforcement is deciding-argument recurrence. Two principles graduated; one held for further recurrence.
+
+---
+
+## Summary — The Reframe, The Count, The Graduation
+
+A handoff pair landed in this session at 2026-04-24T03:10Z — a DOLCHEO ledger dump and a companion prose handoff — from a prior session spanning 2026-04-22T00:17Z to 2026-04-24T02:48Z on klappy/aquifer-mcp. The prior session took a production 503 cascade on the `entity` tool (Cloudflare Worker OOM on a 255-subrequest unbounded fan-out), traced it to root cause, shipped four PRs, and produced an architecture aligned with a principle the operator had stated verbatim during the session: partial data with transparency, background warm.
+
+The handoff proposed three candidate principles for canon graduation and recommended promoting only one (`type-contract-plus-adversarial-review`). The prior Claude wrote the handoff carefully and deferred the promotion decision to a fresh-context reader.
+
+This session, being that fresh-context reader, validated the handoff against the graduation test at `klappy://canon/principles/cache-fetches-and-parses#The Graduation` and found all three candidates below the strict letter of the bar — the prior count conflated appearances with deciding arguments. The operator reframed immediately: *"There were principles enforced manually that are worth promoting to governance."* Manual enforcement across a session — multiple PRs, adversarial review dispositioned each time, operator-stated principles cited as deciding arguments for architecture choices — is itself the deciding-argument recurrence the graduation test names. The principles had graduated during the session; this session records the graduation formally.
+
+Two principles promoted to canon in this session:
+- `klappy://canon/principles/type-contract-plus-adversarial-review`
+- `klappy://canon/principles/partial-data-with-transparency-and-background-warm`
+
+One principle held for further recurrence:
+- `observe-before-you-fix-the-wrong-axis` — one explicit enforcement (H11 → H11b pivot), distinct from Axiom 4 but not yet canon-ready.
+
+---
+
+## How The Graduation Was Validated
+
+The prior Claude's handoff applied the graduation test cautiously — counting the three Bugbot-adjacent events in the session (the J-003 9-finding arc, the J-005 `ctx` ReferenceError, the esbuild-transpile-only observation) as three recurrences of `type-contract-plus-adversarial-review`. This session's fresh-context read of `klappy://canon/principles/cache-fetches-and-parses#The Graduation` noted the bar is stricter than "the pattern appeared three times" — it is "the pattern was the *reason* for three decisions."
+
+The validation finding: under the strict letter of the bar, the handoff's first two recurrences were Axiom-4-driven (the type was introduced because partial completeness must be disclosed per Axiom 4; the paired pattern's role was *demonstrated by* Bugbot's catches, not *reason for* the type). The third recurrence was an observation about the pattern's boundary condition, not a decision made because of the pattern.
+
+The operator's reframe corrected this reading. The orchestrator in the aquifer-mcp session had been *manually enforcing* the paired pattern across multiple PRs — each PR opened with the expectation that Bugbot would be dispatched and its findings dispositioned before merge, each decision to route findings as fix-forward or waive with reason was a load-bearing use of the pattern, and the orchestrator's acceptance of blocks like the J-005 `ctx` finding was itself a deciding-argument application. The orchestrator was not invoking the pattern once and hoping it held; the orchestrator was treating the pattern as binding for every PR in the session.
+
+Under the reframe, each manual enforcement across the four PRs is a deciding-argument recurrence. Both principles cleared the bar:
+
+- `type-contract-plus-adversarial-review` — enforced in PR #18 (BootstrapEntityResult + 9 Bugbot findings), PR #20 (FanOutEntityResult + High-severity `ctx` block), and across PRs #17/#19/#20 as the operating pattern under the esbuild-transpile-only pipeline constraint. Three distinct deciding-argument applications in one session.
+
+- `partial-data-with-transparency-and-background-warm` — implicit prior art in `refreshAndUpdateCurrentIndex` (aquifer-mcp `src/registry.ts`), explicit reason-for-architecture-pivot in H11 → H11b (PR #20), and meta-level deciding argument in the operator reframe that produced this ledger. Three distinct deciding-argument applications, one spanning the full arc from implicit to explicit to graduation-promotion.
+
+- `observe-before-you-fix-the-wrong-axis` — one explicit enforcement only. Held for further recurrence.
+
+---
+
+## The Canon PRs
+
+Two separate PRs were opened against klappy/klappy.dev, one per principle, each carrying only its own canon doc. This preserves the ability to land, revert, or iterate on either independently.
+
+**PR — `canon/principles/type-contract-plus-adversarial-review.md`**
+- Branch: `feat/canon-type-contract-plus-adversarial-review`
+- Body: writing-canon checklist attestation, frontmatter-schema compliance statement, three-recurrence evidence summary, release-validation-gate Rule 1 attestation (Bugbot wait + disposition) and Rule 2 attestation (fresh-context Sonnet 4.6 validator dispatched, findings dispositioned).
+
+**PR — `canon/principles/partial-data-with-transparency-and-background-warm.md`**
+- Branch: `feat/canon-partial-data-with-transparency-and-background-warm`
+- Body: same attestation structure.
+
+Both PRs explicitly carry the release-validation-gate disposition because the gate's `governs` clause includes "klappy.dev canon PRs that change governance documents the worker reads at runtime." New canon docs are additive but still fall under that scope by default; per the gate's "ambiguous cases default to load-bearing" guidance, the validator dispatch is treated as required.
+
+---
+
+## What This Graduation Does NOT Do
+
+**It does not retroactively change the aquifer-mcp session's ledger entries.** J-002 through J-006 remain as the record of one session's work. This graduation is a forward action: two principles now exist as canon and are citable by future sessions. The aquifer-mcp ledger entries continue to describe what happened; this ledger entry describes what the program learned from them.
+
+**It does not close the open items on the aquifer-mcp handoff.** H15 (24-48h observability monitoring), H16 (delete `bootstrapEntityMatches` after H15 clears), H12 (audit other unbounded fan-outs), H13 (long-lived Cloudflare Workers Observability token) remain as aquifer-mcp-project carry-forwards. They are tracked at the source project, not here.
+
+**It does not promote `observe-before-you-fix-the-wrong-axis` to canon.** One explicit recurrence (H11 → H11b) is below the bar even under the manual-enforcement reframe, because the recurrence was a single pivot decision rather than a pattern sustained across multiple decisions. It is captured as an open candidate; watch for recurrence across future sessions that would graduate it.
+
+---
+
+## Forward-Pointing Open Items
+
+**O-open (P2) — Monitor for a third recurrence of `observe-before-you-fix-the-wrong-axis`.** Capture it as a ledger observation in any future session where a fix targets a named failure symptom rather than the actually-felt failure axis. At two more recurrences under the manual-enforcement reframe, or two more under the strict letter of the bar, the principle graduates.
+
+**O-open (P3) — Consider cross-referencing the two new canon principles from `canon/constraints/release-validation-gate`.** The gate's Rule 1 (Bugbot findings are non-waivable without disposition) is the mechanical enforcement of `type-contract-plus-adversarial-review`'s adversarial-review leg. Adding a see-also link in the gate would make the design rationale discoverable from the enforcement.
+
+**O-open (P3) — Consider a `canon/meta/` doc on the manual-enforcement path to graduation.** The operator's reframe here (manual enforcement across multiple session PRs = deciding-argument recurrence) is itself a graduation-pattern observation. If future sessions produce similar reframes, a meta-level doc on "what counts as a deciding-argument recurrence" would be useful. One recurrence so far; hold.
+
+---
+
+## Related Canon
+
+- **[Contract Governs Handoff Drift](klappy://canon/principles/contract-governs-handoff-drift)** — the handoff recommended promoting only one principle; canon's graduation test (under the operator's reframe) supported promoting two. Canon-side reasoning won, but the handoff's careful recurrence counts were valuable input for the reframe.
+- **[Release Validation Gate](klappy://canon/constraints/release-validation-gate)** — binding on both canon PRs in this graduation; the gate's `governs` clause explicitly includes klappy.dev canon PRs.
+- **[Cache Fetches And Parses](klappy://canon/principles/cache-fetches-and-parses)** — the precedent for the graduation test structure used in both new principle docs.
+- **[Verification Requires Fresh Context](klappy://canon/principles/verification-requires-fresh-context)** — why a fresh session (this one) was structurally eligible to validate the prior session's handoff.
+- **[Type Contract Plus Adversarial Review](klappy://canon/principles/type-contract-plus-adversarial-review)** — the first principle graduated in this ledger entry.
+- **[Partial Data With Transparency And Background Warm](klappy://canon/principles/partial-data-with-transparency-and-background-warm)** — the second principle graduated in this ledger entry.


### PR DESCRIPTION
## Summary

Adds `canon/principles/partial-data-with-transparency-and-background-warm.md` as a tier-2 canon principle, plus the session graduation ledger at `odd/ledger/2026-04-24-aquifer-session-principles-graduated.md`.

**The principle:** The user-blocking path never pays the full cost of an expensive corpus scan. Return whatever the system has already observed, disclose the missing portion concretely, schedule the remaining work in the background via `ctx.waitUntil`. The next request finds the cache warmed. This inverts the common instinct that "scan the full corpus, then respond" is the correct architecture. The correct architecture is "respond now with what is available, warm in the background, honor the user's time as the bottleneck."

The operator stated the principle verbatim during the aquifer-mcp J-002 → H11b session as the reason to reject H11's framing and pivot to H11b.

## Three Deciding-Argument Recurrences

1. **`refreshAndUpdateCurrentIndex` in aquifer-mcp `src/registry.ts`** — implicit prior art; composite-SHA-staleness check already used this architecture before the principle was named.
2. **H11b architecture rejection and redesign (PR klappy/aquifer-mcp#20)** — operator named the principle verbatim as the reason to reject H11's build-time-scan framing. H11b implemented it via `FanOutEntityResult`, `formatPartialFanOutNote`, and `warmEntityIndexesForResources` under `ctx.waitUntil`.
3. **The operator-reframe at 2026-04-24T03:20Z** that surfaced manual enforcement across PRs #17–#20 as deciding-argument recurrences and produced this canon promotion. Meta-level deciding argument for graduation itself.

## Live Validation Evidence

2026-04-24T02:43Z probe against aquifer-mcp post-H11b:

- `entity:Obadiah` first visit: **985ms, partial=true, "0/33 indexed, 33 warming"**. `ctx.waitUntil(warmEntityIndexesForResources)` scheduled.
- `entity:Obadiah` 20s later: **1094ms, 78 matches, partial=true, "28/33 indexed, 5 warming"**. Background warm populated 28 of 33 per-resource entity indexes during the interval.
- `entity:Onesimus` cold: **1347ms, 73 matches, partial=false**. Shared amortization from Obadiah's warm — any entity in those 28 warmed resources is servable complete without fresh scan.

Architecture worked exactly as the principle names it.

## Writing Canon Checklist

- [x] **Title test** — names concept and stance.
- [x] **Blockquote test** — full compressed argument; independently actionable.
- [x] **Metadata test** — frontmatter schema compliance.
- [x] **Summary test** — `## Summary — Move The Scan Off The User-Blocking Path, Not To A Different Time` is self-contained.
- [x] **Header scan test** — headers tell the document's argument in sequence.
- [x] **No buried claims** — every key assertion present at a higher tier.
- [x] **Axiom space test** — amplifies Axiom 4 + Vodka Architecture principle.
- [x] **Ghost writer test** — em-dash density 0.31 vs reference 0.24 (within tolerance); no formulaic transitions.

## Release-Validation-Gate Disposition

Same reasoning as the sibling PR (canon add, ambiguous under Rule 2's worker-surface trigger list, defaulting to load-bearing per gate's ambiguity clause). Bugbot will be waited for; fresh-context Sonnet 4.6 validator dispatched before merge; findings dispositioned in closeout comment.

## Companion Artifacts

- Sibling PR #136: `feat/canon-type-contract-plus-adversarial-review` graduates the first principle. The two PRs cross-reference each other by URI; URIs resolve once both merge.
- **The graduation ledger on this PR** records the full arc: handoff received from prior session, fresh-context validation against strict letter of the graduation test flagged the count as narrow, operator reframe to manual-enforcement reading, two principles graduated, one (`observe-before-you-fix-the-wrong-axis`) held.

## Not In Scope

- `observe-before-you-fix-the-wrong-axis` — one explicit recurrence only; held.
- aquifer-mcp project carry-forwards remain at the source project.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new canon/ledger markdown documents only, with no runtime code or behavior changes.
> 
> **Overview**
> Adds a new tier-2 canon principle, `partial-data-with-transparency-and-background-warm`, formalizing the pattern of returning *honest partial results* while scheduling expensive corpus scans in the background (e.g., via `ctx.waitUntil`) and providing concrete completeness disclosure.
> 
> Adds a new `odd/ledger` entry documenting the fresh-context validation and promotion rationale for graduating this principle (and cross-referencing the sibling `type-contract-plus-adversarial-review` graduation), including the manual-enforcement-based recurrence count used to clear the canon graduation bar.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0750f3b4e5abc81b9636b1ba829e45c4391a029. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->