### PR TITLE
P0009 (accept + execute): DOLCHEO+H anti-pattern callout in dolcheo-vocabulary

### DIFF
--- a/canon/definitions/dolcheo-vocabulary.md
+++ b/canon/definitions/dolcheo-vocabulary.md
@@ -216,6 +216,27 @@ This article exists so that any search for "DOLCHEO," "DOLCHE," "OLDC+H," "sessi
 
 ---
 
+## Anti-Pattern — Do Not Write "DOLCHEO+H"
+
+The vocabulary is **DOLCHEO**. The seven letters are D-O-L-C-**H**-E-O — Handoffs is the fifth letter, already inside the acronym. Writing **DOLCHEO+H** is malformed:
+
+- It doubles the H (once inside the acronym, once as the suffix).
+- It is residue from the superseded `OLDC+H` vocabulary (`docs/oddkit/proactive/oldc-h-vocabulary.md`), in which Handoffs were appended with `+H` because the original four letters did not include them. DOLCHEO absorbed Handoffs into the acronym; the suffix is no longer needed.
+- It propagates because agents see "OLDC+H" in canon-adjacent context (this doc's See Also, ledger headers in older artifacts) and pattern-match the suffix onto the new vocabulary by mistake.
+
+When tagging or describing session capture, write **DOLCHEO**. The Handoff section is named with the letter `H` inside the acronym, just like Decision is `D` and Encode is `E`.
+
+### If you are reading an older artifact that uses "DOLCHEO+H"
+
+Treat it as a typo equivalent to "DOLCHEO." Do not propagate the form into new artifacts. If editing the older artifact, correct it.
+
+### Receipts
+
+- `klappy/PTXprint-MCP/canon/encodings/pr-30-fresh-validator-ledger.md` line ~12 — contains "DOLCHEO+H encoding of findings." Marked here as the propagation source for at least one downstream session's hallucination chain.
+- 2026-05-03 slate-authoring session — agent propagated the form 8 times across two synthesis documents before operator correction. Direct stimulus for this anti-pattern callout.
+
+---
+
 ## See Also
 
 - [DOLCHE (superseded)](klappy://docs/oddkit/proactive/dolche-vocabulary) — the prior six-dimension vocabulary this document extends

--- a/docs/promotions/P0009-dolcheo-not-dolcheo-plus-h-anti-pattern.md
+++ b/docs/promotions/P0009-dolcheo-not-dolcheo-plus-h-anti-pattern.md
@@ -6,8 +6,8 @@ exposure: nav
 tier: 3
 voice: neutral
 stability: evolving
-tags: ["promotions", "proposed", "dolcheo", "vocabulary", "anti-pattern", "amendment"]
-promotion_status: proposed
+tags: ["promotions", "accepted", "dolcheo", "vocabulary", "anti-pattern", "amendment"]
+promotion_status: accepted
 ---
 
 # P0009: DOLCHEO+H Is Not the Vocabulary — Explicit Anti-Pattern Callout
@@ -104,16 +104,14 @@ The PTXprint PR-30 ledger's malformed instance is also flagged as a receipt so a
 
 ## Status
 
-`proposed`
+`accepted` (2026-05-05)
 
 ## Review Notes
 
-(To be filled during review)
-
-- **Reviewer**:
-- **Decision**:
-- **Date**:
-- **Notes**:
+- **Reviewer**: klappy (operator)
+- **Decision**: `accepted`
+- **Date**: 2026-05-05
+- **Notes**: Accepted in the same session that surfaced eight stuck `proposed` proposals (P0001 + P0003–P0009) sitting behind the just-merged P0002 promotion chain (PRs #163 → #165 → #166). The "DOLCHEO+H" hallucination is operator-named recurring frustration ("It's minor but I'm frustrated at it resurfacing every conversation"), and the proposed canon edit is a single appended section with one paragraph of net-new prose plus receipts — the smallest possible surface to kill the recurrence at the source. Accepted as drafted; execution committed in the same PR.
 
 ## Execution Record
 


### PR DESCRIPTION
## What this PR does

Combined **acceptance + execution** of promotion **P0009** — the explicit anti-pattern callout for the malformed string `DOLCHEO+H`.

### Acceptance (1 file, +5/-7)
- `docs/promotions/P0009-dolcheo-not-dolcheo-plus-h-anti-pattern.md`
  - `promotion_status: proposed` → `accepted`
  - Tags array `"proposed"` → `"accepted"`
  - Status section header → `accepted` (2026-05-05)
  - Review Notes filled with operator decision

### Execution (1 file, +21/-0)
- `canon/definitions/dolcheo-vocabulary.md`
  - New section `## Anti-Pattern — Do Not Write "DOLCHEO+H"` inserted between `## Discoverability` and `## See Also`
  - Three-bullet rationale (doubled H, OLDC+H residue, propagation mechanism)
  - Sub-section for handling older artifacts that contain the malformed form
  - Receipts citing the propagation source (PTXprint PR #30 ledger) and the 2026-05-03 slate-authoring session

## Why P0009 first

This is the first of **8 stuck `proposed` promotions** sitting behind P0002's just-merged chain (PRs #163 → #165 → #166). Triage order:

1. **P0009** ← this PR — operator-stated frustration ("resurfacing every conversation"); smallest possible execution surface
2. P0001 — oldest backlog item; foundational completion-claims-require-artifacts
3. P0008 — fresh-validator DOLCHEO ledger convention (affects current release-validation-gate workflow)
4. P0007 — DoD as agent-observable behaviors
5. P0006 — vodka boundary enumeration
6. P0003 — reframe-before-trimming method
7. P0004 — docs-proxy canon-as-tool pattern
8. P0005 — async-by-default-for-long-running-tools principle

## Combined-PR note

P0002 separated acceptance (PR #165) from execution (PR #166). This PR combines them to halve review burden across the 8-proposal backlog. If you'd rather have them split (matching P0002's pattern exactly), say so and I'll re-do the remaining 7 as paired PRs.

## DoD

- [x] Proposal frontmatter `promotion_status` flipped to `accepted`
- [x] Review Notes block filled with reviewer / decision / date / notes
- [x] Canon edit text matches the proposed language in P0009 §"Proposed Language" verbatim
- [x] Insertion point matches the proposed section position ("near the end, before `## See Also`")
- [x] No other canon docs touched

## Verification after merge

`oddkit_search` for `"DOLCHEO+H"` should surface this new anti-pattern section ahead of the OLDC+H legacy doc and any older ledger references.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that clarifies correct DOLCHEO terminology and updates a promotion record; no runtime or workflow logic is modified.
> 
> **Overview**
> Adds an explicit **anti-pattern** section to `canon/definitions/dolcheo-vocabulary.md` stating that `DOLCHEO+H` is malformed, explaining why it appears (legacy `OLDC+H` residue) and how to treat/correct older artifacts, with receipts.
> 
> Updates promotion `P0009` to **accepted** by flipping frontmatter (`tags`, `promotion_status`), marking status/date, and filling in review notes to record the acceptance decision.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59e6860b4e16fdad79d37face2b85830da7af0a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->