### PR TITLE
docs(oddkit): client-facing envelope reference + telemetry_public freshening

### DIFF
--- a/docs/oddkit/responses/envelope-reference.md
+++ b/docs/oddkit/responses/envelope-reference.md
@@ -1,0 +1,271 @@
+---
+uri: klappy://docs/oddkit/responses/envelope-reference
+title: "Response Envelope Reference — debug.trace and the Per-Request Story"
+audience: operators
+exposure: nav
+tier: 2
+voice: neutral
+stability: evolving
+tags: ["oddkit", "response", "envelope", "debug", "trace", "transparency", "observability", "client-facing"]
+epoch: E0008
+date: 2026-04-26
+derives_from: "canon/constraints/telemetry-governance.md, canon/principles/vodka-architecture.md"
+complements: "docs/oddkit/tools/telemetry_public.md"
+---
+
+# Response Envelope Reference — debug.trace and the Per-Request Story
+
+> Every oddkit response carries the full story of how it was assembled. This document explains what each field in the response envelope means, with real production traces as worked examples.
+
+## Description
+
+Every oddkit response is a JSON-RPC envelope wrapping a `result`, an `assistant_text`, a `server_time`, and a `debug` block. The `debug` block contains per-request observability that lives only in this response — it is never written to long-term storage. If you want to know why a specific call was slow, why a search returned what it did, or whether your client is hitting cold workers, the answer is in the response you already have.
+
+For aggregate questions across many requests, use the `telemetry_public` tool to query Cloudflare Analytics Engine. The two surfaces share the same arithmetic but serve different audiences: `debug.trace` is for the call you just made; `telemetry_public` is for fleet-level patterns.
+
+## Outline
+
+- The Envelope at a Glance
+- The `debug.trace` Block
+- URL Prefixes — What Each Tier Means
+- Worked Examples from Production
+- When to Read the Envelope vs Query Telemetry
+- Stability Guarantees
+- See Also
+
+---
+
+## The Envelope at a Glance
+
+A typical successful response looks like this:
+
+```json
+{
+  "action": "search",
+  "result": { "...": "tool-specific result payload" },
+  "assistant_text": "...rendered text suitable for direct display...",
+  "server_time": "2026-04-26T22:26:30.506Z",
+  "debug": {
+    "duration_ms": 511,
+    "generated_at": "2026-04-26T22:26:30.506Z",
+    "trace": {
+      "spans": [...],
+      "fetches": [...],
+      "cacheStats": { "hits": 4, "misses": 0, "total": 4 },
+      "total_ms": 721
+    }
+  }
+}
+```
+
+| Field | Meaning |
+|-------|---------|
+| `action` | The action that ran (e.g. `search`, `get`, `orient`) |
+| `result` | Tool-specific payload — the actual answer |
+| `assistant_text` | Pre-rendered text suitable for an LLM client to display directly |
+| `server_time` | Authoritative wall-clock time from the worker. Use this rather than your local clock for time-based reasoning |
+| `debug.duration_ms` | Time spent inside the action handler (not including MCP transport overhead) |
+| `debug.generated_at` | When the response was generated |
+| `debug.trace` | Per-request observability — spans, fetches, cache arithmetic |
+
+> Some tools surface additional fields on `result` — for example, `oddkit_search` returns `hits[]`, `evidence[]`, and `docs_considered`; `oddkit_resolve` returns `supersession_chain`. Those are documented per-tool. The envelope shape above is universal.
+
+---
+
+## The `debug.trace` Block
+
+`debug.trace` has four fields:
+
+### `spans[]` — non-fetch operations
+
+Each entry records something the worker did that wasn't a storage read:
+
+```json
+{ "label": "action:search", "duration_ms": 511 }
+{ "label": "sha:klappy.dev", "duration_ms": 0, "source": "memory" }
+```
+
+- `label` — what the span represents. `action:*` for the action handler itself, `sha:*` for repository-SHA resolution, and so on.
+- `duration_ms` — wall-clock duration in milliseconds.
+- `source` (optional) — present on SHA spans to indicate where the SHA came from (`memory`, `github`, `instance`).
+- `detail` (optional) — free-form supplementary string.
+
+### `fetches[]` — every storage read or network call
+
+Each entry is one trip to a storage tier or external URL:
+
+```json
+{
+  "url": "r2://canon/principles/vodka-architecture.md",
+  "duration_ms": 142,
+  "cached": true,
+  "size": 17217
+}
+```
+
+| Field | Meaning |
+|-------|---------|
+| `url` | Where the data came from. The URL prefix carries the tier (see below). |
+| `duration_ms` | How long the read took, in milliseconds. |
+| `cached` | `true` for cache hits; `false` for misses, cold rebuilds, and live network fetches. This is the primary fact — the URL is the breadcrumb. |
+| `status` | HTTP status code, present only on real network fetches (typically GitHub ZIP archives). |
+| `size` | Byte length of the response, present when known. |
+
+### `cacheStats` — the arithmetic
+
+```json
+{ "hits": 4, "misses": 0, "total": 4 }
+```
+
+Derived from `fetches[]` — `total` is the count of fetch records, `hits` is the count where `cached === true`, `misses = total - hits`. The same numbers feed `cache_hits` and `cache_lookups` in the public telemetry dataset, so per-request and fleet-level views agree by construction.
+
+### `total_ms` — wall-clock for the entire request
+
+Time from request entry to response generation, including all spans and fetches.
+
+---
+
+## URL Prefixes — What Each Tier Means
+
+The `url` field uses a stable prefix scheme that identifies the storage tier. Clients can rely on these prefixes to break down per-fetch latency by tier.
+
+| Prefix | Tier | Typical latency | When `cached` |
+|--------|------|-----------------|---------------|
+| `memory://` | Module-level worker memory cache (5-min TTL) | 0ms | always `true` |
+| `cf-cache://` | Cloudflare Cache API (edge cache) | 1–50ms | `true` on hit, `false` on miss |
+| `r2://` | R2 durable object storage | 50–250ms | `true` on hit, `false` on miss |
+| `build://` | Cold rebuild from a source ZIP | 1500–3000ms | always `false` |
+| `https://...` | Real outbound network fetch (typically a GitHub ZIP archive) | 200–1500ms | always `false`; `status` and `size` populated |
+
+A typical warm-cache request hits `memory://` (instant) or `cf-cache://` (a few ms). A cold-cache request can chain through `cf-cache://` miss → `r2://` miss → `https://github.com/...` for the ZIP → `build://` to extract — visible as four sequential fetch records, all `cached: false`.
+
+> The URL is a breadcrumb, not a literal location. `r2://canon/foo.md` describes the path within the R2 bucket; `cf-cache://index/v2.4/abc123` describes the cache-key shape. The point of the scheme is to give every fetch a stable, parseable identifier.
+
+---
+
+## Worked Examples from Production
+
+These are real envelopes captured from `oddkit.klappy.dev` on 2026-04-26 (cleaned of irrelevant fields for clarity).
+
+### Example 1 — Warm-cache search (everything fast)
+
+```json
+{
+  "action": "search",
+  "result": { "hits": [...] },
+  "debug": {
+    "trace": {
+      "spans": [{ "label": "action:search", "duration_ms": 511 }],
+      "fetches": [
+        { "url": "cf-cache://index/v2.4/...", "duration_ms": 51, "cached": true },
+        { "url": "r2://canon/principles/vodka-architecture.md", "duration_ms": 142, "cached": true, "size": 17217 },
+        { "url": "r2://docs/appendices/epoch-7-1.md", "duration_ms": 134, "cached": true, "size": 8904 },
+        { "url": "r2://canon/principles/maintainability-one-person-indefinitely.md", "duration_ms": 184, "cached": true, "size": 5987 }
+      ],
+      "cacheStats": { "hits": 4, "misses": 0, "total": 4 },
+      "total_ms": 721
+    }
+  }
+}
+```
+
+Reading this trace:
+
+- The search loaded a cached BM25 index from `cf-cache://` (51ms).
+- It then read three result documents from `r2://`, all warm — total 460ms of R2 latency dominates the request.
+- 4 hits, 0 misses. `cacheStats.hits == 4` and `cacheStats.total == 4`, so this request will contribute `cache_hits=4, cache_lookups=4` to the public telemetry.
+
+> If this request were slow, the trace would tell you exactly why: R2 is the dominant cost. Adding a hotter tier in front of R2 (or a Cloudflare Cache layer that holds individual files, not just the index) would address it.
+
+### Example 2 — Cold-cache search (everything slow)
+
+```json
+{
+  "action": "search",
+  "debug": {
+    "trace": {
+      "spans": [{ "label": "action:search", "duration_ms": 11072 }],
+      "fetches": [
+        { "url": "cf-cache://index/v2.4/...", "duration_ms": 33, "cached": false },
+        { "url": "r2://index/v2.4/...", "duration_ms": 82, "cached": false },
+        { "url": "https://github.com/klappy/klappy.dev/archive/main.zip", "duration_ms": 1020, "cached": false, "status": 200, "size": 19271673 },
+        { "url": "build://index/v2.4/default", "duration_ms": 2107, "cached": false },
+        { "url": "r2://docs/archive/klappy-dev/website-telemetry.md", "duration_ms": 103, "cached": false },
+        { "url": "https://github.com/klappy/klappy.dev/archive/main.zip", "duration_ms": 897, "cached": false, "status": 200, "size": 19271673 },
+        { "url": "build://docs/archive/klappy-dev/website-telemetry.md", "duration_ms": 2690, "cached": false, "size": 1141 }
+      ],
+      "cacheStats": { "hits": 0, "misses": 13, "total": 13 }
+    }
+  }
+}
+```
+
+(Some fetches truncated for brevity — the full trace had 13 records.)
+
+Reading this trace:
+
+- `cf-cache://` miss, then `r2://` miss for the index. Both fast (33ms, 82ms) — the misses themselves cost almost nothing; it's what they trigger that's expensive.
+- A GitHub ZIP fetch (1020ms, 19MB) followed by a `build://` rebuild of the search index (2107ms).
+- The same pattern repeats for each result document being read for snippet extraction — three more `build://` rebuilds at ~2 seconds each.
+- 0 hits out of 13 fetches. This single request will contribute `cache_hits=0, cache_lookups=13` to the public telemetry.
+
+> A cold-cache search is roughly 15× slower than a warm one. A reasonable client response to seeing this trace would be: trigger a cheap warmup call (like `oddkit_version`) before any latency-sensitive request to a freshly-spawned worker, or accept the cold tax and surface a "first request is slow" hint to the user.
+
+### Example 3 — Pure-CPU action (no storage at all)
+
+```json
+{
+  "action": "time",
+  "debug": {
+    "trace": {
+      "spans": [{ "label": "action:time", "duration_ms": 0 }],
+      "fetches": [],
+      "cacheStats": { "hits": 0, "misses": 0, "total": 0 },
+      "total_ms": 0
+    }
+  }
+}
+```
+
+Reading this trace:
+
+- No fetches at all — `oddkit_time` is pure-CPU.
+- `cacheStats.total == 0` — this request will contribute `cache_hits=0, cache_lookups=0` to the public telemetry. Any aggregate query that excludes lookup-zero rows (`WHERE cache_lookups > 0`) will exclude this tool entirely, which is usually what you want for cache-effectiveness analysis.
+
+---
+
+## When to Read the Envelope vs Query Telemetry
+
+| Question | Right surface |
+|----------|---------------|
+| Why was *this specific call* slow? | `debug.trace.fetches[]` |
+| Did *this call* hit a cold worker? | `debug.trace.cacheStats` (`hits == 0 && total > 0`) |
+| What URL did the data actually come from? | `debug.trace.fetches[].url` |
+| What's the typical hit rate for `oddkit_audit` over the last week? | `telemetry_public` |
+| Which tools have the highest fan-out? | `telemetry_public` |
+| Has cold-start frequency for `oddkit_search` changed since the last deploy? | `telemetry_public` with a `worker_version` filter |
+
+`debug.trace` is ephemeral, stored only in the response. `telemetry_public` is durable, sampled, and 3-month-retained.
+
+---
+
+## Stability Guarantees
+
+The shape described here reflects oddkit `0.25.0` (the deploy after the [retire-indexsource-interpreter](https://github.com/klappy/oddkit/pull/141) refactor merged on 2026-04-26) and the design pattern adopted from [translation-helps-mcp](https://github.com/klappy/translation-helps-mcp)'s `EdgeXRayTracer`. These are working stability claims, not guarantees:
+
+- **Top-level envelope shape** (`action`, `result`, `assistant_text`, `server_time`, `debug`) has been stable across the E0008 epoch and is intended to remain so. New top-level fields may be added; existing fields are not expected to change shape or be removed without a deprecation window noted in canon.
+- **`debug.trace` field set** (`spans[]`, `fetches[]`, `cacheStats`, `total_ms`) is the current shape. The earlier `index_source` field was removed in the refactor cited above, demonstrating that retirements do happen — they are surfaced via canon updates and PR notes, but clients reading any specific field should be prepared for it to evolve.
+- **The URL-prefix scheme** (`memory://`, `cf-cache://`, `r2://`, `build://`, `https://`) is the current vocabulary. New prefixes may be added when new tiers are introduced; existing prefixes are not expected to be repurposed.
+
+If your client depends on a specific field shape, pin to a known `worker_version` (visible via the `oddkit_version` tool and in every public-telemetry row) and re-verify when that version changes.
+
+The retired field `debug.trace.index_source` — a single string indicating one "winning" cache tier per request — was removed in the [retire-indexsource-interpreter](https://github.com/klappy/oddkit/pull/141) refactor. Clients that read it should switch to `cacheStats` for arithmetic or `fetches[]` for per-tier detail.
+
+---
+
+## See Also
+
+- [telemetry_public](oddkit://tools/telemetry_public) — Aggregate queries across all requests
+- [telemetry_policy](oddkit://tools/telemetry_policy) — What is tracked, what is excluded, and why
+- [Telemetry Governance](klappy://canon/constraints/telemetry-governance) — Authoritative governance constraint
+- [Vodka Architecture](klappy://canon/principles/vodka-architecture) — Why the tracer reports facts and the dashboard does the math

--- a/docs/oddkit/tools/telemetry_public.md
+++ b/docs/oddkit/tools/telemetry_public.md
@@ -8,29 +8,46 @@ voice: neutral
 stability: evolving
 tags: ["oddkit", "tool", "telemetry", "transparency", "analytics", "sql", "vodka-architecture", "prompt-over-code"]
 epoch: E0008
-date: 2026-04-11
+date: 2026-04-26
 derives_from: "canon/constraints/telemetry-governance.md, canon/principles/vodka-architecture.md, canon/principles/prompt-over-code.md"
-complements: "docs/oddkit/tools/telemetry_policy.md"
+complements: "docs/oddkit/tools/telemetry_policy.md, docs/oddkit/responses/envelope-reference.md"
 ---
 
 # telemetry_public — Raw SQL Against the Public Telemetry Dataset
 
 > One tool, one SQL parameter, infinite questions. The server passes your query through to Cloudflare Analytics Engine and returns whatever it finds. No hardcoded leaderboards, no predefined dashboards, no menu of canned reports. The schema is documented. The data is public. Write the query that answers your question.
 
-## Summary — Prompt Over Code for Telemetry
+## Description
 
 `telemetry_public` accepts a raw SQL query against the `oddkit_telemetry` dataset and returns the results. The server has zero domain opinions about which questions to ask — that's the caller's job. The schema is embedded in the tool description so any LLM can write valid queries without a second call.
 
 This design follows Vodka Architecture: the server is a pass-through, not a dashboard. Adding new questions means writing new SQL, not deploying new code. Ten gaps or twenty, the server doesn't change.
+
+Columns are queried by **semantic name** (`tool_name`, `cache_hits`, `duration_ms`), not raw slot identifiers (`blob3`, `double7`, `double2`). The server rewrites the SQL at query time using a SchemaMap fetched from canon, so the names you write match the schema documented here and in `canon/constraints/telemetry-governance.md`.
+
+## Outline
+
+- When to Use
+- Tool Definition
+- Dataset Schema
+- Example Queries
+- Behavioral Rules
+- See Also
+
+---
 
 ## When to Use
 
 - Any question about oddkit usage that can be answered with SQL
 - Building transparency dashboards (web, CLI, or conversational)
 - Investigating spikes, trends, or anomalies
-- Checking adoption signals (which repos are served, which tools are used)
-- Comparing tool performance (duration stats)
+- Checking adoption signals (which knowledge bases are served, which tools are used)
+- Comparing tool performance (duration, cache effectiveness, fan-out)
 - Identifying consumer patterns
+
+For per-request diagnostics on a specific call you just made, look at `debug.trace` in the response envelope instead — that data does not flow into Analytics Engine. See `docs/oddkit/responses/envelope-reference.md`.
+
+---
 
 ## Tool Definition
 
@@ -44,7 +61,7 @@ This design follows Vodka Architecture: the server is a pass-through, not a dash
   "properties": {
     "sql": {
       "type": "string",
-      "description": "SQL query against the oddkit_telemetry dataset"
+      "description": "Analytics Engine SQL query against the oddkit_telemetry dataset"
     }
   },
   "required": ["sql"]
@@ -68,109 +85,192 @@ This design follows Vodka Architecture: the server is a pass-through, not a dash
 }
 ```
 
+---
+
 ## Dataset Schema
 
-Dataset name: `oddkit_telemetry`
+Dataset name: `oddkit_telemetry`. Authoritative governance: `canon/constraints/telemetry-governance.md`.
 
-### Blob Fields (Strings)
+### Structural Dimensions (Strings)
 
-| Field | Column | Content | Example |
-|-------|--------|---------|---------|
-| blob1 | event_type | `"mcp_request"` or `"tool_call"` | `"tool_call"` |
-| blob2 | method | JSON-RPC method | `"tools/call"`, `"initialize"` |
-| blob3 | tool_name | oddkit action name (empty for non-tool events) | `"orient"`, `"search"` |
-| blob4 | consumer_label | Best-effort caller identity | `"Claude-User"`, `"Deno/2.1.4"` |
-| blob5 | consumer_source | How label was resolved | `"x-oddkit-client"`, `"user-agent"` |
-| blob6 | knowledge_base_url | Which knowledge base is being served (from tool args or env default) | `"https://github.com/klappy/klappy.dev"` |
-| blob7 | document_uri | For `get` calls, the URI requested (empty otherwise) | `"klappy://canon/principles/vodka-architecture"` |
-| blob8 | worker_version | oddkit version string | `"0.16.0"` |
+| Column | Content | Example |
+|--------|---------|---------|
+| `event_type` | `"mcp_request"` or `"tool_call"` | `"tool_call"` |
+| `method` | JSON-RPC method | `"tools/call"`, `"initialize"` |
+| `tool_name` | oddkit action name (empty for non-tool events) | `"orient"`, `"search"` |
+| `consumer_label` | Best-effort caller identity | `"Claude-User"`, `"Deno/2.1.4"` |
+| `consumer_source` | How the label was resolved | `"x-oddkit-client"`, `"user-agent"` |
+| `knowledge_base_url` | Which knowledge base is being served | `"https://github.com/klappy/klappy.dev"` |
+| `document_uri` | For `get` calls, the URI requested (empty otherwise) | `"klappy://canon/principles/vodka-architecture"` |
+| `worker_version` | oddkit version string | `"0.25.0"` |
 
-### Double Fields (Numbers)
+> Slot 9 is unused. It previously held `cache_tier` (a single "winning" storage tier per request) and was retired when the tracer was refactored to record per-fetch facts. Cache effectiveness is now derived from `cache_hits` / `cache_lookups` (numeric values 7 and 8).
 
-| Field | Column | Content |
-|-------|--------|---------|
-| double1 | count | Always `1` — use `SUM(_sample_interval)` for totals |
-| double2 | duration_ms | Request processing time in milliseconds |
+### Numeric Values
+
+| Column | Content |
+|--------|---------|
+| `count` | Always `1` — use `SUM(_sample_interval)` for totals |
+| `duration_ms` | Full request wall-clock at the worker edge — includes V8 cold-start, KB fetch, MCP SDK overhead, and handler compute |
+| `bytes_in` | UTF-8 byte length of the JSON-RPC request body. `0` when the body could not be read |
+| `bytes_out` | UTF-8 byte length of the response body. `0` for streamed (SSE) responses where the body cannot be measured without consuming the stream |
+| `tokens_in` | `cl100k_base` token count of the request body. `0` when tokenization was skipped or failed |
+| `tokens_out` | `cl100k_base` token count of the response body. `0` for streamed responses or tokenizer failure |
+| `cache_hits` | Count of per-fetch records in the request whose `cached` flag was true. Sourced from `tracer.cacheStats.hits` |
+| `cache_lookups` | Total per-fetch records in the request — the denominator for hit rate. Sourced from `tracer.cacheStats.total` |
 
 ### Automatic Fields
 
 | Field | Content |
 |-------|---------|
-| timestamp | Automatic per data point — use `toStartOfDay(timestamp)` for daily trends |
-| _sample_interval | Sampling weight — always use `SUM(_sample_interval)` instead of `COUNT(*)` |
+| `timestamp` | Automatic per data point — use `toStartOfInterval(timestamp, INTERVAL '1' DAY)` for daily trends |
+| `_sample_interval` | Sampling weight — always use `SUM(_sample_interval)` instead of `COUNT(*)` |
+
+---
 
 ## Example Queries
 
 These examples are guidance for callers, not code in the server. Write whatever SQL answers your question.
 
 ### Tool leaderboard
+
 ```sql
-SELECT blob3 AS tool, SUM(_sample_interval) AS calls
-FROM oddkit_telemetry WHERE blob1 = 'tool_call'
-GROUP BY tool ORDER BY calls DESC LIMIT 20
+SELECT tool_name, SUM(_sample_interval) AS calls
+FROM oddkit_telemetry
+WHERE timestamp > NOW() - INTERVAL '30' DAY AND tool_name != ''
+GROUP BY tool_name
+ORDER BY calls DESC LIMIT 20
 ```
 
-### All consumers (all events, not just tool calls)
+### Cache hit rate per tool
+
 ```sql
-SELECT blob4 AS consumer, blob5 AS source, SUM(_sample_interval) AS calls
+SELECT tool_name,
+       SUM(cache_hits) AS hits,
+       SUM(cache_lookups) AS lookups,
+       ROUND(SUM(cache_hits) / SUM(cache_lookups) * 100, 1) AS hit_rate_pct
 FROM oddkit_telemetry
-GROUP BY consumer, source ORDER BY calls DESC LIMIT 20
+WHERE timestamp > NOW() - INTERVAL '7' DAY AND cache_lookups > 0
+GROUP BY tool_name
+ORDER BY lookups DESC
+```
+
+### Per-tool storage fan-out — which actions touch the most data per call
+
+```sql
+SELECT tool_name,
+       SUM(_sample_interval) AS calls,
+       ROUND(AVG(cache_lookups), 1) AS avg_fetches_per_call,
+       MAX(cache_lookups) AS peak_fetches
+FROM oddkit_telemetry
+WHERE timestamp > NOW() - INTERVAL '7' DAY AND tool_name != ''
+GROUP BY tool_name
+ORDER BY avg_fetches_per_call DESC
+```
+
+### Cold-start frequency — how often does each tool hit a cold worker
+
+A request with `cache_lookups > 0 AND cache_hits = 0` did at least one storage read and missed every cache tier — strong signal of a cold V8.
+
+```sql
+SELECT tool_name,
+       SUM(_sample_interval) AS calls,
+       SUM(IF(cache_hits = 0 AND cache_lookups > 0, _sample_interval, 0)) AS cold_calls,
+       ROUND(SUM(IF(cache_hits = 0 AND cache_lookups > 0, _sample_interval, 0))
+             / SUM(_sample_interval) * 100, 1) AS cold_pct
+FROM oddkit_telemetry
+WHERE timestamp > NOW() - INTERVAL '24' HOUR AND tool_name != ''
+GROUP BY tool_name
+HAVING SUM(_sample_interval) >= 5
+ORDER BY cold_pct DESC
+```
+
+### Latency vs fan-out — does doing more storage work make a tool slower?
+
+```sql
+SELECT tool_name,
+       ROUND(AVG(duration_ms), 0) AS avg_ms,
+       ROUND(AVG(cache_lookups), 1) AS avg_lookups,
+       ROUND(AVG(bytes_out), 0) AS avg_bytes_out
+FROM oddkit_telemetry
+WHERE timestamp > NOW() - INTERVAL '7' DAY AND tool_name != ''
+GROUP BY tool_name
+HAVING SUM(_sample_interval) >= 5
+ORDER BY avg_ms DESC
 ```
 
 ### Knowledge bases served (the adoption signal)
-```sql
-SELECT blob6 AS knowledge_base_url, SUM(_sample_interval) AS calls
-FROM oddkit_telemetry WHERE blob1 = 'tool_call'
-GROUP BY knowledge_base_url ORDER BY calls DESC
-```
 
-### Daily trend
 ```sql
-SELECT toStartOfDay(timestamp) AS day, SUM(_sample_interval) AS calls
-FROM oddkit_telemetry GROUP BY day ORDER BY day DESC LIMIT 30
-```
-
-### Consumer × tool matrix
-```sql
-SELECT blob4 AS consumer, blob3 AS tool, SUM(_sample_interval) AS calls
-FROM oddkit_telemetry WHERE blob1 = 'tool_call'
-GROUP BY consumer, tool ORDER BY consumer, calls DESC
-```
-
-### Duration stats per tool
-```sql
-SELECT blob3 AS tool, AVG(double2) AS avg_ms, MAX(double2) AS max_ms,
-  SUM(_sample_interval) AS calls
-FROM oddkit_telemetry WHERE blob1 = 'tool_call'
-GROUP BY tool ORDER BY avg_ms DESC
-```
-
-### Consumer trend (daily by consumer)
-```sql
-SELECT toStartOfDay(timestamp) AS day, blob4 AS consumer, SUM(_sample_interval) AS calls
+SELECT knowledge_base_url, SUM(_sample_interval) AS calls
 FROM oddkit_telemetry
-GROUP BY day, consumer ORDER BY day DESC, calls DESC LIMIT 50
+WHERE timestamp > NOW() - INTERVAL '30' DAY AND event_type = 'tool_call'
+GROUP BY knowledge_base_url
+ORDER BY calls DESC
+```
+
+### All consumers (all events, not just tool calls)
+
+```sql
+SELECT consumer_label, consumer_source, SUM(_sample_interval) AS calls
+FROM oddkit_telemetry
+WHERE timestamp > NOW() - INTERVAL '30' DAY
+GROUP BY consumer_label, consumer_source
+ORDER BY calls DESC LIMIT 20
+```
+
+### Daily call volume
+
+```sql
+SELECT toStartOfInterval(timestamp, INTERVAL '1' DAY) AS day,
+       SUM(_sample_interval) AS calls
+FROM oddkit_telemetry
+WHERE timestamp > NOW() - INTERVAL '30' DAY
+GROUP BY day
+ORDER BY day DESC
 ```
 
 ### Most accessed documents
+
 ```sql
-SELECT blob7 AS document_uri, SUM(_sample_interval) AS calls
-FROM oddkit_telemetry WHERE blob7 != ''
-GROUP BY document_uri ORDER BY calls DESC LIMIT 20
+SELECT document_uri, SUM(_sample_interval) AS calls
+FROM oddkit_telemetry
+WHERE timestamp > NOW() - INTERVAL '30' DAY AND document_uri != ''
+GROUP BY document_uri
+ORDER BY calls DESC LIMIT 20
 ```
+
+### Token-cost ranking — which tools produce the most output per call
+
+```sql
+SELECT tool_name,
+       SUM(_sample_interval) AS calls,
+       ROUND(AVG(tokens_out), 0) AS avg_tokens_out,
+       MAX(tokens_out) AS peak_tokens_out
+FROM oddkit_telemetry
+WHERE timestamp > NOW() - INTERVAL '7' DAY AND tool_name != ''
+GROUP BY tool_name
+ORDER BY avg_tokens_out DESC
+```
+
+---
 
 ## Behavioral Rules
 
 1. **Pass-through, not dashboard.** The server executes the SQL and returns the result. It has no opinion about which queries are interesting.
-2. **Schema is the interface.** The dataset schema is documented here and embedded in the tool description. Callers write SQL based on the schema — no menu, no enum, no predefined reports.
+2. **Schema is the interface.** The dataset schema is documented here and embedded in the tool description. Callers write SQL using the semantic column names — no menu, no enum, no predefined reports.
 3. **Public data, same as the maintainer sees.** There is no privileged query interface.
 4. **Results may be sampled.** Always use `SUM(_sample_interval)` instead of `COUNT(*)`.
 5. **Retention is 3 months.** Data older than 3 months is not available.
 6. **Prompt over code.** New questions are answered by writing new SQL, not by deploying new server code.
+7. **Per-request detail lives in the response envelope, not here.** For per-fetch URLs, sizes, and latencies on a specific call, see `debug.trace.fetches[]` in that call's response. Analytics Engine stores only the aggregate counts (`cache_hits`, `cache_lookups`) — not the individual records.
 
-## Canon References
+---
+
+## See Also
 
 - [Telemetry Governance](klappy://canon/constraints/telemetry-governance) — What is tracked, what is excluded, and why
 - [telemetry_policy](oddkit://tools/telemetry_policy) — Fetch the governance document at runtime
+- [Response Envelope Reference](klappy://docs/oddkit/responses/envelope-reference) — Per-request `debug.trace` shape and how to read it
 - [Vodka Architecture](klappy://canon/principles/vodka-architecture) — Thin server, rich canon
 - [Prompt Over Code](klappy://canon/principles/prompt-over-code) — Governance in documents, not compiled into the server


### PR DESCRIPTION
## What

Two doc changes that close the gap between the deployed worker (which serves the new `debug.trace` shape from oddkit PR #141) and what a random consumer of `oddkit.klappy.dev/mcp` can actually read.

### `docs/oddkit/responses/envelope-reference.md` (NEW)

Client-facing reference for the response envelope. The doc that didn't exist anywhere before — without it, the per-fetch arithmetic surfaced by PR #141 was invisible to anyone but the maintainer.

Walks through:

- Top-level shape (`action`, `result`, `assistant_text`, `server_time`, `debug`)
- The `debug.trace` block: `spans[]`, `fetches[]`, `cacheStats`, `total_ms`
- URL-prefix vocabulary (`memory://` `cf-cache://` `r2://` `build://` `https://`) with typical latencies
- **Three worked examples from real production traces captured 2026-04-26**: warm-cache search (4/4 hits, 721ms), cold-cache search (0/13 hits, 11s), and pure-CPU action (no fetches)
- When to read the envelope vs query `telemetry_public`
- Scope-bound stability claims pinned to oddkit `0.25.0` / E0008, with a concrete `worker_version` pinning strategy

### `docs/oddkit/tools/telemetry_public.md` (REWRITTEN)

Static doc was two epochs stale:

- **Missing all 4 payload-shape doubles** (`bytes_in/out`, `tokens_in/out` from E0008.x)
- **Missing the new cache doubles** (`cache_hits`, `cache_lookups` from PR #141)
- Example queries used raw `blob3` / `double2` slot identifiers instead of the semantic names that the deployed SchemaMap rewrite supports
- Stale `worker_version` example string

Updates:

- Schema tables now match the live `tools/list` description verbatim
- All example queries use semantic names (`tool_name`, `cache_hits`, `duration_ms`)
- New worked examples from the ship-day demo: cache hit rate per tool, per-tool storage fan-out, cold-start frequency, latency vs fan-out, token-cost ranking — all of which run today against production
- Cross-link to `envelope-reference.md` for per-request diagnostics
- Slot 9 retirement noted inline where readers will look for it
- Behavioral rules add: *"Per-request detail lives in the envelope, not here"*

## What was already current and didn't need updating

- **Live MCP `tools/list` `telemetry_public` description** — updated as part of PR #141, verified clean (no references to `cache_tier` or `index_source`, includes `cache_hits`/`cache_lookups`)
- **`canon/constraints/telemetry-governance.md`** — updated in PR #144 (this repo)
- **Deployed worker bundle** — verified serving new envelope shape with real production traces

## Pre-commit pressure-test

Ran `oddkit_challenge` in `peer-review-ready` mode against the stability-guarantee claims in the new envelope-reference doc. It correctly flagged over-confident "stable contract" framing on a project still labeled `stability: evolving`. Addressed by:

- Scope-binding to oddkit `0.25.0` and the E0008 epoch
- Naming the comparison target (`translation-helps-mcp`'s `EdgeXRayTracer`) explicitly
- Acknowledging that the retired `index_source` field is itself proof that "stable" doesn't mean "frozen"
- Giving clients a concrete `worker_version` pinning strategy if they need stronger guarantees

## Doc-only PR

No code, no schema, no behavioral changes. Frontmatter follows the schema (booleans/integers/dates unquoted, strings with special chars quoted).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only changes with no runtime behavior, data handling, or interface changes beyond clarifying existing fields.
> 
> **Overview**
> Adds a new `envelope-reference.md` that documents the oddkit JSON-RPC response envelope and the current `debug.trace` shape (`spans`, `fetches`, `cacheStats`, `total_ms`), including the URL-prefix vocabulary and worked warm/cold/pure-CPU examples.
> 
> Rewrites `telemetry_public` docs to align with the live dataset: documents semantic column names (vs `blob*`/`double*` slots), includes newer metrics like `bytes_*`, `tokens_*`, and `cache_hits`/`cache_lookups`, updates/expands example SQL queries, and cross-links to the new envelope reference for per-request diagnostics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2371f275fea01b57b3623e571c9a4714a83e2d9b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->