### PR TITLE
P0004 (accept + execute): docs-proxy canon-as-tool pattern (introduces canon/patterns/)

### DIFF
--- a/canon/patterns/docs-proxy-canon-as-tool.md
+++ b/canon/patterns/docs-proxy-canon-as-tool.md
@@ -1,0 +1,52 @@
+---
+uri: klappy://canon/patterns/docs-proxy-canon-as-tool
+title: "Docs Proxy — Canon-as-Tool So Consumers Wire One MCP"
+audience: canon
+exposure: nav
+tier: 2
+voice: neutral
+stability: evolving
+tags: ["canon", "pattern", "mcp-server", "docs-proxy", "consumer-experience", "vodka-architecture"]
+derives_from:
+  - klappy://canon/principles/vodka-architecture
+  - klappy://canon/principles/consistency-same-pattern-every-time
+  - klappy://canon/principles/dry-canon-says-it-once
+complements:
+  - klappy://canon/principles/doing-less-enables-more
+status: active
+---
+
+# Docs Proxy — Canon-as-Tool
+
+> An MCP server whose action surface depends on a sibling canon repo for domain semantics SHOULD expose a `docs(query, audience?, depth?)` tool that proxies the canon-server (oddkit), parameterized to its own repo. Consumers get both surfaces through one MCP wiring.
+
+## The Pattern
+
+The action MCP server adds one tool — typically named `docs` or `<server>_docs` — whose entire job is to forward queries to the canon-server with the action server's own repo URL pinned as the `knowledge_base_url` parameter.
+
+- **Inputs**: `query` (required), `audience` (optional, server-defined enum), `depth` (optional `1|2|3` — snippet, full top doc, top + next two)
+- **Returns**: `{ answer, sources[], deeper[], governance_source }`
+- **Failure**: graceful degradation when the canon-server is unreachable — `{ answer: null, sources: [], governance_source: "minimal", error }` rather than a hard error that blocks consumer flow
+
+## Vodka Check the Tool Must Pass
+
+The proxy tool knows exactly two URLs: this server's canon repo and the canon-server's MCP endpoint. It holds zero domain semantics. It does not parse, rank, filter, score, or reframe results. It is a pinned forwarding layer.
+
+If the proxy ever grows a domain-flavored taxonomy or a scoring tweak, that taxonomy moves into governance documents in the canon repo (which the canon-server retrieves through the same proxy), not into the tool's implementation. Domain logic in the proxy is a vodka-boundary leak.
+
+## Why the Pattern Exists
+
+Without the pattern, every consumer pays a wire-two-MCPs tax: one MCP for actions, a second MCP for canon retrieval, configured with the action server's repo as `knowledge_base_url`. Consumers who do not pay the tax lose canon-in-flow access at the moment they need it most. The pattern absorbs the tax once, server-side, for every present and future consumer.
+
+This pattern is orthogonal to `canon/principles/consistency-same-pattern-every-time`, which covers the *same-server-many-knowledge-bases* axis. This pattern covers *many-servers-one-knowledge-base*. Both are real; both deserve canon coverage.
+
+## Failure Mode
+
+Without this pattern: per-consumer onboarding friction; canon drifts from living context to web-search-of-last-resort; the canon-as-living-context value proposition silently degrades because consumers never wire it.
+
+With the pattern: one MCP wired, both surfaces accessible; canon stays in-flow as designed.
+
+## Receipts
+
+- **PTXprint-MCP v1.2 §3 `docs` tool.** Added in session 13 (2026-04-29), reversing v1.0's "no retrieval in MCP server" decision with explicit rationale: downstream agents like BT Servant want one MCP wiring. Vodka boundary preserved.
+- *(Future receipts: each server adopting the pattern adds one row — server, tool name, date adopted, link to spec section.)*

--- a/docs/promotions/P0004-docs-proxy-canon-as-tool.md
+++ b/docs/promotions/P0004-docs-proxy-canon-as-tool.md
@@ -6,8 +6,8 @@ exposure: nav
 tier: 3
 voice: neutral
 stability: evolving
-tags: ["promotions", "proposed", "mcp-server", "docs-proxy", "canon", "vodka-architecture", "consumer-experience"]
-promotion_status: proposed
+tags: ["promotions", "accepted", "mcp-server", "docs-proxy", "canon", "vodka-architecture", "consumer-experience"]
+promotion_status: accepted
 ---
 
 # P0004: Docs Proxy — Canon-as-Tool So Consumers Wire One MCP, Not Two
