### PR TITLE
fix(writings): align biblical-roots appendix forward-ref to auto-heal target

### DIFF
--- a/writings/the-broken-wall-and-the-buried-talent.md
+++ b/writings/the-broken-wall-and-the-buried-talent.md
@@ -83,10 +83,10 @@ related:
   - uri: klappy://writings/choosing-faith-not-fear
     label: "Choosing Faith, Not Fear (previous chapter)"
     relationship: prequel
-  - uri: klappy://draft-zeros/appendix-a-the-biblical-roots
+  - uri: klappy://writings/the-biblical-roots
     label: "The Biblical Roots (appendix)"
     relationship: related
-complements: "writings/choosing-faith-not-fear.md, draft-zeros/appendix-a-the-biblical-roots.md"
+complements: "writings/choosing-faith-not-fear.md, writings/the-biblical-roots.md"
 ---
 
 # The Broken Wall and the Buried Talent
@@ -331,5 +331,5 @@ Dig it up. Bring it to the room. The wall won't build itself. And it was never a
 
 *The previous chapter, [Choosing Faith, Not Fear](klappy://writings/choosing-faith-not-fear), anchors identity in what doesn't change. This chapter asks what that identity demands of us.*
 
-<!-- audit-allow: dead-reference reason="forward-ref to Appendix A; drafted at draft-zeros/appendix-a-the-biblical-roots; auto-heals on promote to writings/ or whichever published path the appendix lands at" -->
-*The appendix, [The Biblical Roots](klappy://draft-zeros/appendix-a-the-biblical-roots), maps the scriptural foundations underneath every principle in this book.*
+<!-- audit-allow: dead-reference reason="forward-ref to Appendix A; drafted at draft-zeros/appendix-a-the-biblical-roots.md (declares uri klappy://writings/the-biblical-roots); auto-heals on promote to writings/the-biblical-roots.md" -->
+*The appendix, [The Biblical Roots](klappy://writings/the-biblical-roots), maps the scriptural foundations underneath every principle in this book.*


### PR DESCRIPTION
## What

Aligns the appendix forward-reference in `the-broken-wall-and-the-buried-talent.md` to the URI the draft itself declares, so promotion of the draft will auto-heal the link instead of leaving an orphan.

## Why

Audit job #36 reported `klappy://draft-zeros/appendix-a-the-biblical-roots` as a dead reference. The draft does exist at `draft-zeros/appendix-a-the-biblical-roots.md`, but its frontmatter declares `uri: klappy://writings/the-biblical-roots`. The mismatch meant the existing `audit-allow` directive could not actually self-heal on promotion — the link slug and the draft's declared URI disagreed.

## Changes

One file, four edits, all rewriting `klappy://draft-zeros/appendix-a-the-biblical-roots` (and the matching `complements:` path) to the future home `klappy://writings/the-biblical-roots`:

- `related:` URI in frontmatter
- `complements:` field
- inline body link in the closing teaser
- `audit-allow` comment reason text (now references the actual auto-heal target)

## Audit report context

The other 5 findings from canon-quality job #36 (the `nothing-new-even-ai` → `preface-nothing-new-even-ai` rename in `agentic-software-development.md`, and the four `/page/...` → `klappy://...` conversions in `getting-started-with-odd-and-oddkit.md`) are already resolved in main. The audit report appears stale relative to current HEAD.

The Ch.7 forward-refs (`klappy://writings/four-questions-that-change-everything` in `choosing-faith-not-fear.md` and `the-voice-came-first.md`) need no change — they already align with `draft-zeros/ch07-four-questions-that-change-everything.md`'s declared URI and will auto-heal cleanly on promotion.

## Disposition

Per operator decision (option B): fix the appendix slug to auto-heal, leave Ch.7 refs as-is.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: updates only internal metadata and links in a single markdown article, with no functional code changes. Main risk is an incorrect target URI causing a broken cross-reference if the appendix path differs.
> 
> **Overview**
> Updates `writings/the-broken-wall-and-the-buried-talent.md` to consistently reference the appendix via `klappy://writings/the-biblical-roots` instead of the old `draft-zeros/appendix-a-the-biblical-roots` slug.
> 
> This adjusts the frontmatter `related` entry, the `complements` list, the closing inline appendix link, and the `audit-allow` note so the forward-ref matches the appendix’s intended published URI and stops tripping dead-reference audits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27c7b4d974de74d51a70fdc19cb9065d5cee4198. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->