### PR TITLE
P0008 (accept + execute): validator-deliverable convention in release-validation-gate

### DIFF
--- a/canon/constraints/release-validation-gate.md
+++ b/canon/constraints/release-validation-gate.md
@@ -158,6 +158,48 @@ The full session post-mortem is at `klappy://odd/ledger/2026-04-20-p1-3-3-challe
 
 ---
 
+## Validator Deliverable Convention — The PR-NN Fresh-Validator Ledger
+
+A fresh-session validator running under this gate MUST produce two artifacts as part of accepting or rejecting a PR. Both committed to the repo.
+
+### 1. The Ledger
+
+**Path**: `canon/encodings/pr-NN-fresh-validator-ledger.md` (or repo-equivalent)
+**Structure**: DOLCHEO per `canon/definitions/dolcheo-vocabulary`
+
+Sections (in order):
+
+- **Decisions (D)** — the verdict (`SAFE TO MERGE` | `NOT SAFE`) with one-paragraph reason
+- **Observations Closed (O)** — per-DoD-item PASS/FAIL with file:line evidence
+- **Learnings (L)** — patterns the validator wants future readers to internalize
+- **Constraints (C)** — deviations from spec accepted as platform/library constraints. Each accepted-as-constraint deviation MUST be paired with either "permanent" or "v+1 revisit candidate" — never silently accepted as permanent without explicit naming
+- **Handoff (H)** — nits-grade follow-ups for the next session
+- **Opens (O-open)** — still-open questions, each numbered for back-reference from future sessions
+
+### 2. The Companion Review
+
+**Path**: `canon/handoffs/pr-NN-fresh-validator-review.md` (or repo-equivalent)
+
+Free-form prose attribution and summary. May reference the ledger's numbered observations directly. Names the validator (model + session ID), date, scope.
+
+### Both committed to the repo
+
+In the same PR or as a follow-up commit on the validation branch. Frontmatter declares `reviewer:` and `reviews:`. Date in frontmatter `date:`.
+
+### Why a Canon-Resident Ledger Is the Deliverable
+
+GitHub PR comments are ephemeral — filtered, paginated, hidden on thread collapse, not searchable across repos. A canon-resident ledger is searchable via oddkit, indexed by the validator's repo, and forms the long-term record of what was checked, what was accepted as a platform constraint with v+1 candidate, and what nits remain. Future PRs that reopen the same ground can cite the ledger directly.
+
+### Failure Mode
+
+Without this convention: findings live in PR comments that are read once and forgotten. The same deviation gets re-discovered three PRs later. The same "platform constraint" gets re-litigated each session because no one knows whether it was already accepted. The ledger creates the system memory the gate's enforcement-by-convention-plus-enforcer shape requires.
+
+### Receipts
+
+- `klappy/PTXprint-MCP` PR #30 v1.3 telemetry — `canon/encodings/pr-30-fresh-validator-ledger.md` + `canon/handoffs/pr-30-fresh-validator-review.md`. Re-validation produced `pr-30-revalidation-addendum.md` referencing the original ledger's numbered observations.
+
+---
+
 ## Related Canon
 
 - **[Verification Requires Fresh Context](klappy://canon/principles/verification-requires-fresh-context)** — the principle this constraint operationalizes for the release pipeline specifically.

--- a/docs/promotions/P0008-pr-validator-dolcheo-ledger-as-deliverable.md
+++ b/docs/promotions/P0008-pr-validator-dolcheo-ledger-as-deliverable.md
@@ -6,8 +6,8 @@ exposure: nav
 tier: 3
 voice: neutral
 stability: evolving
-tags: ["promotions", "proposed", "release-validation-gate", "dolcheo", "validator-ledger", "fresh-context", "amendment"]
-promotion_status: proposed
+tags: ["promotions", "accepted", "release-validation-gate", "dolcheo", "validator-ledger", "fresh-context", "amendment"]
+promotion_status: accepted
 ---
 
 # P0008: Fresh-Validator Deliverable Is a DOLCHEO Ledger Committed to the Repo
@@ -117,16 +117,14 @@ Joining `release-validation-gate` + `dolcheo-vocabulary` at the deliverable laye
 
 ## Status
 
-`proposed`
+`accepted` (2026-05-05)
 
 ## Review Notes
 
-(To be filled during review)
-
-- **Reviewer**:
-- **Decision**:
-- **Date**:
-- **Notes**:
+- **Reviewer**: klappy (operator)
+- **Decision**: `accepted`
+- **Date**: 2026-05-05
+- **Notes**: Accepted in the 8-proposal sweep (P0001 + P0003–P0009) sitting behind P0002's just-merged chain. P0008 is prioritised as third in the queue because it directly affects the release-validation-gate workflow that PRs ship under daily. The proposed language is appended verbatim before `## Related Canon`. Two structural choices ratified: (1) the canon-resident ledger is the validator's deliverable, not PR comments; (2) accepted-as-constraint deviations MUST be paired with permanent / v+1-revisit-candidate framing — silent acceptance is the failure mode being prevented.
 
 ## Execution Record
 


