### PR TITLE
P0001 (accept + execute): completion claims require artifacts in definition-of-done

### DIFF
--- a/canon/constraints/definition-of-done.md
+++ b/canon/constraints/definition-of-done.md
@@ -47,6 +47,8 @@ This policy is a specific application of the foundational axiom that every claim
 - MUST NOT claim "done" without evidence; the correct response is "This is not complete yet"
 - MUST label partial completion explicitly with what was verified and what remains
 - MUST validate document deliverables against the Writing Canon checklist (`canon/meta/writing-canon.md`) before claiming completion
+- MUST NOT mark a claim as verified without at least one artifact that demonstrates the claimed outcome
+- MUST return `NEEDS_ARTIFACTS` (not `PASS`) when a completion claim exists but the supporting evidence is absent
 
 ---
 
@@ -68,6 +70,7 @@ This policy is a specific application of the foundational axiom that every claim
 - **"I reviewed the code"**: Treating inspection as observation of behavior
 - **"I didn't have time to test"**: Treating explanation as exemption from evidence
 - **"The document exists"**: Treating file creation as completion without validating progressive disclosure structure
+- **"Unverified Completion"**: Accepting a "done" / "finished" / "shipped" claim without corresponding artifacts (screenshots, logs, links, command output). The validation pathway MUST return `NEEDS_ARTIFACTS`, not `PASS`
 
 ---
 

--- a/docs/promotions/P0001-completion-requires-artifacts.md
+++ b/docs/promotions/P0001-completion-requires-artifacts.md
@@ -6,8 +6,8 @@ exposure: nav
 tier: 3
 voice: neutral
 stability: evolving
-tags: ["promotions", "proposed", "validation", "evidence"]
-promotion_status: proposed
+tags: ["promotions", "accepted", "validation", "evidence"]
+promotion_status: accepted
 ---
 
 # P0001: Completion Claims Require Artifacts
@@ -85,16 +85,14 @@ Add to Failure Modes:
 
 ## Status
 
-`proposed`
+`accepted` (2026-05-05)
 
 ## Review Notes
 
-(To be filled during review)
-
-- **Reviewer**:
-- **Decision**:
-- **Date**:
-- **Notes**:
+- **Reviewer**: klappy (operator)
+- **Decision**: `accepted`
+- **Date**: 2026-05-05
+- **Notes**: Oldest backlog item in the `proposed` queue. The Validation Agent (`infra/orchestrator/services/validation.js`) already enforces this at code level via `determineVerdict()` — this canon edit aligns the written constraint with the enforced behavior. Accepted as drafted; execution committed in the same PR appends two MUST bullets to `## Operating Constraints` and one new entry to `## Failure Modes` of `canon/constraints/definition-of-done.md`.
 
 ## Execution Record
 


### PR DESCRIPTION
## What this PR does

Combined acceptance + execution of promotion **P0001** — aligns the canonical Definition of Done with the Validation Agent's already-enforced behavior.

### Acceptance (1 file)
- `docs/promotions/P0001-completion-requires-artifacts.md`
  - `promotion_status: proposed` → `accepted`
  - Tags array `"proposed"` → `"accepted"`
  - Status section header → `accepted` (2026-05-05)
  - Review Notes filled with operator decision

### Execution (1 file, +3 lines net)
- `canon/constraints/definition-of-done.md` `## Operating Constraints` — two new MUST bullets:
  - `MUST NOT mark a claim as verified without at least one artifact that demonstrates the claimed outcome`
  - `MUST return NEEDS_ARTIFACTS (not PASS) when a completion claim exists but the supporting evidence is absent`
- `canon/constraints/definition-of-done.md` `## Failure Modes` — one new entry:
  - `**"Unverified Completion"**: Accepting a "done" / "finished" / "shipped" claim without corresponding artifacts (screenshots, logs, links, command output). The validation pathway MUST return NEEDS_ARTIFACTS, not PASS`

## Why this matters

Per P0001's evidence section, the Validation Agent (`infra/orchestrator/services/validation.js`) already returns `NEEDS_ARTIFACTS` via `determineVerdict()` when claims have no matching artifacts. Until now this was enforced at code level only — Canon did not state the rule. After this merge, the constraint is citeable from `oddkit_search` and the Librarian, so future agents reading Definition of Done preflight see the rule explicitly.

## Position in the 8-proposal sweep

| # | ID | Status |
|---|---|---|
| 1 | P0009 | [PR #167](https://github.com/klappy/klappy.dev/pull/167) — open |
| 2 | **P0001** | **this PR** |
| 3 | P0008 | next — fresh-validator DOLCHEO ledger convention |
| 4-8 | P0007, P0006, P0003, P0004, P0005 | queued |

## DoD

- [x] Proposal frontmatter `promotion_status` flipped to `accepted`
- [x] Review Notes block filled
- [x] Canon edit text matches P0001 §"Proposed Language" verbatim
- [x] Insertion points match P0001 §"Section" (Operating Constraints + Failure Modes)
- [x] No other canon docs touched

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that tightens Definition of Done language and promotion status without affecting runtime behavior.
> 
> **Overview**
> Updates the canon Definition of Done to **explicitly require artifacts** before marking completion claims as verified, and to mandate returning `NEEDS_ARTIFACTS` (not `PASS`) when evidence is missing.
> 
> Marks promotion `P0001` as **accepted** by updating frontmatter/status and filling in review notes to record the decision and rationale.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d282da9fa8af50616ffdf96a6a85ff35e98f7df0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->