@@ -131,16 +131,14 @@ The placement under `canon/patterns/` rather than `canon/principles/` is deliber
 
 ## Status
 
-`proposed`
+`accepted` (2026-05-05)
 
 ## Review Notes
 
-(To be filled during review)
-
-- **Reviewer**:
-- **Decision**:
-- **Date**:
-- **Notes**:
+- **Reviewer**: klappy (operator)
+- **Decision**: `accepted`
+- **Date**: 2026-05-05
+- **Notes**: Accepted in the 8-proposal sweep. Created `canon/patterns/docs-proxy-canon-as-tool.md` as a tier-2 pattern doc. **Note for review:** this is the first doc under a new top-level subdirectory `canon/patterns/` — the existing canon hierarchy has bootstrap, case-studies, constraints, decisions, defaults, definitions, diagnostics, instructions, meta, methods, observations, principles, resonance, values. The proposal explicitly names this path; if you want this relocated under `methods/` or `principles/` instead, the file is small (one move + one frontmatter `uri:` edit + zero downstream consumers).
 
 ## Execution Record
 


### PR DESCRIPTION
## What this PR does

Combined acceptance + execution of promotion **P0004** — adds a tier-2 pattern doc for the docs-proxy tool that lets MCP server consumers wire one MCP instead of two.

### Acceptance (1 file)
- `docs/promotions/P0004-docs-proxy-canon-as-tool.md`
  - `promotion_status: proposed` → `accepted`
  - Tags array `"proposed"` → `"accepted"`
  - Status section header → `accepted` (2026-05-05)
  - Review Notes filled

### Execution (1 file, NEW)
- **`canon/patterns/docs-proxy-canon-as-tool.md`** (new tier-2 pattern doc)
  - Frontmatter:
    - `tier: 2`, `audience: canon`, `status: active`
    - `derives_from`: `vodka-architecture`, `consistency-same-pattern-every-time`, `dry-canon-says-it-once`
    - `complements`: `doing-less-enables-more`
  - Sections: The Pattern (inputs/returns/failure spec) / Vodka Check / Why the Pattern Exists / Failure Mode / Receipts

### ⚠ New canon subdirectory: `canon/patterns/`

This is the **first doc** under `canon/patterns/`. Existing canon subdirectories are: `bootstrap`, `case-studies`, `constraints`, `decisions`, `defaults`, `definitions`, `diagnostics`, `instructions`, `meta`, `methods`, `observations`, `principles`, `resonance`, `values`.

The proposal explicitly names `canon/patterns/docs-proxy-canon-as-tool.md` as the target. If you'd rather the doc live under `methods/` or `principles/`, the move is one `git mv` + a one-line `uri:` edit in the frontmatter — no downstream consumers yet.

## Position in the 8-proposal sweep

| # | ID | Status |
|---|---|---|
| 1 | P0009 | [PR #167](https://github.com/klappy/klappy.dev/pull/167) |
| 2 | P0001 | [PR #168](https://github.com/klappy/klappy.dev/pull/168) |
| 3 | P0008 | [PR #169](https://github.com/klappy/klappy.dev/pull/169) |
| 4 | P0007 | [PR #170](https://github.com/klappy/klappy.dev/pull/170) |
| 5 | P0006 | [PR #171](https://github.com/klappy/klappy.dev/pull/171) |
| 6 | P0003 | [PR #172](https://github.com/klappy/klappy.dev/pull/172) |
| 7 | **P0004** | **this PR** |
| 8 | P0005 | last in queue — async-by-default principle |

## DoD

- [x] Proposal frontmatter `promotion_status` flipped
- [x] Review Notes filled (with explicit flag about the new subdirectory)
- [x] New canon doc created at the proposed path
- [x] Frontmatter follows `frontmatter-schema`
- [x] H1 + blockquote + descriptive headers

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; main risk is introducing a new `canon/patterns/` directory that could affect nav/build discovery if tooling assumes a fixed canon tree.
> 
> **Overview**
> **Accepts P0004** by updating `docs/promotions/P0004-docs-proxy-canon-as-tool.md` from `proposed` to `accepted`, including frontmatter tags/status and filled review notes.
> 
> **Executes the promotion** by adding a new tier-2 canon pattern doc at `canon/patterns/docs-proxy-canon-as-tool.md`, establishing the new `canon/patterns/` section and specifying the expected `docs(query, audience?, depth?)` proxy tool shape, return contract, and graceful failure behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1df616c20f3b639df983cea66b3c5e67faa0736e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->