### PR DESCRIPTION
## What this PR does

Combined acceptance + execution of promotion **P0008** — codifies the validator's deliverable shape for the release-validation-gate workflow.

### Acceptance (1 file)
- `docs/promotions/P0008-pr-validator-dolcheo-ledger-as-deliverable.md`
  - `promotion_status: proposed` → `accepted`
  - Tags array `"proposed"` → `"accepted"`
  - Status section header → `accepted` (2026-05-05)
  - Review Notes filled

### Execution (1 file, +42 lines)
- `canon/constraints/release-validation-gate.md` — new section before `## Related Canon`:
  - **`## Validator Deliverable Convention — The PR-NN Fresh-Validator Ledger`**
  - Two-artifact requirement: DOLCHEO ledger at `canon/encodings/pr-NN-fresh-validator-ledger.md` + companion handoff at `canon/handoffs/pr-NN-fresh-validator-review.md`
  - DOLCHEO section ordering specified (D, O, L, C, H, O-open) with what each captures
  - Constraints (C) MUST be paired with `permanent` or `v+1 revisit candidate` — silent acceptance is the named failure mode
  - Receipts cite PTXprint PR #30 v1.3 telemetry as the worked example

## Why this is third in the queue

The release-validation-gate runs on every load-bearing PR — including the 7 still-queued promotion PRs in this sweep. Codifying the validator deliverable shape now means those subsequent PRs (or the next fresh-validator dispatch) have canon to point at, rather than re-deriving the format under time pressure.

## Position in the 8-proposal sweep

| # | ID | Status |
|---|---|---|
| 1 | P0009 | [PR #167](https://github.com/klappy/klappy.dev/pull/167) |
| 2 | P0001 | [PR #168](https://github.com/klappy/klappy.dev/pull/168) |
| 3 | **P0008** | **this PR** |
| 4 | P0007 | next — DoD as 5–7 agent-observable behaviors |
| 5-8 | P0006, P0003, P0004, P0005 | queued |

## DoD

- [x] Proposal frontmatter `promotion_status` flipped to `accepted`
- [x] Review Notes block filled
- [x] Canon edit text matches P0008 §"Proposed Language" verbatim
- [x] Insertion point matches P0008 §"Section" (append, before Related Canon)
- [x] No other canon docs touched

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it adds a new, enforced-by-convention deliverable requirement for fresh-validator reviews, which may change release-validation-gate workflows and reviewer expectations. Changes are documentation/canon-only with no runtime code impact.
> 
> **Overview**
> **Accepts and executes promotion `P0008` to standardize fresh-validator outputs under `release-validation-gate`.**
> 
> Updates `canon/constraints/release-validation-gate.md` with a new *Validator Deliverable Convention* that requires two repo-committed artifacts for each fresh-context validator review: a DOLCHEO-structured ledger at `canon/encodings/pr-NN-fresh-validator-ledger.md` (with mandated D/O/L/C/H/O-open sections, including explicit permanent vs `v+1 revisit candidate` constraint labeling) and a companion prose review at `canon/handoffs/pr-NN-fresh-validator-review.md`.
> 
> Promotes `docs/promotions/P0008-pr-validator-dolcheo-ledger-as-deliverable.md` from `proposed` to `accepted`, updating metadata and filling the review notes with the acceptance decision/date.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 802421ecd4b2c8360b1c115eb33738018483ce2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->