### PR TITLE
Refresh virtues-revisited essay: survey + personality radar integration

### DIFF
--- a/writings/software-virtues-revisited.md
+++ b/writings/software-virtues-revisited.md
@@ -18,32 +18,34 @@ tags:
   - tradeoffs
   - ilities
   - tension-matrix
+  - tension-survey
+  - personality-radar
   - revisit
 epoch: E0008.4
 date: 2026-05-10
 
 # Discovery
-hook: "Eight years later, a partner asked me which '-ilities' actually trade off against which. I sent him the article and told him I still stand by it — then realized it never built the full map."
-description: "Eight years ago I wrote about ten software virtues and the tensions among them. A partner asked today which actually trade off against which, in which use cases — and I realized the article I'd been recommending for a decade had only listed tensions per-virtue and never assembled the full map. So I built it, and then realized the map was a worked example of something larger: a constraints survey for new work with agents."
+hook: "Eight years later, a partner asked me which '-ilities' actually trade off against which. I sent him the article, told him I still stand by it — then realized it never built the full map. So I built the map, then a survey on top of it, then a radar that shows your product its own personality."
+description: "Eight years ago I wrote about ten software virtues and the tensions among them. A partner asked today which actually trade off against which, and the article I'd been recommending for a decade only listed tensions per-virtue. So I built the full matrix, then a seven-phase constraints survey on top of it, then realized the cleanest framing was that the survey is a personality test for the product — and the radar it produces is the roadmap, visualized."
 slug: software-virtues-revisited
 
 # Social graph
 og_title: "Software Virtues, Revisited"
-og_description: "Eight years later, a partner asked me which '-ilities' actually trade off against which. I sent him the article and told him I still stand by it — then realized it never built the full map."
+og_description: "Eight years later, a partner asked me which '-ilities' actually trade off against which. The article I'd been recommending for a decade never built the full map. So I built it — and a personality test for the product."
 og_type: article
 twitter_card: summary_large_image
 twitter_title: "Software Virtues, Revisited"
-twitter_description: "Eight years later, a partner asked me which '-ilities' actually trade off against which. I sent him the article and told him I still stand by it — then realized it never built the full map."
+twitter_description: "Eight years later, a partner asked me which '-ilities' actually trade off against which. The article I'd been recommending for a decade never built the full map. So I built it — and a personality test for the product."
 
 # Relationships
-derives_from: "https://medium.com/@klappy/what-are-software-virtues-and-how-to-prioritize-them-f0b583741afe (2018-09-09 — original article), canon/observations/quality-attribute-tension-matrix.md, canon/principles/quality-attributes-are-in-tension.md, canon/definitions/software-virtues-vocabulary.md, odd/maturity.md"
+derives_from: "https://medium.com/@klappy/what-are-software-virtues-and-how-to-prioritize-them-f0b583741afe (2018-09-09 — original article), canon/observations/quality-attribute-tension-matrix.md, canon/principles/quality-attributes-are-in-tension.md, canon/definitions/software-virtues-vocabulary.md, canon/methods/quality-attribute-tension-survey.md, odd/maturity.md"
 complements: "writings/agentic-software-development.md"
 status: active
 ---
 
 # Software Virtues, Revisited — What I Wrote in 2018, What I Stand By, and What I Owed the Reader
 
-> I wrote about ten software virtues and the tensions among them in 2018. Eight years later, a partner asked me which "-ilities" actually trade off against which, in which use cases. I sent him the article and told him I still stand by it. Then I realized the article only listed the tensions named per-virtue — it never built the full map. So I built it, and then realized the map was a worked example of something larger: a constraints survey for new work with agents.
+> I wrote about ten software virtues and the tensions among them in 2018. Eight years later, a partner asked me which "-ilities" actually trade off against which, in which use cases. I sent him the article and told him I still stand by it. Then I realized the article only listed the tensions named per-virtue — it never built the full map. So I built it. Then I realized the map was a worked example of something larger — a constraints survey for new work with agents — so I built that too. And then I realized the cleanest framing of the whole thing is that the survey is a personality test for the product, and the radar it draws is the roadmap.
 
 ---
 
