### PR TITLE
frontmatter: mark archive/infra/.../orchestrator/README archived

### DIFF
--- a/docs/archive/infra/infra/orchestrator/README.md
+++ b/docs/archive/infra/infra/orchestrator/README.md
@@ -1,3 +1,16 @@
+---
+archived: true
+archived_reason: "E0005.1 — superseded by OddKit dynamic routing"
+uri: klappy://docs/archive/infra/infra/orchestrator/README
+title: "Orchestrator Infrastructure"
+audience: docs
+exposure: nav
+tier: 3
+voice: neutral
+stability: stable
+tags: ["docs", "archive", "orchestrator", "infrastructure", "router", "librarian", "pre-vodka"]
+---
+
 # Orchestrator Infrastructure
 
 Runtime components for agent coordination and enforcement.


### PR DESCRIPTION
## What

Adds the eight universal frontmatter fields plus archive flags to `docs/archive/infra/infra/orchestrator/README.md`, which previously had **zero frontmatter**.

```yaml
---
archived: true
archived_reason: "E0005.1 — superseded by OddKit dynamic routing"
uri: klappy://docs/archive/infra/infra/orchestrator/README
title: "Orchestrator Infrastructure"
audience: docs
exposure: nav
tier: 3
voice: neutral
stability: stable
tags: ["docs", "archive", "orchestrator", "infrastructure", "router", "librarian", "pre-vodka"]
---
```

## Why

The README documented the **pre-Vodka imperative orchestrator substrate** — `router.js` (lookup detection), `services/librarian.js` (citation-first retrieval), `validators/librarian-response.js` (citation compliance). That whole substrate was replaced by prompt-over-code epistemic guidance via canon docs and oddkit MCP tools. The file is genuinely outdated, retained as proof of evolution.

The drift was: archive content with no metadata signaling its archival state. This adds the signal.

## Pattern

Matches established convention in this archive tree (`docs/archive/PRD.md`, `docs/archive/attempt-lifecycle.md`):
- `archived: true` (unquoted boolean)
- `archived_reason: "E0005.1 — superseded by OddKit dynamic routing"`
- Title preserved unchanged
- `tier: 3` for operational/infrastructure docs
- `exposure: nav` — discoverable as historical artifact, not promoted

## Authority

- `klappy://canon/meta/frontmatter-schema` — booleans/integers/dates unquoted; eight universal fields required
- `klappy://canon/constraints/frontmatter-validation-before-merge` — applies, validated locally with PyYAML (all native types parse correctly)

## Scope

Single file. Scoped intentionally — there's broader archive-tree drift (e.g. `docs/archive/infra/infra/README.md` lacks `archived` flag despite living in archive), worth a follow-up sweep if desired. Body unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that adds archive metadata/frontmatter; no runtime code paths are affected.
> 
> **Overview**
> Adds standard YAML frontmatter (including `archived: true`, `archived_reason`, `uri`, and tagging) to `docs/archive/infra/infra/orchestrator/README.md` so it’s explicitly treated as archived/superseded content while leaving the body unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0233fa830c9dc2bff05996a236a4d7dae714455. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->