### PR TITLE
docs+canon: replace stale OLDC+H instructional text with DOLCHEO + close supersession metadata gap

### DIFF
--- a/canon/bootstrap/model-operating-contract.md
+++ b/canon/bootstrap/model-operating-contract.md
@@ -92,7 +92,7 @@ The oddkit tools encode the discipline. They are not invoked on request — they
 
 ### For Durable Records
 
-- **`oddkit_encode`** — Structure decisions, insights, and boundaries as OLDC+H artifacts. Does not persist — the caller saves to file. Encode continuously at natural breakpoints.
+- **`oddkit_encode`** — Structure decisions, insights, and boundaries as [DOLCHEO](klappy://canon/definitions/dolcheo-vocabulary) artifacts. Does not persist — the caller saves to file. Encode continuously at natural breakpoints.
 
 ### Governance
 

--- a/canon/constraints/core-governance-baseline.md
+++ b/canon/constraints/core-governance-baseline.md
@@ -157,7 +157,7 @@ These files MUST be present in the baseline snapshot. The worker build fails if 
 
 These files enhance tool behavior but their absence degrades to sensible minimums rather than failing:
 
-- Every file in `odd/encoding-types/` — encode falls back to OLDC+H defaults
+- Every file in `odd/encoding-types/` — encode falls back to [DOLCHEO](klappy://canon/definitions/dolcheo-vocabulary) defaults
 - Every file in `odd/challenge-types/` — challenge falls back to generic pressure questions
 - Every file in `odd/gate/` — gate falls back to structural prereqs
 - All `writings/`, `docs/`, `apocrypha/` content — only relevant for search/get/catalog, not governance

--- a/canon/methods/supersession.md
+++ b/canon/methods/supersession.md
@@ -33,7 +33,7 @@ The foundation is Axiom 3: Integrity Is Non-Negotiable Efficiency. Overwriting a
 
 The five responses form a spectrum from least to most action: tolerate, observe, graduate, replace, regenerate. Each has a place. None is universally correct. Applying graduation where replacement is needed produces ceremony without value. Applying replacement where graduation is needed destroys provenance. The taxonomy exists so the response matches the situation.
 
-Every drift response produces OLDC artifacts (observations, learnings, decisions, constraints) that belong in the epistemic ledger — not in conversation history that evaporates between sessions.
+Every drift response produces [DOLCHEO](klappy://canon/definitions/dolcheo-vocabulary) artifacts (decisions, observations, learnings, constraints, handoffs, encodes, opens) that belong in the epistemic ledger — not in conversation history that evaporates between sessions.
 
 -----
 
@@ -53,11 +53,11 @@ This is the right response when the drift causes no confusion in practice — no
 
 The drift is real. The tension is real. But action is premature — the system hasn't resolved the underlying question yet, or the pain hasn't surfaced in practice.
 
-This maps to the drift value's "acknowledge" response and to the OLDC model's observation entry. The observation names the tension, classifies the drift type, identifies the documents in conflict, and sits in the ledger. It waits. When the pain arrives — when an agent follows the wrong document, when a reader gets confused, when the tension blocks progress — the observation already exists and the decision about what to do next starts from documented ground, not from re-discovery.
+This maps to the drift value's "acknowledge" response and to the DOLCHEO model's observation entry. The observation names the tension, classifies the drift type, identifies the documents in conflict, and sits in the ledger. It waits. When the pain arrives — when an agent follows the wrong document, when a reader gets confused, when the tension blocks progress — the observation already exists and the decision about what to do next starts from documented ground, not from re-discovery.
 
 **When to use:** Two documents with overlapping governance surface but no clear winner. An emphasis shift that might reverse as understanding matures. A tension between E0005 and E0006 concepts where forcing resolution would lose something important.
 
-**What to record:** OLDC ledger entry: what drifted, what type (terminological, structural, emphasis, scope, value), which documents are in tension, why action is deferred.
+**What to record:** DOLCHEO ledger entry: what drifted, what type (terminological, structural, emphasis, scope, value), which documents are in tension, why action is deferred.
 
 ### 3. Graduate
 
@@ -67,7 +67,7 @@ Graduation retires the document from active governance to historical evidence. T
 
 **When to use:** Governance drift where the amendment would fundamentally rewrite the document's framing. Epoch transitions that introduce new governance concepts replacing the previous epoch's approach. New documents that cover the same governance surface with clearer, more accurate treatment.
 
-**What to record:** Full OLDC ledger entry plus bidirectional frontmatter pointers (`stability: superseded`, `superseded_by`, `supersedes`) and a `supersession_reason` field on the successor. See "Graduation Mechanics" below.
+**What to record:** Full DOLCHEO ledger entry plus bidirectional frontmatter pointers (`stability: superseded`, `superseded_by`, `supersedes`) and a `supersession_reason` field on the successor. See "Graduation Mechanics" below.
 
 ### 4. Replace
 
@@ -79,7 +79,7 @@ Replacing a derived document is not forced coherence. It's maintenance of a livi
 
 **When to use:** Index files (READMEs that list contents). Outlines and navigational summaries. Metadata aggregations. Any document whose sole purpose is to point to other documents or reflect their current state.
 
-**What to record:** Minimal — the git commit that made the change is the record. No OLDC entry needed unless the replacement reveals a systemic issue.
+**What to record:** Minimal — the git commit that made the change is the record. No DOLCHEO entry needed unless the replacement reveals a systemic issue.
 
 ### 5. Regenerate — The Default for Projections
 
@@ -205,9 +205,9 @@ oddkit's drift audit can run on new document entry, comparing against existing d
 
 -----
 
-## The Supersession Record — OLDC for the Epistemic Ledger
+## The Supersession Record — DOLCHEO for the Epistemic Ledger
 
-Every graduation creates a record. This is not optional — it is the evidence that the system grew. Per the epistemic ledger model (`odd/ledger/epistemic-ledger.md`), the record follows OLDC structure:
+Every graduation creates a record. This is not optional — it is the evidence that the system grew. Per the epistemic ledger model (`odd/ledger/epistemic-ledger.md`), the record follows DOLCHEO structure:
 
 **Observation:** What drifted? Name the specific tension. Classify the drift type and layer.
 
@@ -217,7 +217,7 @@ Every graduation creates a record. This is not optional — it is the evidence t
 
 **Constraint:** What must the successor honor that the predecessor did not? What new invariant does the supersession introduce?
 
-The compressed version lives in the successor's `supersession_reason` frontmatter field. The full OLDC record lives in the epistemic ledger. The frontmatter is the pointer; the ledger is the substance.
+The compressed version lives in the successor's `supersession_reason` frontmatter field. The full DOLCHEO record lives in the epistemic ledger. The frontmatter is the pointer; the ledger is the substance.
 
 Replace and regenerate responses produce minimal records — the git commit for replacements, the derivation function and content hash for regenerations. Tolerate and observe responses produce ledger entries proportional to the significance of the drift.
 
@@ -233,7 +233,7 @@ Replace and regenerate responses produce minimal records — the git commit for 
 
 **Compiled Memory** (`docs/appendices/compiled-memory.md`) — The original "wipeable artifacts" model. Regeneration extends this concept from context packs to any derived document.
 
-**Self-Audit** (`canon/methods/self-audit.md`) — Should include checking whether a deliverable supersedes existing documents, and if so, whether bidirectional pointers and OLDC records are in place.
+**Self-Audit** (`canon/methods/self-audit.md`) — Should include checking whether a deliverable supersedes existing documents, and if so, whether bidirectional pointers and DOLCHEO records are in place.
 
 **Writing Canon** (`canon/meta/writing-canon.md`) — Applies to successor documents. Superseded documents are not required to pass the current checklist retroactively — they are historical artifacts whose structure reflects their epoch's standards.
 
@@ -277,7 +277,7 @@ All drift layers are treated as governance drift. Every format inconsistency tri
 - The `supersession_reason` field SHOULD be present on successor documents. Its absence degrades the evolution narrative.
 - Format, style, and preference drift SHOULD be tolerated unless the format communicates false governance. The test: wrong decisions vs. dated appearance.
 - Regeneratable documents MUST declare their sources in frontmatter (`derived_from: [source URIs]`) to enable automation and staleness detection.
-- Every graduation MUST produce an OLDC ledger entry. Replace and regenerate produce minimal records (git commit, content hash).
+- Every graduation MUST produce a DOLCHEO ledger entry. Replace and regenerate produce minimal records (git commit, content hash).
 
 -----
 

--- a/docs/examples/project-instructions-template.md
+++ b/docs/examples/project-instructions-template.md
@@ -168,7 +168,7 @@ All tools are available individually and via the `oddkit` router (pass `action` 
 
 **Durable records**
 
-- **`oddkit_encode`** — Structure decisions, insights, boundaries as OLDC+H artifacts. Does NOT persist — save output to file. Encode continuously at natural breakpoints.
+- **`oddkit_encode`** — Structure decisions, insights, boundaries as [DOLCHEO](klappy://canon/definitions/dolcheo-vocabulary) artifacts. Does NOT persist — save output to file. Encode continuously at natural breakpoints.
 
 **Governance & transparency**
 
@@ -190,7 +190,7 @@ All tools are available individually and via the `oddkit` router (pass `action` 
 - **Preflight before building.** Call `oddkit_preflight` before any artifact-producing step.
 - **Challenge before encoding.** Pressure-test consequential decisions before `oddkit_encode`.
 - **Validate before declaring done.** Run `oddkit_validate` with artifact references before any "complete" claim.
-- **Track OLDC+H continuously.** Encode what was shared and what was done. Save encoded artifacts to file — `oddkit_encode` does not persist.
+- **Track DOLCHEO continuously.** Encode what was shared and what was done. Save encoded artifacts to file — `oddkit_encode` does not persist.
 
 ## Credentials
 

--- a/docs/oddkit/proactive/continuous-encoding.md
+++ b/docs/oddkit/proactive/continuous-encoding.md
@@ -1,19 +1,19 @@
 ---
 uri: klappy://docs/oddkit/proactive/continuous-encoding
-title: "Continuous OLDC+H Encoding — Track at Every Turn, Not Just Session End"
+title: "Continuous DOLCHEO Encoding — Track at Every Turn, Not Just Session End"
 audience: docs
 exposure: nav
 tier: 3
 voice: neutral
 stability: stable
-tags: ["odd", "oddkit", "encode", "oldc-h", "proactive", "continuous", "journal", "epoch-7"]
+tags: ["odd", "oddkit", "encode", "dolcheo", "oldc-h", "proactive", "continuous", "journal", "epoch-7"]
 epoch: E0007
 date: 2026-04-03
 ---
 
-# Continuous OLDC+H Encoding — Track at Every Turn, Not Just Session End
+# Continuous DOLCHEO Encoding — Track at Every Turn, Not Just Session End
 
-> Track OLDC+H at every exchange. Encode when substantive. Persist at breakpoints. The session journal is built incrementally, not reconstructed from memory at the end.
+> Track [DOLCHEO](klappy://canon/definitions/dolcheo-vocabulary) at every exchange. Encode when substantive. Persist at breakpoints. The session journal is built incrementally, not reconstructed from memory at the end.
 
 ---
 
@@ -27,7 +27,7 @@ The proactive pattern is three cadences working together: track at every exchang
 
 ## The Three Cadences
 
-**Track** — At every exchange, the agent maintains awareness of what just happened. Did the operator share an observation? Did the conversation produce a learning? Was a decision made? Did a new constraint emerge? This is not encoding — it is attention. The agent notices OLDC+H material as it occurs.
+**Track** — At every exchange, the agent maintains awareness of what just happened. Did the operator share an observation? Did the conversation produce a learning? Was a decision made? Did a new constraint emerge? This is not encoding — it is attention. The agent notices DOLCHEO material as it occurs.
 
 **Encode** — When the tracked material is substantive — a real decision, a genuine learning, a constraint that will govern future work — the agent calls encode to structure it. Not every exchange produces encode-worthy material. The agent uses judgment.
 
@@ -37,7 +37,7 @@ The proactive pattern is three cadences working together: track at every exchang
 
 ## What "Every Turn" Means in Practice
 
-"Every turn" does not mean calling encode on every message. It means the agent is always paying attention to OLDC+H categories. Most turns produce nothing worth encoding. Some produce an observation worth noting. A few produce a decision or learning worth structuring. The agent tracks silently, encodes selectively, and persists at breakpoints.
+"Every turn" does not mean calling encode on every message. It means the agent is always paying attention to DOLCHEO categories. Most turns produce nothing worth encoding. Some produce an observation worth noting. A few produce a decision or learning worth structuring. The agent tracks silently, encodes selectively, and persists at breakpoints.
 
 ---
 
@@ -51,6 +51,6 @@ Under E0007, the journal builds itself. The agent tracks continuously, and the o
 
 ## Don't Separate by Type
 
-A common failure mode is separating journal entries by OLDC+H category — all observations in one section, all decisions in another. This erases the narrative. The sequence matters: observation led to learning, learning informed decision, decision created constraint. Separating by type destroys the causal chain that makes the journal useful for future conversations.
+A common failure mode is separating journal entries by DOLCHEO category — all observations in one section, all decisions in another. This erases the narrative. The sequence matters: observation led to learning, learning informed decision, decision created constraint. Separating by type destroys the causal chain that makes the journal useful for future conversations.
 
 Keep entries in chronological narrative order. Tag them with their type, but don't sort by it.

--- a/docs/oddkit/proactive/encode-does-not-persist.md
+++ b/docs/oddkit/proactive/encode-does-not-persist.md
@@ -31,7 +31,7 @@ The natural assumption is that "encode" means "record." In most systems, encodin
 
 This design is intentional. ODD does not own the operator's storage. Different operators use different storage: files, databases, project management tools, version control. The protocol provides structure. The operator provides persistence.
 
-But the design created a gap: operators assumed encoding meant saving. Sessions of valuable OLDC+H capture were silently lost because the operator called encode and moved on, not realizing the output needed to be explicitly saved.
+But the design created a gap: operators assumed encoding meant saving. Sessions of valuable [DOLCHEO](klappy://canon/definitions/dolcheo-vocabulary) capture were silently lost because the operator called encode and moved on, not realizing the output needed to be explicitly saved.
 
 ---
 

--- a/docs/oddkit/proactive/handoff-to-new-conversation.md
+++ b/docs/oddkit/proactive/handoff-to-new-conversation.md
@@ -42,7 +42,7 @@ The test: would a fresh conversation with a curated bootstrap produce better res
 
 Bootstrapping the next conversation means curating what transfers. Not the entire conversation history — that's the problem handoff solves. Instead:
 
-- **Project journal** — the accumulated OLDC+H from this session.
+- **Project journal** — the accumulated [DOLCHEO](klappy://canon/definitions/dolcheo-vocabulary) from this session.
 - **Active decisions** — what was decided and what governs.
 - **Active constraints** — what rules apply going forward.
 - **Handoff items** — explicit next actions and open questions.

--- a/docs/oddkit/proactive/oldc-h-vocabulary.md
+++ b/docs/oddkit/proactive/oldc-h-vocabulary.md
@@ -5,10 +5,12 @@ audience: docs
 exposure: nav
 tier: 3
 voice: neutral
-stability: stable
+stability: superseded
 tags: ["odd", "oddkit", "oldc-h", "observations", "learnings", "decisions", "constraints", "handoffs", "vocabulary", "epoch-7"]
 epoch: E0007
 date: 2026-04-03
+superseded_by: "docs/oddkit/proactive/dolche-vocabulary.md"
+supersession_reason: "Superseded by DOLCHE (six dimensions, adds Encode as meta-action) and then by DOLCHEO (seven dimensions, adds Open as forward-pointing thread). Walk superseded_by transitively for current canonical: klappy://canon/definitions/dolcheo-vocabulary."
 ---
 
 # OLDC+H — The Five Standard Artifact Types for Session Capture

--- a/docs/oddkit/proactive/proactive-bootstrap.md
+++ b/docs/oddkit/proactive/proactive-bootstrap.md
@@ -57,13 +57,13 @@ This project uses the **oddkit MCP server** as its epistemic guide. oddkit tools
 - **search** — Search canon before making claims canon might have guidance on. Before answering policy questions, before proposing conventions, before writing documents. Search silently and incorporate results naturally.
 - **challenge** — Challenge proactively before encoding consequential decisions. When a claim would close options, create constraints, or be expensive to reverse — name the claim, identify the risk, present a concrete counter-argument. Do not wait to be asked.
 - **gate** — Gate at every implicit mode transition. When the operator's language shifts from questions to directives, when exploration converges on a solution, when planning pivots to execution — gate the transition even if nobody names it.
-- **encode** — Track OLDC+H (Observations, Learnings, Decisions, Constraints, Handoffs) continuously. Encode when substantive. **CRITICAL: encode does NOT persist.** Every encode output must be saved to the project journal or file storage. Encode returns the artifact in the response — it does not save it anywhere.
+- **encode** — Track [DOLCHEO](klappy://canon/definitions/dolcheo-vocabulary) (Decisions, Observations, Learnings, Constraints, Handoffs, Encodes, Opens) continuously. Encode when substantive. **CRITICAL: encode does NOT persist.** Every encode output must be saved to the project journal or file storage. Encode returns the artifact in the response — it does not save it anywhere.
 - **preflight** — Preflight before any execution that produces an artifact. What constraints apply? What's the definition of done? Ask before building, not after shipping.
 - **validate** — Validate proactively before claiming any task complete. Before presenting deliverables, before saying "done." The operator should not have to ask "did you check?"
 - **get** — Fetch a specific canonical document by URI when you need its full content.
 - **catalog** — List available documentation. Use `sort_by: "date"` to discover recent articles. Use `filter_epoch` to find articles from a specific epoch.
 
-### Continuous Session Capture (OLDC+H)
+### Continuous Session Capture (DOLCHEO)
 
 Track what happens at every exchange using five categories:
 
@@ -99,7 +99,7 @@ When work produces durable artifacts, capture what happened (journal), what chan
 | Tool usage | "Use orient to..." | "Reorient whenever context shifts..." |
 | Creed | Stated once at orientation | "Resurface whenever confidence outpaces evidence" |
 | Initiative | Operator acts, system responds | "The system acts, the operator reviews" |
-| OLDC+H | Not mentioned in system prompt | Full vocabulary with three cadences |
+| DOLCHEO | Not mentioned in system prompt | Full vocabulary with three cadences |
 | Encode persistence | Not mentioned | "CRITICAL: encode does NOT persist" |
 | Artifact provenance | Not mentioned | "Before every review, before finalizing" |
 | Working principles | "Orient before executing" | "The system acts, the operator reviews" |

--- a/docs/oddkit/proactive/proactive-session-close.md
+++ b/docs/oddkit/proactive/proactive-session-close.md
@@ -23,13 +23,13 @@ Every productive session ends with the same gap: the operator asks for a journal
 
 Under E0007, the agent captures provenance at the points where it matters — not at session end. The trigger is not "wrapping up." The trigger is the work itself: when durable artifacts are produced, when work is ready for review, and when work is finalized.
 
-This applies regardless of domain. In code, provenance means commits, changelogs, and version bumps. In writing, it means revision notes and draft tracking. In planning, it means decision records and handoff documents. In any domain, it means OLDC+H capture — what was observed, learned, decided, constrained, and what comes next.
+This applies regardless of domain. In code, provenance means commits, changelogs, and version bumps. In writing, it means revision notes and draft tracking. In planning, it means decision records and handoff documents. In any domain, it means [DOLCHEO](klappy://canon/definitions/dolcheo-vocabulary) capture — what was decided, observed, learned, constrained, handed off, encoded, and what remains open.
 
 ---
 
 ## The Three Provenance Artifacts
 
-**Session capture** — OLDC+H in narrative order. What was observed, learned, decided, constrained, and what comes next. The reasoning layer that makes the artifacts' history legible. Written to the project's journal or ledger.
+**Session capture** — DOLCHEO in narrative order. What was decided, observed, learned, constrained, handed off, encoded, and what remains open. The reasoning layer that makes the artifacts' history legible. Written to the project's journal or ledger.
 
 **Change summary** — What changed and why, in language appropriate for the audience who will review or consume the work. In code, this is a changelog. In writing, this is revision notes. In planning, this is an updated decision record.
 
@@ -41,7 +41,7 @@ This applies regardless of domain. In code, provenance means commits, changelogs
 
 ### At Every Milestone
 
-When work reaches a natural breakpoint — a completed task, a significant decision, a phase transition — the session capture should be current. OLDC+H is tracked continuously (per `docs/oddkit/proactive/continuous-encoding.md`), and each milestone is a natural persist point.
+When work reaches a natural breakpoint — a completed task, a significant decision, a phase transition — the session capture should be current. DOLCHEO is tracked continuously (per `docs/oddkit/proactive/continuous-encoding.md`), and each milestone is a natural persist point.
 
 ### Before Every Review
 

--- a/docs/oddkit/proactive/terminology-project-journal.md
+++ b/docs/oddkit/proactive/terminology-project-journal.md
@@ -19,7 +19,7 @@ date: 2026-04-03
 
 ## Summary — Name Things for the Audience That Uses Them
 
-The OLDC+H capture mechanism lives in the `odd/ledger/` directory and is formally called the "epistemic ledger" in canon documentation. This term is precise — it describes a record of epistemic events (observations, learnings, decisions, constraints, handoffs) structured for retrieval.
+The [DOLCHEO](klappy://canon/definitions/dolcheo-vocabulary) capture mechanism lives in the `odd/ledger/` directory and is formally called the "epistemic ledger" in canon documentation. This term is precise — it describes a record of epistemic events (decisions, observations, learnings, constraints, handoffs, encodes, opens) structured for retrieval.
 
 But "epistemic ledger" is jargon. An operator encountering oddkit for the first time does not know what "epistemic" means in this context, does not know what a "ledger" implies beyond accounting, and cannot infer from the term what the tool actually does.
 

--- a/odd/encoding-types/how-to-write-encoding-types.md
+++ b/odd/encoding-types/how-to-write-encoding-types.md
@@ -199,7 +199,7 @@ Resolution order:
 2. If multiple types declare `fallback: true`, the first one discovered wins (alphabetical by filename)
 3. If no type declares `fallback: true`, the server uses the first type discovered as fallback
 
-The recommended convention is to mark **Observation (O)** as the fallback. An unclassified paragraph is raw content without interpretation — semantically, that's what an Observation is. This convention is followed by the default OLDC+H types.
+The recommended convention is to mark **Observation (O)** as the fallback. An unclassified paragraph is raw content without interpretation — semantically, that's what an Observation is. This convention is followed by the default DOLCHEO types.
 
 ---
 

--- a/odd/ledger/project-journal-best-practices.md
+++ b/odd/ledger/project-journal-best-practices.md
@@ -19,7 +19,7 @@ date: 2026-04-03
 
 ## Summary — The Journal That Works Is the One You Can Read
 
-A project journal captures OLDC+H from work sessions. The format is simple. The failure modes are predictable. This article documents what works, what doesn't, and the one tradeoff that looks like an improvement but isn't.
+A project journal captures [DOLCHEO](klappy://canon/definitions/dolcheo-vocabulary) from work sessions. The format is simple. The failure modes are predictable. This article documents what works, what doesn't, and the one tradeoff that looks like an improvement but isn't.
 
 ---
 
@@ -41,7 +41,7 @@ Include timestamps on every entry. ISO 8601 format. Timestamps enable chronologi
 
 ## The Narrative Tradeoff
 
-The temptation is to organize journal entries by OLDC+H type: all observations together, all decisions together, all constraints together. This looks cleaner. It is worse.
+The temptation is to organize journal entries by DOLCHEO type: all observations together, all decisions together, all constraints together. This looks cleaner. It is worse.
 
 Separating by type destroys the causal chain. The observation that led to the learning that informed the decision that created the constraint — that sequence is the journal's value. Without it, each item is an isolated fact. With it, each item has context.
 


### PR DESCRIPTION
## Summary

Sweeps stale `OLDC+H` / `OLDC` instructional text that named the session-capture vocabulary as current, replacing it with **DOLCHEO** plus a first-mention link to `klappy://canon/definitions/dolcheo-vocabulary`. Preserves historical narrative, search-alias frontmatter tags, and supersession lineage references.

Also closes a bidirectional supersession metadata gap on `docs/oddkit/proactive/oldc-h-vocabulary.md` — that doc had no `superseded_by` pointer despite `canon/methods/supersession` requiring bidirectional linkage. It now correctly points forward to `dolche-vocabulary.md`, which already points forward to `dolcheo-vocabulary.md` (transitive walk gives current canonical).

## Headline fix

`canon/bootstrap/model-operating-contract.md` (line 95) no longer instructs models to encode as **"OLDC+H artifacts"**. That line was the direct source of repeated vocabulary drift in agent sessions since DOLCHEO landed (2026-04-19) — model loads the bootstrap doc on session start, reads "OLDC+H," resurrects the deprecated form. The bug was canon, not the model.

## Edit policy

| Category | Action |
|---|---|
| Active instructional text using OLDC+H/OLDC as the current vocabulary | **Replace** with DOLCHEO + canon link on first mention |
| Frontmatter `tags: [..., "oldc-h", ...]` | **Preserve** as search aliases (added `dolcheo` to the one stable doc whose title also changed) |
| Lineage references like "OLDC+H (superseded)" | **Preserve** — they are the supersession trail |
| Historical narrative quotes (`"the operator would say 'encode OLDC+H'"`) | **Preserve** — these record past habits |
| Superseded docs (`stability: superseded`) | **Preserve** content, no edits |
| Anti-pattern doc (P0009) and the legacy vocabulary docs themselves | **Preserve** — they intentionally talk *about* OLDC+H |
| Historical session ledgers (`odd/ledger/2026-*`) | **Preserve** — records of sessions written when OLDC+H was current |

## Files changed (13)

- `canon/bootstrap/model-operating-contract.md` — the headline fix
- `canon/constraints/core-governance-baseline.md` — encode-fallback line, matches `CHANGELOG.md` line 266 reality (fallback was upgraded to DOLCHEO already in code; canon was lagging)
- `canon/methods/supersession.md` — 10 active uses (the supersession process itself was using stale vocab)
- `docs/examples/project-instructions-template.md` — template copied into new projects
- `docs/oddkit/proactive/continuous-encoding.md` — title, frontmatter title, body. Frontmatter `tags` got `dolcheo` added alongside the legacy `oldc-h` alias. 2 historical narrative quotes preserved (lines 22, 46)
- `docs/oddkit/proactive/encode-does-not-persist.md` — line 34
- `docs/oddkit/proactive/handoff-to-new-conversation.md` — line 45
- `docs/oddkit/proactive/oldc-h-vocabulary.md` — **frontmatter only**, supersession metadata fix
- `docs/oddkit/proactive/proactive-bootstrap.md` — 3 lines
- `docs/oddkit/proactive/proactive-session-close.md` — 3 lines
- `docs/oddkit/proactive/terminology-project-journal.md` — line 22
- `odd/encoding-types/how-to-write-encoding-types.md` — line 202
- `odd/ledger/project-journal-best-practices.md` — 2 active lines

## Net diff

13 files, +36 / −34. Fully reversible.

## Companion PR

`klappy/oddkit` has matching stale strings in `workers/src/orchestrate.ts` (orient proactive-posture instruction, validate finalization gap message). Separate PR landing alongside this one.

## Provenance

Found while debugging an unrelated vocabulary drift in a live agent session — the model emitted "OLDC+H" because it had just fetched the bootstrap doc, which still said "OLDC+H." Tracing it back surfaced 13 active-vocab files plus the metadata gap.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, documentation-only changes, but they affect the canonical bootstrap/instructional text that models read, so wording/link errors could influence agent behavior.
> 
> **Overview**
> Updates canon and oddkit docs to treat **`DOLCHEO`** (linked to `klappy://canon/definitions/dolcheo-vocabulary` on first mention) as the current session-capture/encoding vocabulary, replacing stale references to `OLDC+H`/`OLDC` across bootstrap, templates, and guidance.
> 
> Adds missing supersession metadata to `docs/oddkit/proactive/oldc-h-vocabulary.md` (`stability: superseded`, `superseded_by`, `supersession_reason`) and refreshes related supersession/governance copy to reference DOLCHEO-based ledger records and encode fallback behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1073c65448855c75c84826bfad310f9d9374a3ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->