@@ -153,26 +155,140 @@ If you have read the original article and felt overwhelmed, the matrix is what y
 
 Ian got the table he asked for. You get the table he asked for too.
 
-## What This Becomes Next
+## What This Became
 
-Here is the part I did not see clearly until this morning, and that I think is actually the most useful turn in the whole eight-year arc:
+The first draft of this essay closed with a forward-looking sketch: *the matrix is a constraints survey for new work with agents, and that's what I'm building next.* By the time I finished publishing, the survey was already built. The canon now carries the [seven-phase method](klappy://canon/methods/quality-attribute-tension-survey) the sketch promised. The arc landed faster than the essay anticipated, which is the right way for an essay about a tradeoff system to age — the system kept moving while the writing was settling.
 
-The matrix is not a reference document. It is **a constraints survey for new work with agents.**
+The shape of the method is small enough to describe in a paragraph and big enough that it took the rest of the day to specify. You start by naming the project's stage — proof of concept, pilot, production, refactor, or *other*-with-a-name. You select the ilities that apply, both the ones the project optimizes for **today** and the ones it should optimize for **going forward**; the two lists are usually close and never identical. You rank each ility on the MoSCoW scale — *Won't, Could, Should, Must* — for both states. You consult the tension matrix (or generate dynamically for non-canonical ilities) to surface the sacrifices the desired ranking commits to and the sacrifices the current state is already living with. You acknowledge each sacrifice explicitly, and you let the inevitable rejections kick you back to re-rank. Then you encode the result.
 
-When you scope a new project — a new product, a new service, a new feature, a new agent task — you are implicitly ranking quality attributes whether you say so or not. Most projects fail to articulate the ranking, hit the tensions sideways, and call the resulting confusion "scope creep" or "technical debt" or "we shipped the wrong thing." The article from 2018 named the ten virtues. The matrix names the tensions among them. The constraints survey is what you do *with* the matrix when you sit down to start something new.
+The encoding is where the survey stops being a workshop artifact and starts being infrastructure. Three [DOLCHEO](klappy://canon/definitions/dolcheo-vocabulary) artifact types fall out of one survey pass: **Constraints** capturing the desired state (the priorities the project commits to, the sacrifices it accepts, the ilities it explicitly does not optimize for), **Observations** capturing the current state (the observed level of each ility, with the source — telemetry, code review, contributor survey, lived experience), and **Opens** capturing the gap between them (one roadmap item per non-zero gap, ranked by magnitude, direction of investment named). The agent working on the project inherits the Constraints automatically. The Observations are the falsifiable baseline against which future surveys measure drift. The Opens are the prioritized roadmap.
 
-The flow looks like this:
+The whole loop is wired to [oddkit](https://oddkit.klappy.dev) actions: `preflight` opens the survey, `gate` enforces every phase boundary, `challenge` pressure-tests sacrifices before they're accepted, `encode` produces the typed output, `validate` closes the survey. The runtime contract is mechanical — it adds no rules, it just enforces the ones canon already carries. A re-run is triggered by phase transition, scope change, tension surprise, stakeholder change, or measured drift; the prior artifacts are archived, the new ones supersede.
 
-- Pick the quality attributes that matter for *this* project. (Usually a subset of the ten, occasionally with additions from the broader universe — securability, auditability, accessibility, observability, whatever the project actually requires.)
-- Rank them for the project's current phase.
-- Reference the tension graph — for the canonical ten, the matrix; for any other set, generate the graph dynamically against the same principle.
-- Encode the chosen priorities and predicted sacrifices as constraints the agents working on the project inherit.
+That description is the spec. The reason the spec is interesting is not that the spec is interesting. It is that the spec produces a picture.
 
-That last step is what makes this an agent-work tool rather than an architectural diagram. Agents — whether you mean LLM-driven coding agents, autonomous task runners, or the next generation of whatever this becomes — work best when the constraints they are operating under are explicit. A constraints survey grounded in the tension graph gives them a coherent answer to the question "what am I optimizing for, and what am I willing to sacrifice?" That answer is what stops an agent from cheerfully refactoring for maintainability while shipping a project whose phase calls for urgency, or from optimizing for originality on a project whose users need stability above all else.
+## The Survey Is a Personality Test for the Product
 
-I did not see this clearly when I started writing the matrix this morning. I saw it when I told a partner I had built the table, and the next sentence out of his mouth was that he hates reinventing the wheel and would absolutely use the abstractions. The article — once a piece of management writing aimed at a human audience that mostly bounced off it — turns out to be exactly the right shape for instrumented agent work. Or rather: the article was the seed, the matrix is the worked example, and the constraints survey is what makes both into infrastructure.
+The cleanest way to think about the survey's output is not as a list of constraints but as a personality profile. The same shape humans use to map traits onto a person — a radar chart with one axis per trait — maps naturally onto a project. Each ility is a trait. The project's ranking on each ility is its score. The polygon connecting the scores is the project's *shape*. Two products can have similar functions and entirely different personalities, and that personality difference is the most important thing a stakeholder, a reviewer, or an inheriting agent needs to know about the project up front.
 
-That last layer is what I am building next. The article is staying load-bearing for one more turn.
+The framing earns the radar chart for free. It is also the framing that lets the survey reach audiences who would never read a method doc. "What's your product's personality?" is a question that gets answered. "Have you completed your quality-attribute tension survey?" is a question that gets ignored. The personality framing is the spoonful of sugar; the survey is the medicine.
+
+The default radar has one axis per ility, ordered so that **ilities in strong mutual tension sit across from each other on the chart**, and ilities that reinforce each other sit adjacent. The visual benefit is structural: a spike on one axis with a valley directly across shows the polygon *leaning* toward what the project prioritizes against what it sacrifices. Adjacent synergistic ilities form smooth contours. The polygon's silhouette becomes the tradeoff record by construction.
+
+The scale is the same MoSCoW scale the 2018 article surfaced. Quantitative 0–100 scoring is rejected as false precision; *Won't / Could / Should / Must* matches the level at which decisions are actually made.
+
+And the survey produces *two* polygons, not one — because every survey is dual-state. The **desired** polygon (solid, full opacity) is the personality the project commits to. The **current** polygon (dashed outline, lighter) is the personality the project actually has today. Where the polygons coincide, the project is on-target on that axis. Where they diverge, the gap is a roadmap item. The radar *is* the roadmap, visualized.
+
+Here is the worked example from canon — a hypothetical pilot-stage authentication service:
+
+<svg viewBox="0 0 600 470" xmlns="http://www.w3.org/2000/svg" role="img" aria-labelledby="radar-title radar-desc" style="max-width: 600px; background: white;">
+  <title id="radar-title">Project Personality Radar — Pilot-stage Authentication Service (Current and Desired)</title>
+  <desc id="radar-desc">Radar chart with ten axes showing both the current and desired priority profiles of a hypothetical pilot-stage authentication service. The desired polygon (solid blue) reaches level 4 on Stability, Reality, and Interoperability and level 3 on Maintainability and Affordability. The current polygon (dashed orange) is smaller, sitting at level 2 on Stability, Maintainability, and Interoperability and level 3 on Reality and Affordability. Gaps between the two polygons on Stability, Maintainability, Reality, and Interoperability visualize the roadmap. Axes ordered tension-opposite clockwise from top: Stability, Maintainability, Reality, Affordability, Efficiency, Urgency, Versatility, Originality, Usability, Interoperability.</desc>
+
+  <!-- Scale rings -->
+  <g fill="none" stroke="#d0d0d0" stroke-width="0.7">
+    <polygon points="300.0,212.5 322.0,219.7 335.7,238.4 335.7,261.6 322.0,280.3 300.0,287.5 278.0,280.3 264.3,261.6 264.3,238.4 278.0,219.7" />
+    <polygon points="300.0,175.0 344.1,189.3 371.3,226.8 371.3,273.2 344.1,310.7 300.0,325.0 255.9,310.7 228.7,273.2 228.7,226.8 255.9,189.3" />
+    <polygon points="300.0,137.5 366.1,159.0 407.0,215.2 407.0,284.8 366.1,341.0 300.0,362.5 233.9,341.0 193.0,284.8 193.0,215.2 233.9,159.0" />
+    <polygon points="300.0,100.0 388.2,128.6 442.7,203.6 442.7,296.4 388.2,371.4 300.0,400.0 211.8,371.4 157.3,296.4 157.3,203.6 211.8,128.6" stroke="#999" stroke-width="1" />
+  </g>
+
+  <!-- Axis lines (tension-opposite ordering, clockwise from top) -->
+  <g stroke="#999" stroke-width="0.5">
+    <line x1="300" y1="250" x2="300.0" y2="100.0" />
+    <line x1="300" y1="250" x2="388.2" y2="128.6" />
+    <line x1="300" y1="250" x2="442.7" y2="203.6" />
+    <line x1="300" y1="250" x2="442.7" y2="296.4" />
+    <line x1="300" y1="250" x2="388.2" y2="371.4" />
+    <line x1="300" y1="250" x2="300.0" y2="400.0" />
+    <line x1="300" y1="250" x2="211.8" y2="371.4" />
+    <line x1="300" y1="250" x2="157.3" y2="296.4" />
+    <line x1="300" y1="250" x2="157.3" y2="203.6" />
+    <line x1="300" y1="250" x2="211.8" y2="128.6" />
+  </g>
+
+  <!-- Desired polygon (solid fill, full opacity) -->
+  <polygon points="300.0,100.0 366.1,159.0 442.7,203.6 407.0,284.8 344.1,310.7 300.0,287.5 278.0,280.3 264.3,261.6 264.3,238.4 211.8,128.6"
+           fill="rgba(0,100,200,0.20)" stroke="#0064C8" stroke-width="2" />
+
+  <!-- Current polygon (dashed outline, no fill, contrasting color) -->
+  <polygon points="300.0,175.0 344.1,189.3 407.0,215.2 407.0,284.8 344.1,310.7 300.0,287.5 278.0,280.3 264.3,261.6 264.3,238.4 255.9,189.3"
+           fill="none" stroke="#E07B2A" stroke-width="2" stroke-dasharray="5,3" />
+
+  <!-- Desired polygon vertices -->
+  <g fill="#0064C8">
+    <circle cx="300.0" cy="100.0" r="3.5" />
+    <circle cx="366.1" cy="159.0" r="3.5" />
+    <circle cx="442.7" cy="203.6" r="3.5" />
+    <circle cx="407.0" cy="284.8" r="3.5" />
+    <circle cx="344.1" cy="310.7" r="3.5" />
+    <circle cx="300.0" cy="287.5" r="3.5" />
+    <circle cx="278.0" cy="280.3" r="3.5" />
+    <circle cx="264.3" cy="261.6" r="3.5" />
+    <circle cx="264.3" cy="238.4" r="3.5" />
+    <circle cx="211.8" cy="128.6" r="3.5" />
+  </g>
+
+  <!-- Current polygon vertices -->
+  <g fill="#E07B2A">
+    <circle cx="300.0" cy="175.0" r="2.5" />
+    <circle cx="344.1" cy="189.3" r="2.5" />
+    <circle cx="407.0" cy="215.2" r="2.5" />
+    <circle cx="407.0" cy="284.8" r="2.5" />
+    <circle cx="344.1" cy="310.7" r="2.5" />
+    <circle cx="300.0" cy="287.5" r="2.5" />
+    <circle cx="278.0" cy="280.3" r="2.5" />
+    <circle cx="264.3" cy="261.6" r="2.5" />
+    <circle cx="264.3" cy="238.4" r="2.5" />
+    <circle cx="255.9" cy="189.3" r="2.5" />
+  </g>
+
+  <!-- Axis labels -->
+  <g font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif" font-size="12" fill="#333">
+    <text x="300.0" y="75.0" text-anchor="middle">Stability</text>
+    <text x="402.9" y="108.4" text-anchor="middle">Maintainability</text>
+    <text x="466.4" y="199.9" text-anchor="start">Reality</text>
+    <text x="466.4" y="308.1" text-anchor="start">Affordability</text>
+    <text x="402.9" y="395.6" text-anchor="middle">Efficiency</text>
+    <text x="300.0" y="425.0" text-anchor="middle">Urgency</text>
+    <text x="197.1" y="395.6" text-anchor="middle">Versatility</text>
+    <text x="133.6" y="308.1" text-anchor="end">Originality</text>
+    <text x="133.6" y="199.9" text-anchor="end">Usability</text>
+    <text x="197.1" y="108.4" text-anchor="middle">Interoperability</text>
+  </g>
+
+  <!-- Scale labels along the top axis -->
+  <g font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif" font-size="9" fill="#999">
+    <text x="305" y="216">1</text>
+    <text x="305" y="178">2</text>
+    <text x="305" y="141">3</text>
+    <text x="305" y="103">4</text>
+  </g>
+
+  <!-- Title -->
+  <g font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif" fill="#222">
+    <text x="300" y="22" text-anchor="middle" font-size="14" font-weight="600">Pilot-Stage Authentication Service</text>
+    <text x="300" y="40" text-anchor="middle" font-size="11" fill="#666">Personality Radar — MoSCoW (1=Won't, 2=Could, 3=Should, 4=Must)</text>
+  </g>
+
+  <!-- Legend -->
+  <g font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif" font-size="11" fill="#333">
+    <line x1="438" y1="445" x2="458" y2="445" stroke="#0064C8" stroke-width="2" />
+    <text x="462" y="448">Desired</text>
+    <line x1="510" y1="445" x2="530" y2="445" stroke="#E07B2A" stroke-width="2" stroke-dasharray="5,3" />
+    <text x="534" y="448">Current</text>
+  </g>
+</svg>
+
+Three things the picture makes visible at a glance that the table buries.
+
+**The gap between the polygons is the roadmap.** The visible gap segments — Stability (top, +2), Maintainability (upper-right, +1), Reality (right, +1), Interoperability (upper-left, +2) — are the four committed investment directions, ranked by gap magnitude. The bottom and bottom-left of the chart show coincident polygons: those axes are on-target. The radar audits the project's trajectory, not just its commitments.
+
+**Tension-opposite axes show their tradeoff structurally.** Stability sits at the top, Urgency directly across at the bottom — the project's spike on Stability (level 4) with valley on Urgency (level 1) shows the strongest single tradeoff being made, visualized as the radar's most pronounced lean. The same pattern across Reality/Originality, Affordability/Usability, Interoperability/Efficiency. The silhouette is the tradeoff record.
+
+**An honest profile is asymmetric, and the two polygons should usually differ.** A near-circular polygon means the ranking was rubber-stamped — no real prioritization happened. A perfectly-coincident pair of polygons means either the project is already at its committed personality (rare on a first survey) or the current state was reported aspirationally rather than observationally. Both failure modes are diagnoseable from the picture.
+
+A project asked which virtues it prioritizes will sometimes claim all of them. A project asked which personality it has will not — because *all of them* is not a personality. The reframe extracts an honest answer where the direct question extracted a defensive one. That is the point.
 
 ## Where to Go Next
 
@@ -183,5 +299,7 @@ If you want the systematic map: [Quality Attribute Tension Matrix](klappy://cano
 If you want the principle behind the map: [Quality Attributes Are In Tension](klappy://canon/principles/quality-attributes-are-in-tension).
 
 If you want the vocabulary the canon uses: [Software Virtues Vocabulary](klappy://canon/definitions/software-virtues-vocabulary).
+
+If you want the survey itself — the seven-phase method that turns the matrix into an operational artifact and produces the radar — start at [Quality Attribute Tension Survey](klappy://canon/methods/quality-attribute-tension-survey).
 
 If you want the discipline that makes the map worth carrying: [the rest of klappy.dev](https://klappy.dev).


### PR DESCRIPTION
## Summary

Refreshes the *Software Virtues, Revisited* essay (`writings/software-virtues-revisited.md`) to incorporate canon that landed after the essay was first published — specifically the seven-phase Quality Attribute Tension Survey method, the dual-state (current + desired) framing, the DOLCHEO Constraints/Observations/Opens output types, the oddkit runtime contract, and the personality-test/radar-chart framing with the worked-example SVG.

The first draft closed with "what I'm building next." The system kept moving; the closing was stale.

## What changed

- **Top blockquote** updated to land the full arc — matrix → survey → personality-test reframe — in one paragraph.
- **`What This Becomes Next` → `What This Became`.** Replaces the four-bullet forward sketch with a compressed description of:
  - the seven-phase shape (Stage → Ility Selection → Phase-Weighted Ranking → Tension Surfacing → Sacrifice Acknowledgment → Output Encoding → Re-Run Triggers, named not respecified)
  - dual-state framing (current + desired in one pass)
  - DOLCHEO output: **Constraints** for desired state, **Observations** for current state, **Opens** for gaps as roadmap
  - oddkit runtime contract: `preflight`, `gate`, `challenge`, `encode`, `validate` wired to phase boundaries
- **New section: `The Survey Is a Personality Test for the Product`.** The audience-facing reframe and the essay's new payoff. Includes:
  - the personality framing (radar with one axis per ility, polygon = project's *shape*)
  - tension-opposite axis ordering (the silhouette is the tradeoff record by construction)
  - MoSCoW scale rationale (categorical matches the level decisions are made at)
  - dual polygons (desired = solid; current = dashed) — the radar is the roadmap, visualized
  - the embedded worked-example SVG from canon (pilot-stage authentication service)
  - three things the picture makes visible: gap is roadmap, tension-opposite shows tradeoff structurally, honest profile is asymmetric
- **`Where to Go Next`** gains an entry pointing at `klappy://canon/methods/quality-attribute-tension-survey`.
- **Frontmatter:**
  - `derives_from` adds `canon/methods/quality-attribute-tension-survey.md`
  - tags add `tension-survey`, `personality-radar`
  - `hook`, `description`, `og_description`, `twitter_description` refreshed for social-graph parity with the new arc

## What was preserved intact

Original load-bearing sections retained without edits:
- A Question from a Partner
- What the Article Got Right (the ten virtues list, the central no-single-objective-function claim)
- What the Article Only Sketched (the 21-of-45 named pairs observation)
- What the Matrix Looks Like (four relationship types, phase weighting, three uses)
- Article Lacked an Operator
- Honest Is Overwhelming
- What I Stand By (the five-claim central thesis)

The voice is unchanged. The five-claim thesis is unchanged.

## What was deliberately not done

Three Opens from `odd/ledger/2026-05-10-software-virtues-canon-package` remain pending operator review and are NOT addressed in this PR:

- **O-open P1** — observability-class virtues inclusion in the matrix
- **O-open P2** — strength of the ODD tie in "Article Lacked an Operator"
- **O-open P3** — MoSCoW / Hundred Dollar Method positioning at the operational level

Each is its own decision; bundling them here would have widened scope without resolving them.

## Reversibility

Canon prose, single-file change. No code, no SDK lock-in, no schema migration. Revert is a follow-up PR; the original content lives in git history. Social-graph metadata changes (og/twitter descriptions) will refresh on next crawl.

## Diff size

1 file changed, 144 insertions(+), 26 deletions(-)

Closes the stale forward-looking arc; opens the door for the standalone personality-test essay teased in the survey canon to land as a non-technical entry point downstream.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: prose-only updates in a single markdown essay plus metadata tweaks; main risk is broken links/rendering of the embedded SVG in downstream publishing.
> 
> **Overview**
> Updates `writings/software-virtues-revisited.md` to reflect the now-shipped *Quality Attribute Tension Survey* method, reframing the essay’s arc from *“what I’ll build next”* to *“what this became”*.
> 
> Adds a new *personality-test* framing with a dual-state (current vs desired) radar chart, including an embedded worked-example SVG, and refreshes frontmatter/social metadata (tags, `derives_from`, hook/description, OG/Twitter blurbs) plus a new “Where to Go Next” link to the survey.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a2c92522cff058f72009bfdc85ee1420241ea12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->