### PR TITLE
fix(writings): repair software-virtues-revisited frontmatter

### DIFF
--- a/writings/software-virtues-revisited.md
+++ b/writings/software-virtues-revisited.md
@@ -1,14 +1,41 @@
 ---
 uri: klappy://writings/software-virtues-revisited
 title: "Software Virtues, Revisited — What I Wrote in 2018, What I Stand By, and What I Owed the Reader"
+subtitle: "What I Wrote in 2018, What I Stand By, and What I Owed the Reader"
+author: "Klappy"
+type: essay
+public: true
 audience: public
-exposure: published
+exposure: public
 tier: 3
-voice: klappy
+voice: first_person
 stability: stable
-tags: ["writings", "essay", "software-virtues", "quality-attributes", "tradeoffs", "ilities", "tension-matrix", "revisit"]
+tags:
+  - writings
+  - essay
+  - software-virtues
+  - quality-attributes
+  - tradeoffs
+  - ilities
+  - tension-matrix
+  - revisit
 epoch: E0008.4
 date: 2026-05-10
+
+# Discovery
+hook: "Eight years later, a partner asked me which '-ilities' actually trade off against which. I sent him the article and told him I still stand by it — then realized it never built the full map."
+description: "Eight years ago I wrote about ten software virtues and the tensions among them. A partner asked today which actually trade off against which, in which use cases — and I realized the article I'd been recommending for a decade had only listed tensions per-virtue and never assembled the full map. So I built it, and then realized the map was a worked example of something larger: a constraints survey for new work with agents."
+slug: software-virtues-revisited
+
+# Social graph
+og_title: "Software Virtues, Revisited"
+og_description: "Eight years later, a partner asked me which '-ilities' actually trade off against which. I sent him the article and told him I still stand by it — then realized it never built the full map."
+og_type: article
+twitter_card: summary_large_image
+twitter_title: "Software Virtues, Revisited"
+twitter_description: "Eight years later, a partner asked me which '-ilities' actually trade off against which. I sent him the article and told him I still stand by it — then realized it never built the full map."
+
+# Relationships
 derives_from: "https://medium.com/@klappy/what-are-software-virtues-and-how-to-prioritize-them-f0b583741afe (2018-09-09 — original article), canon/observations/quality-attribute-tension-matrix.md, canon/principles/quality-attributes-are-in-tension.md, canon/definitions/software-virtues-vocabulary.md, odd/maturity.md"
 complements: "writings/agentic-software-development.md"
 status: active


### PR DESCRIPTION
## What

Fixes the May 10 essay `writings/software-virtues-revisited.md` so it actually appears on the homepage.

## Why it was invisible

The doc-listing Supabase function (which feeds the homepage) silently filters out entries whose frontmatter doesn't conform. This essay had:

| Field | Was | Now | Note |
|---|---|---|---|
| `exposure` | `published` | `public` | `published` is not a valid value. Canon allows `nav \| public \| draft \| hidden \| internal`. |
| `voice` | `klappy` | `first_person` | Not in voice enum either. |
| `type` | *(missing)* | `essay` | Renderer cannot select template without this. |
| `slug` | *(missing)* | `software-virtues-revisited` | Renderer cannot generate page URL without this. |
| `public` | *(missing)* | `true` | Boolean, unquoted. |
| `hook` / `description` / `subtitle` / `author` / og+twitter | *(missing)* | backfilled | Pulled from author's own opening blockquote — no new content invented. |

Both crash patterns above are documented in `klappy://canon/constraints/frontmatter-validation-before-merge` § Known Crash Patterns. The canon constraint mandates automated schema validation pre-merge; the implementation gap (canon-quality.yml only audits `klappy://` reference integrity, not frontmatter schemas) will be closed in a follow-up oddkit PR adding a `frontmatter-schema` rule pack to `oddkit_audit`.

## Verification

- Frontmatter parsed with PyYAML, all eight universal fields present, all enum values in their canon-allowed sets, no `public:false + exposure:public` contradictions, no quoted-boolean issues.
- Body untouched (160 lines preserved verbatim).

## Canon

- `klappy://canon/constraints/frontmatter-validation-before-merge`
- `klappy://canon/meta/frontmatter-schema`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to frontmatter metadata (enums/required fields) to make the essay render/list correctly; no application logic changes.
> 
> **Overview**
> Fixes `writings/software-virtues-revisited.md` frontmatter to conform to the site’s expected schema so the essay is eligible for listing/rendering.
> 
> Adds missing required metadata (`type`, `slug`, `public`, plus social/discovery fields) and normalizes invalid values (e.g., `exposure: public`, `voice: first_person`) while leaving the body content unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3f2a40c2a2518bcd262d5f119db6f1078b2e04a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->