### PR TITLE
writings: clear canon floor (audit-allow forward-refs to upcoming Ch.7 + Appendix A)

### DIFF
--- a/writings/choosing-faith-not-fear.md
+++ b/writings/choosing-faith-not-fear.md
@@ -200,4 +200,7 @@ AI is the newest thing under the sun. It's genuinely impressive. It's genuinely 
 
 Choose faith, not fear. Not because the fear isn't real — it is. But because the thing you're afraid of losing was never the thing that defined you. And the one who does define you has never, not once, failed to show up.
 
-*The next chapter, [The Most Expensive Problem](klappy://writings/the-most-expensive-problem), zooms out to the civilizational pattern — every generation faced the same bottleneck, and AI just inverted the cost. Or if you'd rather jump to the principles, [Four Questions That Change Everything](klappy://writings/four-questions-that-change-everything) gives you the framework without the story.*
+*The next chapter, [The Most Expensive Problem](klappy://writings/the-most-expensive-problem), zooms out to the civilizational pattern — every generation faced the same bottleneck, and AI just inverted the cost.*
+
+<!-- audit-allow: dead-reference reason="forward-ref to upcoming Ch.7; drafted at draft-zeros/ch07-four-questions-that-change-everything; auto-heals on promote to writings/" -->
+*Or if you'd rather jump to the principles, [Four Questions That Change Everything](klappy://writings/four-questions-that-change-everything) gives you the framework without the story.*

--- a/writings/the-broken-wall-and-the-buried-talent.md
+++ b/writings/the-broken-wall-and-the-buried-talent.md
@@ -329,4 +329,7 @@ The servant who buried his talent saw a hard master and hid. The child who knows
 
 Dig it up. Bring it to the room. The wall won't build itself. And it was never about the wall anyway.
 
-*The previous chapter, [Choosing Faith, Not Fear](klappy://writings/choosing-faith-not-fear), anchors identity in what doesn't change. This chapter asks what that identity demands of us. The appendix, [The Biblical Roots](klappy://draft-zeros/appendix-a-the-biblical-roots), maps the scriptural foundations underneath every principle in this book.*
+*The previous chapter, [Choosing Faith, Not Fear](klappy://writings/choosing-faith-not-fear), anchors identity in what doesn't change. This chapter asks what that identity demands of us.*
+
+<!-- audit-allow: dead-reference reason="forward-ref to Appendix A; drafted at draft-zeros/appendix-a-the-biblical-roots; auto-heals on promote to writings/ or whichever published path the appendix lands at" -->
+*The appendix, [The Biblical Roots](klappy://draft-zeros/appendix-a-the-biblical-roots), maps the scriptural foundations underneath every principle in this book.*

--- a/writings/the-broken-wall-and-the-buried-talent.md
+++ b/writings/the-broken-wall-and-the-buried-talent.md
@@ -331,5 +331,5 @@ Dig it up. Bring it to the room. The wall won't build itself. And it was never a
 
 *The previous chapter, [Choosing Faith, Not Fear](klappy://writings/choosing-faith-not-fear), anchors identity in what doesn't change. This chapter asks what that identity demands of us.*
 
-<!-- audit-allow: dead-reference reason="forward-ref to Appendix A; drafted at draft-zeros/appendix-a-the-biblical-roots; auto-heals on promote to writings/ or whichever published path the appendix lands at" -->
-*The appendix, [The Biblical Roots](klappy://draft-zeros/appendix-a-the-biblical-roots), maps the scriptural foundations underneath every principle in this book.*
+<!-- audit-allow: dead-reference reason="forward-ref to Appendix A; drafted at draft-zeros/appendix-a-the-biblical-roots.md with canonical uri klappy://writings/the-biblical-roots; auto-heals on promote to writings/" -->
+*The appendix, [The Biblical Roots](klappy://writings/the-biblical-roots), maps the scriptural foundations underneath every principle in this book.*

--- a/writings/the-broken-wall-and-the-buried-talent.md
+++ b/writings/the-broken-wall-and-the-buried-talent.md
@@ -86,7 +86,7 @@ related:
   - uri: klappy://writings/the-biblical-roots
     label: "The Biblical Roots (appendix)"
     relationship: related
-complements: "writings/choosing-faith-not-fear.md, writings/the-biblical-roots.md"
+complements: "writings/choosing-faith-not-fear.md, draft-zeros/appendix-a-the-biblical-roots.md"
 ---
 
 # The Broken Wall and the Buried Talent

--- a/writings/the-broken-wall-and-the-buried-talent.md
+++ b/writings/the-broken-wall-and-the-buried-talent.md
@@ -83,10 +83,10 @@ related:
   - uri: klappy://writings/choosing-faith-not-fear
     label: "Choosing Faith, Not Fear (previous chapter)"
     relationship: prequel
-  - uri: klappy://draft-zeros/appendix-a-the-biblical-roots
+  - uri: klappy://writings/the-biblical-roots
     label: "The Biblical Roots (appendix)"
     relationship: related
-complements: "writings/choosing-faith-not-fear.md, draft-zeros/appendix-a-the-biblical-roots.md"
+complements: "writings/choosing-faith-not-fear.md, writings/the-biblical-roots.md"
 ---
 
 # The Broken Wall and the Buried Talent

--- a/writings/the-voice-came-first.md
+++ b/writings/the-voice-came-first.md
@@ -241,4 +241,5 @@ Maybe text was always just the compression. Maybe we’re watching the reason fo
 
 Nothing new under the sun. The oldest method. The newest technology. The same question.
 
+<!-- audit-allow: dead-reference reason="forward-ref to upcoming Ch.7; drafted at draft-zeros/ch07-four-questions-that-change-everything; auto-heals on promote to writings/" -->
 *The next chapter, [Four Questions That Change Everything](klappy://writings/four-questions-that-change-everything), takes the pattern you just saw — voice first, artifact last, verify everything — and compresses it into four axioms that govern every kind of collaboration. Or if you’d rather see the system in action first, [Your AI Collaboration’s Memory](klappy://writings/the-project-journal) shows you how to stop losing what you’ve already figured out.*


### PR DESCRIPTION
PR-3.1.5 of the link-rot campaign — clears the canon floor of the three pre-existing dead references that the canon-quality workflow surfaces on its first run, so the observation cycle (and eventual hard-block flip in PR-3.2) starts against a zero-findings baseline.## What this PR doesThree writings touch closing-italic "offramp" paragraphs that point forward to upcoming book chapters that aren't published yet:| File | Forward-ref target | Drafted at ||---|---|---|| `writings/choosing-faith-not-fear.md` | `klappy://writings/four-questions-that-change-everything` | `draft-zeros/ch07-four-questions-that-change-everything.md` || `writings/the-broken-wall-and-the-buried-talent.md` | `klappy://draft-zeros/appendix-a-the-biblical-roots` | `draft-zeros/appendix-a-the-biblical-roots.md` (resolver does not serve `draft-zeros/` paths) || `writings/the-voice-came-first.md` | `klappy://writings/four-questions-that-change-everything` | same as row 1 |These are intentional rot — the chapters are on the way. Each gets a line-level `<!-- audit-allow: dead-reference reason="..." -->` directive per the audit spec (`klappy://docs/oddkit/specs/oddkit-audit` v2.2 §Allowlist).## Editorial change in two of three filesTwo of the three target lines contain **multiple links per line** — the closing italic paragraph has both a "next chapter" pointer and a separate offramp link. Per spec, `audit-allow` directives are line-level and scope to the **next** markdown link only, not all links on a multi-link line. To make the directive land on the actually-dead link, the closing italic paragraph is split into two italic paragraphs at the natural rhetorical seam:- `choosing-faith-not-fear.md` — splits "next chapter" pointer from "or if you'd rather jump to the principles" offramp- `the-broken-wall-and-the-buried-talent.md` — splits "previous chapter / this chapter" pair from the appendix referenceBoth reads more naturally as two italic paragraphs than as comma-spliced single lines.`the-voice-came-first.md` already has the dead link as the first link on the line, so only the directive is added — no prose change.## What the directives sayAll three reasons follow the same pattern:```forward-ref to <upcoming target>; drafted at <draft-zeros path>; auto-heals on promote to writings/```When each chapter is promoted from `draft-zeros/` to `writings/` (or wherever the appendix lands), the resolver will start finding the URI, the audit will return OK on that finding, and the directive becomes harmless dead text. A future cleanup sweep can remove it; until then it does no harm.## Verification pathAfter merge, the canon-quality workflow re-runs against main and the next PR. Expected new floor: **zero dead-reference findings** in `writings/` default scope. The three findings move from `findings` to `suppressed_findings` in the audit envelope (count visible to reviewers per spec §Allowlist).## Refs- Spec: `klappy://docs/oddkit/specs/oddkit-audit` (DRAFT v2.2 §Allowlist)- Workflow that surfaced these: klappy/klappy.dev#149 (Phase 3 PR-3.1)- Campaign: `klappy://docs/planning/link-rot-elimination-campaign` (Phase 3 between PR-3.1 and PR-3.2)- Session ledger covering this thread of work: `klappy://odd/ledger/2026-04-27-link-rot-phase-2-shipped`## After this PRPR-3.1 (#149) merges → this PR merges → observation cycle on real PRs (3–5 of them) → PR-3.2 flips `vars.AUDIT_ENFORCEMENT_MODE` to `hard`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only changes that add audit suppression annotations and adjust link formatting; main risk is unintended link/URI mistakes affecting navigation or audit baselines.
> 
> **Overview**
> Clears the `writings/` dead-reference audit baseline by adding line-scoped `<!-- audit-allow: dead-reference ... -->` directives for intentional forward references to the upcoming Ch.7 and Appendix A.
> 
> To ensure the allowlist applies to the correct target, the closing italic “offramp” lines are split into separate italic paragraphs in two chapters, and the appendix pointer is updated from a `draft-zeros` URI to the canonical `klappy://writings/the-biblical-roots`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01498d4cd671532530ee758ad83ac616eaf871df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->