### PR TITLE
P0006 (accept + execute): vodka boundary enumeration as spec convention

### DIFF
--- a/canon/principles/vodka-architecture.md
+++ b/canon/principles/vodka-architecture.md
@@ -145,6 +145,35 @@ Before any change to a vodka-architecture server, answer these three questions:
 
 ---
 
+## Spec Convention — The Boundary Must Be Enumerated
+
+A server claiming to follow vodka-architecture MUST include three enumerated sections in its spec:
+
+### Boundary Section
+
+`## What This Server Knows` — bullet list of every state, schema, or external resource the server understands or holds.
+
+`## What This Server Does NOT Know` — bullet list of the domain semantics this server defers to canon or the consumer environment. **This list IS the vodka boundary, written down.**
+
+### Non-Goals Section
+
+`## What This Server Is NOT` — bullet list of the categories of responsibility this server explicitly refuses. Each item is a statement future PR authors must rebut to expand scope.
+
+### Why Enumeration Matters
+
+A boundary kept in author intuition gets violated when the author rotates out. A boundary written down survives the rotation. PR authors proposing a new tool must argue against an enumerated non-property — asymmetrically harder than arguing for a useful-sounding addition.
+
+### Failure Mode
+
+Implicit boundaries drift. After a few PRs, the server has accumulated "small additions" that each individually felt fine but cumulatively violate the original vodka frame. The next vodka rewrite has to undo those additions one by one. Enumeration prevents the drift at the PR-review surface, where it is cheapest to catch.
+
+### Receipts
+
+- `klappy/PTXprint-MCP` v1.2 §1 — enumerated boundary + non-goals, with explicit attribution that the v1.0 → v1.1 sprawl happened because the v1.0 boundary was implicit.
+- *(Each subsequent vodka-compliant spec adds a row pointing at its boundary section.)*
+
+---
+
 ## See Also
 
 ### Design Heritage — Full Articles

--- a/docs/promotions/P0006-vodka-boundary-enumeration-as-spec-convention.md
+++ b/docs/promotions/P0006-vodka-boundary-enumeration-as-spec-convention.md
@@ -6,8 +6,8 @@ exposure: nav
 tier: 3
 voice: neutral
 stability: evolving
-tags: ["promotions", "proposed", "vodka-architecture", "spec-convention", "boundary", "non-goals", "amendment"]
-promotion_status: proposed
+tags: ["promotions", "accepted", "vodka-architecture", "spec-convention", "boundary", "non-goals", "amendment"]
+promotion_status: accepted
 ---
 
 # P0006: Vodka Boundary Enumeration — Specs Must List What the Server Knows, Doesn't Know, and Is NOT
@@ -103,16 +103,14 @@ Placed at the end of vodka-architecture.md (near "See Also" but above it) so the
 
 ## Status
 
-`proposed`
+`accepted` (2026-05-05)
 
 ## Review Notes
 
-(To be filled during review)
-
-- **Reviewer**:
-- **Decision**:
-- **Date**:
-- **Notes**:
+- **Reviewer**: klappy (operator)
+- **Decision**: `accepted`
+- **Date**: 2026-05-05
+- **Notes**: Accepted in the 8-proposal sweep. P0006 sharpens vodka-architecture from philosophy to spec convention by requiring three enumerated sections in any compliant spec ("What This Server Knows", "What This Server Does NOT Know", "What This Server Is NOT"). Section appended before `## See Also` so the convention sits as the operationalization closure of the principle. Last of the small append-style amendments in this sweep — P0003/P0004/P0005 next create whole new canon docs.
 
 ## Execution Record
 


### PR DESCRIPTION
## What this PR does

Combined acceptance + execution of promotion **P0006** — sharpens vodka-architecture from philosophy to a concrete spec-shape requirement.

### Acceptance (1 file)
- `docs/promotions/P0006-vodka-boundary-enumeration-as-spec-convention.md`
  - `promotion_status: proposed` → `accepted`
  - Tags array `"proposed"` → `"accepted"`
  - Status section header → `accepted` (2026-05-05)
  - Review Notes filled

### Execution (1 file, +27 lines)
- `canon/principles/vodka-architecture.md` — new section before `## See Also`:
  - **`## Spec Convention — The Boundary Must Be Enumerated`**
  - Mandates three enumerated sections in any vodka-compliant spec:
    - `## What This Server Knows`
    - `## What This Server Does NOT Know` ← the vodka boundary, written down
    - `## What This Server Is NOT` ← non-goals to rebut for scope expansion
  - Why-Enumeration: written boundary survives author rotation; rebutting an enumerated non-goal is asymmetrically harder than arguing for a useful-sounding addition
  - Failure Mode: implicit boundaries drift; "small additions" cumulatively violate the original vodka frame
  - Receipt: PTXprint v1.2 §1

## Position in the 8-proposal sweep

| # | ID | Status |
|---|---|---|
| 1 | P0009 | [PR #167](https://github.com/klappy/klappy.dev/pull/167) |
| 2 | P0001 | [PR #168](https://github.com/klappy/klappy.dev/pull/168) |
| 3 | P0008 | [PR #169](https://github.com/klappy/klappy.dev/pull/169) |
| 4 | P0007 | [PR #170](https://github.com/klappy/klappy.dev/pull/170) |
| 5 | **P0006** | **this PR** ← last of the small append-style PRs |
| 6 | P0003 | next — reframe-before-trimming (NEW canon doc) |
| 7-8 | P0004, P0005 | queued (also new docs) |

## DoD

- [x] Proposal frontmatter `promotion_status` flipped
- [x] Review Notes filled
- [x] Canon edit text matches P0006 §"Proposed Language" verbatim
- [x] Insertion at the proposed location ("near the end of the existing doc, before any 'See Also' / footer sections")
- [x] No other canon docs touched

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only change that introduces a new spec-convention requirement; risk is limited to process/workflow expectations for future vodka-compliant specs.
> 
> **Overview**
> **Accepts P0006** by flipping its promotion metadata/status to `accepted` and recording the review decision/date.
> 
> **Updates `canon/principles/vodka-architecture.md`** with a new *spec convention* that mandates three explicit sections in any vodka-compliant server spec: `## What This Server Knows`, `## What This Server Does NOT Know` (the written boundary), and `## What This Server Is NOT` (enumerated non-goals), plus rationale and a reference receipt.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04e9c637a3830c2ecd45a79b35e6d06cb2dccaf7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->