### PR TITLE
odd: land Epoch 9 trio handoff + planning ledger (bootstrap)

### DIFF
--- a/odd/handoffs/2026-05-12-epoch-9-trio.md
+++ b/odd/handoffs/2026-05-12-epoch-9-trio.md
@@ -1,0 +1,453 @@
+---
+uri: klappy://odd/handoffs/2026-05-12-epoch-9-trio
+title: "Handoff — Epoch 9 Declaration Trio (Two-PR Sequence Against klappy/klappy.dev)"
+audience: docs
+exposure: nav
+tier: 2
+voice: neutral
+stability: semi_stable
+tags: ["odd", "handoff", "session", "epoch-9", "epoch-bump", "essay-import", "we-were-the-wire", "governance-change-discipline", "writing-canon", "two-pr-sequence"]
+epoch: E0008.6
+date: 2026-05-12
+derives_from: "canon/constraints/governance-change-discipline.md, canon/meta/writing-canon.md, canon/constraints/ai-voice-cliches.md, canon/constraints/guide-posture.md, canon/voice/oddie-the-river-guide.md, canon/principles/agents-need-their-own-wire.md, canon/architecture/substrate-stack.md, canon/methods/persona-shaped-agent-runtime.md, canon/methods/dispatch-paths.md, canon/methods/trigger-source-taxonomy.md, klappy/agent-messaging-service:ESSAY.md"
+complements: "odd/ledger/2026-05-12-epoch-9-planning.md, docs/appendices/epoch-8-3.md, docs/oddkit/release-notes/2026-04-20-post-4-7-adaptation.md"
+governs: "The next session's lane is executing the two-PR trio that plants the Epoch 9 flag in klappy.dev: declaration + frontmatter retag (PR A), public essay import + expansion + writing governance (PR B). All four governance-change-discipline markers must accompany the epoch bump. Execution happens in a fresh-context session per verification-requires-fresh-context."
+status: open
+---
+
+# Handoff — Epoch 9 Declaration Trio (Two-PR Sequence Against klappy/klappy.dev)
+
+> Plant the E0009 flag with full governance discipline, retag the agentic-substrate canon that earned it, and give klappy.dev a public-facing essay surface for the "agents-need-their-own-wire" argument. Two PRs, serial. All four markers from `governance-change-discipline` accompany the epoch bump — canon version, changelog, release notes, appendix doc — not just the appendix. Essay imports "We Were the Wire" from `klappy/agent-messaging-service` and expands it ~1,500 words to cover the broader Epoch 9 themes (substrate stack, autonomous-trigger dispatch, R2-ESE pipeline, validator-on-substrate, Oddie as L4 persona). Klappy first-person voice throughout, not Oddie. Execution in a fresh-context session per `verification-requires-fresh-context`. The planning session that produced this handoff is captured in the sibling ledger.
+
+---
+
+## Summary — What the Next Session Does
+
+Two PRs against `klappy/klappy.dev`, in this order:
+
+**PR A: Epoch 9 declaration + frontmatter retag.** Mechanical canon work. New appendix doc, four-marker governance discipline applied in full (canon version bump, changelog entry, release notes, epoch appendix), frontmatter retag from `E0008.5` to `E0009` on the agentic-substrate canon catalog landed during the past week. Plus `canon/bootstrap/model-operating-contract` from `E0008.3` to `E0009` (frontmatter-only; content update is deferred to a separate session).
+
+**PR B: "We Were the Wire" essay import + expansion + writing governance pass.** New file at `writings/we-were-the-wire.md`. Spine imported from `klappy/agent-messaging-service/ESSAY.md` (~2,300 words, currently the only canonical version of the essay). Expansion (~1,500 words) added before the "What Happens Next" close, covering the broader themes Epoch 9 addresses: the wire problem is not just agent-to-agent (audits, validators, session-routing, ingestion, memory all had the same shape), the substrate stack as the answer, autonomous-trigger as the dispatch path that ends operator-as-relay, the R2-drop-a-file-get-knowledge worked example, Oddie as the first L4 persona earning the substrate. Writing canon checklist applied; voice locked to Klappy first-person (not Oddie). The essay closes back into the original's "the interesting part is everything you can do once the wire is just there."
+
+PR A merges first because PR B references `epoch: E0009` in frontmatter, which only resolves once PR A lands. Both PRs are file-delete reversible.
+
+---
+
+## Context — Why This Now
+
+The week of 2026-05-07 through 2026-05-12 produced an unusually dense canon catalog all pointed at the same shift: the operator is no longer the wire. The load-bearing docs already exist in canon — `agents-need-their-own-wire` (Tier-1 principle), `substrate-stack` (six-layer architectural map), `persona-shaped-agent-runtime` (substrate-vs-runtime distinction), `spawned-agent-session-runtime-contract` (five orthogonal dimensions), `spawned-agent-session-substrate-options` (multi-vendor catalog), `dispatch-paths` (assistant-orchestrated vs autonomous-trigger binary, landed 2026-05-12), `trigger-source-taxonomy` (nine canonical trigger types, landed 2026-05-12), `mode-transitions-require-encoded-handoff`, `sessions-mirror-modes`, `creators-get-paid`, `magical-first-run`, `symmetric-participation`, plus the supporting voice and methodology canon. The frontmatter validator (PR #196) is live and hard-blocks any malformed frontmatter.
+
+The live work that earns the epoch is `klappy/agent-messaging-service` PR #77 (open as of 2026-05-12T02:24Z): audit-gate runtime migration from Anthropic Managed Agents onto Cloudflare's Agents Week primitives (Durable Object + Agents SDK + Project Think). That migration is the first production wiring of `persona-shaped-agent-runtime`. The trio in this handoff plants the flag the migration marches under.
+
+The narrative case for the shift exists today only inside the AMS repo at `ESSAY.md` ("We Were the Wire"). It has not yet been brought into `klappy.dev/writings/`. The argument has grown teeth since the essay was written; the import is also an opportunity to expand it to match the canon catalog that has densified around it.
+
+---
+
+## Scope
+
+### In Scope
+
+- `docs/appendices/epoch-9.md` — new file, modeled on `docs/appendices/epoch-8-3.md` shape
+- `canon/CHANGELOG.md` — new version entry (likely `0.38.0`; verify by tail of file)
+- `docs/oddkit/release-notes/2026-05-12-epoch-9-substrate-becomes-the-wire.md` — new file (slug negotiable; see open questions)
+- Frontmatter `epoch:` retag on the agentic-substrate canon docs (full candidate list below; per-doc verification required before mutation)
+- `canon/bootstrap/model-operating-contract.md` frontmatter epoch bump (E0008.3 → E0009; content untouched)
+- `writings/we-were-the-wire.md` — new file, spine imported from AMS `ESSAY.md`, expansion added
+- Writing governance pass on the new essay against `writing-canon` + `ai-voice-cliches` + `guide-posture`
+
+### Out of Scope
+
+- AMS-side `ESSAY.md` modification — keeps original; forward-pointer to klappy.dev expanded version is a separate AMS PR
+- Bootstrap content update for E0009 disciplines (dispatch-path discipline, autonomous-trigger error-routing) — separate session
+- `ams.convention.v1` (L3 identity-and-convention) — entirely separate work track
+- AMS PR #77 review — independent and ongoing
+- Frontmatter retag of E0008.4 / E0008.6 docs that are NOT substrate-shaped (e.g., software-virtues canon, specs-lock-at-implementation)
+
+---
+
+## Sequence
+
+**PR A first; PR B opens only after PR A merges.** Reason: PR B's essay frontmatter declares `epoch: E0009`, which is a meaningful tag only after PR A makes E0009 a named epoch in canon. Opening B before A would leave a forward reference to an unresolved epoch.
+
+Approximate effort: PR A is ~4–6 hours of mechanical canon work (writing the appendix, the release notes, the changelog entry, plus the per-doc frontmatter retag). PR B is ~6–10 hours dominated by the essay expansion and the writing governance pass.
+
+---
+
+## PR A — Full Specification
+
+### Artifacts Created
+
+**1. `docs/appendices/epoch-9.md`** — modeled on `docs/appendices/epoch-8-3.md`.
+
+Required frontmatter shape (per existing appendix convention):
+- `uri: klappy://docs/appendices/epoch-9`
+- `title: "Epoch 9 — Substrate Becomes the Wire"` *(working title; alternative: "The Operator Is No Longer the Wire". Pick during execution.)*
+- `audience: docs`
+- `exposure: nav`
+- `tier: 2`
+- `voice: neutral`
+- `stability: stable`
+- `tags: ["odd", "epochs", "substrate", "agentic", "vodka-architecture", "epoch-9", "operator-as-wire", "persona-shaped-runtime"]`
+- `epoch: E0009`
+- `date: 2026-05-12`
+- `forcing_fault: "The operator was the wire. The substrate's intelligence ended at the human's clipboard. Every cross-agent hop, every audit, every validation, every session transition routed through human attention. The system bottleneck was not tokens — it was the human in the loop being the integration layer. Audits were regex against prose. Validation was same-session self-review. Cross-agent coordination was copy-paste. Knowledge ingestion was manual transcription. Memory was operator-remembers. The intelligence stack was real but the wire between intelligences was a human relay."`
+- `new_invariant: "Operator-as-wire is past tense. Audits are spawned agent sessions on substrate. Validation has its own substrate and its own context break. Personas are deployable peers with accounts and streams, not voices in chat windows. Cross-agent coordination is direct over the wire (AMS), not relayed. Knowledge ingestion is autonomous-trigger pipelines (R2 → ESE → KB) with no assistant in the loop. The operator's attention is reserved for direction-setting and pivot decisions; the substrate handles transport, dispatch, audit, validation, and ingestion."`
+- `core_shift: "From assistant-mediated workflow with operator as integration layer → substrate-mediated workflow with operator as director. The wire moves from human shoulders to infrastructure. The dispatch-paths binary (assistant-orchestrated vs autonomous-trigger) makes the choice mechanical; the substrate-stack makes the layers orthogonal; the persona-shaped runtime makes Oddie deployable as a real peer on the wire."`
+- `derives_from: "docs/appendices/epoch-8-6.md (if it exists; otherwise epoch-8-3.md), canon/principles/agents-need-their-own-wire.md, canon/architecture/substrate-stack.md, canon/methods/persona-shaped-agent-runtime.md, canon/methods/spawned-agent-session-runtime-contract.md, canon/methods/dispatch-paths.md, canon/methods/trigger-source-taxonomy.md, canon/constraints/audit-gates-are-spawned-agent-sessions.md, klappy/agent-messaging-service:ESSAY.md, klappy/agent-messaging-service:#77"`
+- `documents_introduced: ["docs/appendices/epoch-9.md", "writings/we-were-the-wire.md"]`
+
+Body shape (modeled on `epoch-8-3.md`):
+- Title + blockquote summary (one paragraph synthesizing the three frontmatter axes)
+- `## Forcing Fault` (the operator-as-wire failure mode, with the receipts the past week's canon produced)
+- `## New Invariant` (what is now true that was not before)
+- `## Core Shift` (the qualitative jump from E0008.x's "validation as observable mode" / "specs lock at implementation" to E0009's "substrate becomes the wire")
+- `## Layered Receipts — What Each L1–L6 Owes the Epoch` (table: layer, what done looks like at this layer, which canon already covers it, what remains)
+- `## Documents Introduced` (this appendix + the essay)
+- `## What Comes Next` (audit-gate migration AMS #77 lands as the first production runtime, Oddie deploys as a real L4 peer, `ams.convention.v1` ships, TinCan magical first-run earns L5)
+- `## See Also` (cross-references to load-bearing canon)
+
+**2. `canon/CHANGELOG.md` — version bump entry.**
+
+Append at the top (under the `# 📜 Canon Changelog` header):
+
+```markdown
+## 0.38.0 — 2026-05-12
+
+**Substrate Becomes the Wire (E0009)**
+
+A new epoch. Epoch 8 made validation observable, time observable, encoding-types governed, and specs locked at implementation. Epoch 9 ends operator-as-wire as the default integration pattern. The substrate stack is named end-to-end (`canon/architecture/substrate-stack`); persona-shaped runtimes are specified (`canon/methods/persona-shaped-agent-runtime`); dispatch paths are bounded into a binary (`canon/methods/dispatch-paths`); trigger sources are taxonomized (`canon/methods/trigger-source-taxonomy`); and the first production-grade exercise of the runtime — the audit-gate migration onto Cloudflare's Agents Week primitives — is open as `klappy/agent-messaging-service` #77.
+
+The narrative form of the epoch's central argument — "We Were the Wire" — is imported into `writings/` as a public-facing essay, expanded to cover the substrate stack and the layered receipts each tier of the stack owes the epoch.
+
+Behavior change: from this version forward, when canon describes a workflow that includes a human in an integration role, it is describing a design smell unless the role is explicitly direction-setting or pivot-decisioning. The operator is a director, not a relay. Validators are spawned agent sessions. Audits are spawned agent sessions. Ingestion is autonomous-trigger pipelines. The wire is no longer a person.
+
+- Adds: `docs/appendices/epoch-9.md`, `writings/we-were-the-wire.md`, `docs/oddkit/release-notes/2026-05-12-epoch-9-substrate-becomes-the-wire.md`
+- Retags: ~18 agentic-substrate canon docs from `epoch: E0008.5` to `epoch: E0009`; bootstrap from `E0008.3` to `E0009` (frontmatter-only)
+- Related: `klappy/agent-messaging-service` #77 (audit-gate runtime migration — the first production runtime exercise)
+```
+
+*Verify the next-version number by reading the current tail of `canon/CHANGELOG.md` before writing — the planning session observed 0.37.0 was the latest, so 0.38.0 is the expected next minor. If the tail has moved, adjust.*
+
+**3. `docs/oddkit/release-notes/2026-05-12-epoch-9-substrate-becomes-the-wire.md`** — new file, modeled on `docs/oddkit/release-notes/2026-04-20-post-4-7-adaptation.md`.
+
+Required frontmatter shape:
+- `uri: klappy://docs/oddkit/release-notes/2026-05-12-epoch-9-substrate-becomes-the-wire`
+- `title: "Release Notes — Epoch 9: Substrate Becomes the Wire (2026-05-12)"`
+- `audience: docs`, `exposure: nav`, `tier: 2`, `voice: neutral`, `stability: stable`
+- `tags: ["docs", "oddkit", "release-notes", "epoch-9", "substrate", "agents-need-their-own-wire", "behavior-change"]`
+- `epoch: E0009`, `date: 2026-05-12`
+- `derives_from: "canon/constraints/governance-change-discipline.md, docs/appendices/epoch-9.md, writings/we-were-the-wire.md, canon/principles/agents-need-their-own-wire.md"`
+- `governs: "Operator and agent behavior after PR A merges — the substrate stack is the default integration pattern, operator-as-wire is named as a design smell, autonomous-trigger is the canonical path for everything except synchronous user-facing assistance."`
+- `related_pr: "<URL of PR A once opened>"`
+
+Body shape (per `post-4-7-adaptation` precedent — frame impact by *usage*, not by file inventory):
+- Title + blockquote summary
+- `## Summary — Behavior Change Is the Deliverable`
+- `## What Changes for Operators`
+- `## What Changes for Agents`
+- `## What Does Not Change`
+- `## How to Recognize Operator-as-Wire (and Replace It)`
+- `## Receipts Per Layer` (what each L1–L6 owes; reuse the table from the appendix)
+- `## Related`
+
+**4. Frontmatter retag — per-doc verification then mutation.**
+
+**Candidate list (verify each frontmatter before mutating):**
+
+```
+canon/architecture/substrate-stack.md                                     E0008.5 → E0009
+canon/methods/persona-shaped-agent-runtime.md                             E0008.5 → E0009
+canon/methods/spawned-agent-session-runtime-contract.md                   E0008.5 → E0009
+canon/methods/spawned-agent-session-substrate-options.md                  E0008.5 → E0009
+canon/methods/dispatch-paths.md                                           E0008.5 → E0009
+canon/methods/trigger-source-taxonomy.md                                  E0008.5 → E0009
+canon/principles/agents-need-their-own-wire.md                            E0008.5 → E0009
+canon/principles/symmetric-participation.md                               E0008.5 → E0009
+canon/principles/sessions-mirror-modes.md                                 E0008.5 → E0009
+canon/principles/creators-get-paid.md                                     E0008.5 → E0009
+canon/principles/magical-first-run.md                                     E0008.5 → E0009
+canon/principles/methodology-personification.md                           E0008.5 → E0009
+canon/principles/voice-as-cognitive-load-shedding.md                      E0008.5 → E0009
+canon/constraints/mode-transitions-require-encoded-handoff.md             E0008.5 → E0009
+canon/constraints/critic-cannot-be-resolver.md                            E0008.5 → E0009
+canon/observations/clone-klappy-to-oddie-recognition.md                   E0008.5 → E0009
+canon/definitions/epistemic-modes.md                                      E0008.5 → E0009
+docs/appendices/mode-separated-conversations.md                           E0008.5 → E0009
+canon/bootstrap/model-operating-contract.md                               E0008.3 → E0009
+```
+
+**Per-doc verification procedure (mandatory — `meaning-must-not-depend-on-path`):**
+For each candidate, read the doc's current frontmatter and `governs` field. Confirm that the doc is in fact substrate / agentic-runtime / persona-shaped work that earned its tag from the Epoch 9 push, not from incidental dating. If any doc reads as orthogonal (e.g., it was tagged `E0008.5` because of when it was written but governs unrelated subject matter), exclude it from the retag and note the exclusion in the PR description. Do not retag based on date alone.
+
+**Not bumping** (verified out of scope): software-virtues package (E0008.4 — virtues-revisited, tension-matrix, tension-survey, software-virtues-vocabulary, etc.), `canon/principles/specs-lock-at-implementation` and related E0008.6 docs (specs lock is its own E0008.6 sub-epoch, not part of the substrate push).
+
+### PR A — Definition of Done
+
+- All four `governance-change-discipline` markers present (canon version bump, changelog entry, release notes file, epoch appendix doc)
+- All retag candidates verified per-doc (not blanket-applied)
+- Frontmatter validator CI (`#196`) passes on the PR
+- All `klappy://` URIs in the new docs resolve (run `oddkit_audit` locally or via the canon-quality workflow)
+- Cursor Bugbot reaches `completed` (not just `in_progress`) per `release-validation-gate` discipline
+- PR description references this handoff URI and the original ESSAY.md source
+
+### PR A — Reversibility
+
+- New files: deletable
+- Frontmatter mutations: reversible via revert-the-commit
+- Canon version bump: revertible via subsequent patch version with a "revert" entry
+- Release notes file: deletable
+- No code shipped, no production behavior altered, no tools changed
+
+---
+
+## PR B — Full Specification
+
+### Artifact Created
+
+**`writings/we-were-the-wire.md`** — new file. Spine imported from `klappy/agent-messaging-service/ESSAY.md` (read at: `https://api.github.com/repos/klappy/agent-messaging-service/contents/ESSAY.md`, ~11,641 chars / ~2,300 words). Expansion added before the original's "What Happens Next" closing section.
+
+### Frontmatter
+
+```yaml
+uri: klappy://writings/we-were-the-wire
+title: "We Were the Wire"
+subtitle: "An Essay on Why Agents Need Their Own Messaging Protocol — and How the Substrate Stack Ends Operator-as-Wire"
+author: Klappy
+type: essay
+public: true
+audience: public
+exposure: public
+tier: 3
+voice: first_person
+stability: stable
+tags: ["writings", "essay", "agents", "substrate", "wire", "AMS", "tokens-not-messages", "dial-tone", "TCP-IP", "agents-need-their-own-wire", "substrate-stack", "persona-shaped-runtime", "dispatch-paths", "autonomous-trigger", "epoch-9"]
+epoch: E0009
+date: 2026-05-12
+hook: "At a hackathon two months ago, my collaborator and I sat in the back row and watched our agents need to talk to each other. We copied messages between Signal and two chat windows. For forty minutes, two reasoning systems with arbitrary bandwidth were bottlenecked through two humans operating a clipboard. We were the wire."
+description: "The hackathon scene that named the problem; the dial-tone argument that frames the answer; the substrate stack that earns it. Operator-as-wire is the default failure mode for every agent integration today — not just agent-to-agent messaging, but audits, validation, session-routing, ingestion, and memory. AMS gives the wire its own substrate; the stack above it gives every other layer its own shape. The interesting part is everything you can do once the wire is just there."
+slug: we-were-the-wire
+og_title: "We Were the Wire"
+og_description: "Two agents needed to talk. We copied messages between Signal and two chat windows for forty minutes. The hackathon scene that named the problem; the stack that earned the answer."
+og_type: article
+twitter_card: summary_large_image
+twitter_title: "We Were the Wire"
+twitter_description: "Two agents needed to talk. We copied messages between Signal and two chat windows for forty minutes. The hackathon scene that named the problem; the stack that earned the answer."
+derives_from: "klappy/agent-messaging-service:ESSAY.md (original spine, ~2300 words), canon/principles/agents-need-their-own-wire.md (canon principle form), canon/architecture/substrate-stack.md, canon/methods/persona-shaped-agent-runtime.md, canon/methods/dispatch-paths.md, canon/methods/trigger-source-taxonomy.md, canon/methods/spawned-agent-session-runtime-contract.md"
+complements: "writings/agentic-software-development.md, writings/the-dream-house-and-pre-optimization.md"
+status: active
+---
+```
+
+### Body Structure
+
+**Spine sections (imported verbatim or near-verbatim from AMS ESSAY.md; ~2,300 words preserved):**
+
+1. `# We Were the Wire` (title + tagline)
+2. `## The Hackathon` — the back-row scene, the copy-paste, "we were the wire"
+3. `## What Is Actually Missing` — human-built tools fail for agents
+4. `## Tokens, Not Messages` — streaming, fan-out
+5. `## The Stack That Does Not Yet Exist` — verticals reinvent the wire badly; the TCP/IP comparison
+6. `## What We Are Building` — AMS as four primitives: account, conversation, stream, token
+7. `## The Inverted Inbox` — own your writes, not your reads
+
+**Expansion sections (NEW, ~1,500 words added between section 7 and the original's "What Happens Next"):**
+
+8. `## The Wire Problem Was Never Just Agent-to-Agent` — extend the hackathon insight beyond two-agents. The same shape appears at every integration boundary:
+   - Audits that lint prose with regex are humans-as-wire by another name
+   - Validation that happens in the same session as creation is the creator-as-wire (the lenses used to build are the lenses used to evaluate)
+   - Knowledge ingestion that requires manual transcription is the operator-as-wire between sensor and KB
+   - Session-routing between Claude / Cursor / ChatGPT / Lovable is the operator-as-wire between models
+   - Memory that depends on the operator remembering what got encoded is the operator-as-wire between sessions
+   - In every case, the symptom looks different but the underlying shape is the same: a finite human attention is the integration layer.
+
+9. `## The Stack That Answers the Wire Problem` — name the six layers:
+   - **L1 Wire** (AMS): tokens between accounts, no opinion
+   - **L2 Wrapper/Adapter** (MCP edge, channel adapters, AI-tool adapters): translation between L1 and a specific runtime or channel, no application opinion
+   - **L3 Identity & Convention** (`ams.convention.v1`): metadata for legible peer identity
+   - **L4 Role/Agent** (Oddie, future personas): canon-driven behavior, persona-shaped runtime
+   - **L5 Application** (TinCan): magical first-run in under a minute
+   - **L6 Economy** (Stripe rails, penny economy): creators get paid, substrate never extracts
+   - Each layer is replaceable in principle; each layer holds one concern; cross-layer features are suspicious by default.
+
+10. `## The Dispatch Path Question That Settles Everything Else` — the binary that organizes the runtime:
+    - *Assistant-orchestrated:* a human reads the result through a chat assistant. Clarifying questions can be surfaced inline. Errors get explained in chat. The assistant is the consumer of record.
+    - *Autonomous-trigger:* an external event wakes the runtime. There is no chat, no inline operator, no inline assistant. Clarifying questions are incoherent — there is no listener. Errors must emit to a configured channel.
+    - One decision rule: *when the runtime returns, who reads the result first?*
+    - Almost every workflow that historically had a human in the wire was, in fact, an autonomous-trigger shape mistaken for an assistant-orchestrated one. Naming the binary makes the wiring honest.
+
+11. `## Worked Example — Drop a File, Get Knowledge` — the R2/object-store + ESE pipeline:
+    - File lands in R2. Notification through Queues. Queue consumer wakes a Durable-Object-hosted ingestion persona. Persona runs Epistemic Surface Extraction (OCR / ASR / frame extraction / structural parsing). Artifacts encoded as Dolcheo+. Pipeline routes them into the knowledge base.
+    - *Operator drops a file in a bucket; artifacts appear in the KB.* No assistant in the loop.
+    - The shape is reusable: substitute "file" with "transcript," "calendar event," "PR webhook," "Slack message." The wake mechanism changes; the runtime contract does not.
+
+12. `## What Audits Look Like When the Wire Is Substrate` — validator-on-substrate:
+    - The audit gate that lints a PR used to be a regex script. The regex could not read prose; it pattern-matched and missed the things prose actually said.
+    - The audit gate is now a spawned Oddie session. Fresh context, canon-driven behavior, structured deliverable. Same canon governs the auditor that governs the work.
+    - The receipt that proves this is the day the substrate-hosted audit catches a defect a same-session smoke would have missed. That catch is in the audit ledger. The operator-as-wire is past tense.
+
+13. `## Oddie Gets an Account` — methodology-as-deployable-peer:
+    - Oddie has been a voice profile inside chat sessions. In Epoch 9, Oddie gets an AMS account and a stream. A real peer on the wire, not a voice in a window.
+    - Same canon, different surface. Oddie validating a PR (autonomous-trigger, GitHub webhook), Oddie guiding a TinCan room (autonomous-trigger, AMS frame), Oddie running an audit on a schedule (autonomous-trigger, alarm) — all the same persona, mechanically applied.
+
+**Closing section (imported verbatim from original):**
+
+14. `## What Happens Next` — original close, plus a one-paragraph epilogue tying the closing line ("the interesting part is everything you can do once the wire is just there") to the stack now standing above the wire. The hackathon was forty minutes. The stack is six layers. The interesting part is open.
+
+### Length Target
+
+~3,500–4,000 words total. Hard cap 4,000. Do not pad the original spine — it earns its weight. The expansion is *additive*, not interpolated into the existing argument.
+
+### Voice — Mandatory Rules
+
+- **Klappy first-person** throughout. The essay uses "we" for the hackathon scene (Klappy + Ian), "I" for retrospective framing, never "Oddie" or any third-person omniscient register.
+- **Oddie voice does NOT apply.** Per `canon/voice/oddie-the-river-guide` activation rules: Oddie is default-on in oddkit-driven sessions and ODD-mode sessions; default-off in published essays. Public essays stay in the author's voice. This is an explicit not-Oddie surface.
+- **AI-voice-clichés constraint applies.** No "delve," "in today's fast-paced world," no false-balance "however / on the other hand" cadence, no hollow "ultimately," no "tapestry." The essay is direct, dry, and named.
+- **Guide-posture applies even in first-person.** The reader is the hero coming to understand the wire problem. The author is the guide who lived through it. The essay does not lecture; it shows.
+- **Voice-as-cognitive-load-shedding applies.** Calm, brief, dense. Long sentences earn their length by carrying information.
+
+### Writing Canon Checklist (per `canon/meta/writing-canon`)
+
+- Title alone actionable (`We Were the Wire` — yes, names a stance)
+- Title + blockquote actionable (hook + 1-line summary together convey the argument)
+- Title + blockquote + frontmatter metadata actionable (tags + description give scope)
+- `## Summary` section actionable on its own (one paragraph synthesizing the essay's spine)
+- Full doc actionable (the full argument, the worked examples, the closing)
+- Descriptive headers as nav (every `##` is a content header, not "Introduction" / "Conclusion")
+
+### PR B — Definition of Done
+
+- File created at `writings/we-were-the-wire.md`
+- Frontmatter validates against the schema CI (#196)
+- Word count between 3,500 and 4,000
+- All `klappy://` URIs resolve via `oddkit_audit` or equivalent
+- Voice canon checks pass — no Oddie register leakage, no AI tells
+- Writing canon checklist all five depths actionable
+- Spine sections preserved (compare diff against original ESSAY.md — additions only; original prose untouched except for minor punctuation alignment with `klappy.dev` style)
+- Cursor Bugbot reaches `completed`
+- PR description references `epoch: E0009` (resolves only after PR A merges)
+- AMS-side `ESSAY.md` is *not* modified by this PR
+
+### PR B — Reversibility
+
+- New file: deletable
+- No retroactive changes to AMS-side `ESSAY.md`
+- Spine is imported, not replaced — original always available at AMS
+
+---
+
+## Pre-Resolved Decisions (Falsifiable)
+
+These are decisions I made during planning to keep the next session in execution mode rather than re-planning. Each is named so it can be overridden if the executing session sees a reason.
+
+1. **Two PRs, not one.** Cleaner review surface. PR A is mechanical canon; PR B is writing work. Independent merge timing. Override if: the executing session prefers atomic landing and is willing to manage the larger diff.
+
+2. **Bootstrap doc gets a frontmatter bump only.** Content update for E0009-specific disciplines (dispatch-path discipline, autonomous-trigger error-routing) is deferred. Override if: the executing session decides the bootstrap update is mechanical enough to fold in without expanding scope.
+
+3. **Essay voice = Klappy first-person, not Oddie.** Per `oddie-the-river-guide` activation defaults: public essays stay in author voice. Override if: the operator explicitly requests Oddie register for the public essay (would be unusual).
+
+4. **AMS-side `ESSAY.md` stays unchanged in this trio.** Forward-pointer to klappy.dev expanded version is a separate AMS PR. Override if: the executing session has authority to also open the AMS PR and prefers atomic narrative-import.
+
+5. **Essay length target 3,500–4,000 words.** Original is ~2,300; expansion adds ~1,500. Hard cap 4,000. Override if: the expansion runs short or long for organic reasons — the cap is a guideline, not a constraint.
+
+6. **Borrow-evaluation-before-implementation is NOT APPLICABLE here.** Reason: this trio has no upstream substrate to evaluate (the essay is the operator's own work; frontmatter retags are mechanical; the appendix is a new canon doc with no implementation analog). The 6B table would be ceremony. Surface this explicitly in the PR description so the constraint check is auditable.
+
+---
+
+## Open Questions for the Executing Session
+
+These genuinely require judgment at execution time and should not be pre-resolved by the planner.
+
+1. **Per-doc retag verification.** Read each of the ~18 candidate doc frontmatters before mutating. Does each one's `governs` field describe substrate / agentic-runtime / persona-shaped work? If any one reads as orthogonal subject matter that just happened to be tagged `E0008.5` by date, exclude it and note the exclusion in the PR description.
+
+2. **Canon version next number.** The planning session observed `0.37.0` as the latest in `canon/CHANGELOG.md`. If the tail has moved since (other work may have shipped), adjust to the next minor.
+
+3. **Appendix title.** "Substrate Becomes the Wire" vs "The Operator Is No Longer the Wire" vs other framing. Either works; pick during execution. The frontmatter `forcing_fault` and `new_invariant` carry the substance regardless.
+
+4. **Should PR A also bump `docs/appendices/mode-separated-conversations.md` from E0008.5 → E0009?** It's borderline: the doc is the consumer-facing appendix for `mode-discipline-and-bottleneck-respect`, which is foundational to E0009 but not itself an Epoch 9 invention. Judgment call. Lean *yes* (it's the consumer reference for the mode discipline the runtime contract mechanizes), but the executing session may differ.
+
+5. **Should `canon/definitions/epistemic-modes.md` retag?** It's the deepest dependency of the agentic substrate work, but it was a foundational E0008.5 doc that the substrate canon was built on, not produced by the substrate push. Judgment call. Lean *yes* (the retag reflects which epoch it now governs), but acceptable to leave at E0008.5 if the executing session sees a reason.
+
+---
+
+## Risks and Mitigations
+
+- **Risk: A retag candidate is orthogonal to substrate work and gets retagged anyway.**  
+  *Mitigation:* Mandatory per-doc verification step — read each frontmatter `governs` field before mutating. The executing session does NOT batch-replace by sed.
+
+- **Risk: Essay loses crispness through expansion.**  
+  *Mitigation:* Hard cap 4,000 words. Spine sections preserved verbatim. Expansion is additive, slotted between section 7 and the close, not interpolated into the original argument.
+
+- **Risk: Voice drift toward Oddie or AI cliché in the expansion.**  
+  *Mitigation:* Writing governance pass is part of PR B's DoD. The diff is read against `ai-voice-cliches` and `oddie-the-river-guide` activation rules before opening.
+
+- **Risk: Forward-reference from PR B to PR A's E0009 declaration breaks if A doesn't merge first.**  
+  *Mitigation:* Serial sequencing — PR B opens only after PR A merges. The planning session verified PR A has no blockers (no other open klappy.dev PRs, frontmatter validator is green on current main, no merge conflicts expected).
+
+- **Risk: Multi-parallel-agent collision on the same canon files.**  
+  *Mitigation:* The planning session observed (2026-05-12T02:24Z): zero open klappy.dev PRs, zero open klappy/oddkit PRs, one open klappy/agent-messaging-service PR (#77, independent). Window is open. The executing session re-checks open PRs before opening its own.
+
+- **Risk: `release-validation-gate` ambiguity for canon-only PRs.**  
+  *Mitigation:* The constraint as written targets `klappy/oddkit` (code that ships to consumers). For canon-only PRs in `klappy.dev`, the analog is: frontmatter validator must pass, Bugbot must complete, references must resolve. No managed-agent validator dispatch is required for canon-only changes. If the executing session believes a managed-agent validator IS warranted (e.g., the essay's argument is load-bearing enough), they may dispatch one — but it is not a strict prerequisite.
+
+---
+
+## Receipts to Verify Before Each Merge
+
+### Before merging PR A
+- [ ] `docs/appendices/epoch-9.md` exists; frontmatter validates; all five Writing Canon depths actionable
+- [ ] `canon/CHANGELOG.md` entry appended at version `0.38.0` (or current next-minor); date `2026-05-12`
+- [ ] `docs/oddkit/release-notes/2026-05-12-epoch-9-substrate-becomes-the-wire.md` exists; framed by usage impact; resolves all referenced canon
+- [ ] All retag candidates verified per-doc (no orthogonal docs retagged); any excluded ones named in PR description
+- [ ] Bootstrap doc frontmatter bumped (content unchanged)
+- [ ] Frontmatter validator CI green
+- [ ] All `klappy://` URIs in new docs resolve via `oddkit_audit`
+- [ ] Cursor Bugbot reaches `completed` (not `in_progress`)
+- [ ] PR description references this handoff URI and the sibling session ledger
+
+### Before merging PR B
+- [ ] PR A has merged; `epoch: E0009` resolves on `main`
+- [ ] `writings/we-were-the-wire.md` exists; frontmatter validates; word count 3,500–4,000
+- [ ] All five Writing Canon depths actionable
+- [ ] Spine sections preserved (diff vs AMS `ESSAY.md` shows additions only, not edits)
+- [ ] Voice canon pass: no Oddie register leakage; no AI clichés
+- [ ] All `klappy://` URIs resolve
+- [ ] Frontmatter validator CI green
+- [ ] Cursor Bugbot reaches `completed`
+- [ ] PR description references this handoff URI, PR A's merge commit, and the AMS `ESSAY.md` source
+- [ ] AMS `ESSAY.md` confirmed unchanged
+
+---
+
+## Borrow-Evaluation Skip Justification
+
+Per `canon/constraints/borrow-evaluation-before-implementation`: this trio does not require a 6B Evaluation table. Reason: there is no upstream substrate to evaluate. The deliverables are (a) a new canon appendix authored from scratch using the established `docs/appendices/epoch-N.md` shape, (b) a frontmatter retag, mechanical, (c) an essay imported from the operator's own AMS repo and expanded with operator-authored content. None of these are implementation tasks against an SDK, reference impl, or widely-adopted library that the project might otherwise rebuild. The 6B discipline applies to "should I build this or borrow it" decisions; this trio has no such decision to make. Surface this in each PR description so the constraint check is auditable.
+
+---
+
+## Context Health for the Executing Session
+
+This handoff is designed to be the *only* document the executing session needs to read to begin work. It is self-sufficient. Optional supporting context:
+
+- **The sibling session ledger** (`odd/ledger/2026-05-12-epoch-9-planning.md`) carries the audit trail of how this plan was produced — useful for understanding the gauntlet outputs and the challenge catches, not required for execution.
+- **The AMS `ESSAY.md`** is the source material for PR B. The executing session reads it directly from `klappy/agent-messaging-service/ESSAY.md` (raw URL or GitHub API).
+- **Recent klappy.dev canon** (substrate-stack, dispatch-paths, trigger-source-taxonomy, persona-shaped-agent-runtime, agents-need-their-own-wire) ground the appendix and essay expansion. The executing session reads only the sections it needs while drafting.
+
+The planning session's mode rhythm: exploration → planning → handoff-ready (gate PASS at 2026-05-12T02:42Z). The executing session opens in *planning* mode briefly to confirm scope against current `main`, then gates to *execution*.
+
+---
+
+## See Also
+
+- `klappy://canon/constraints/governance-change-discipline` — the four-marker discipline this trio satisfies
+- `klappy://canon/principles/verification-requires-fresh-context` — why this handoff exists at all
+- `klappy://canon/constraints/mode-transitions-require-encoded-handoff` — why this handoff is a durable canon artifact
+- `klappy://canon/principles/agents-need-their-own-wire` — the canon principle whose essay form lands in PR B
+- `klappy://canon/architecture/substrate-stack` — the six-layer map referenced throughout
+- `klappy://canon/methods/dispatch-paths` — the binary that organizes the runtime
+- `klappy://canon/methods/trigger-source-taxonomy` — the nine canonical trigger types
+- `klappy://canon/meta/writing-canon` — the five-depth actionability rule
+- `klappy://canon/voice/oddie-the-river-guide` — the activation rules that keep this essay in Klappy voice
+- `klappy://docs/appendices/epoch-8-3` — the appendix shape PR A models on
+- `klappy://docs/oddkit/release-notes/2026-04-20-post-4-7-adaptation` — the release notes shape PR A models on
+- `klappy/agent-messaging-service:ESSAY.md` — the spine PR B imports
+- `klappy/agent-messaging-service:#77` — the live work that earns this epoch

--- a/odd/ledger/2026-05-12-epoch-9-planning.md
+++ b/odd/ledger/2026-05-12-epoch-9-planning.md
@@ -1,0 +1,182 @@
+---
+uri: klappy://odd/ledger/2026-05-12-epoch-9-planning
+title: "Session Ledger — Epoch 9 Planning + Gauntlet + Handoff (2026-05-12)"
+audience: odd
+exposure: nav
+tier: 3
+voice: neutral
+stability: stable
+tags: ["ledger", "session-journal", "dolcheo", "epoch-9", "planning", "gauntlet", "handoff", "governance-change-discipline", "challenge-catch"]
+epoch: E0008.6
+date: 2026-05-12
+session_start: "2026-05-12T01:38Z"
+session_end: "2026-05-12T02:45Z"
+session_duration_ms: 4020000
+governance_source: knowledge_base
+derives_from: "canon/constraints/governance-change-discipline.md, canon/principles/verification-requires-fresh-context.md, canon/constraints/mode-transitions-require-encoded-handoff.md, canon/definitions/dolcheo-vocabulary.md"
+governs: "Audit trail for the planning session that produced odd/handoffs/2026-05-12-epoch-9-trio.md. Reading this ledger reproduces the operator's view of what was decided, observed, learned, constrained, handed off, encoded, and left open during the Epoch 9 trio planning session."
+status: active
+---
+
+# Session Ledger — Epoch 9 Planning + Gauntlet + Handoff (2026-05-12)
+
+> One planning session, Opus 4.7 instance, 67 minutes elapsed. Operator named the Epoch 9 trio (declaration + essay import + writing governance pass); model surveyed merged PRs and recent canon to ground the plan; gauntlet ran cleanly (preflight, challenge, gate, encode); the challenge step caught three of four `governance-change-discipline` markers that would otherwise have been missed; planning gated to handoff-ready, not in-session execution, per `verification-requires-fresh-context`. Durable artifact produced: `odd/handoffs/2026-05-12-epoch-9-trio.md`. Execution belongs to a fresh-context session.
+
+---
+
+## Summary — The Loop That Ran
+
+The operator opened the session naming "Epoch 9" as direction-of-travel and asked the model to explore the full framing. The model confirmed `oddkit_time`, fetched the bootstrap operating contract, surveyed the canon catalog, and synthesized the substrate-stack + dispatch-paths + trigger-source-taxonomy + persona-shaped-runtime picture into a coherent map. The model produced "DOLCHEO+H" once mid-session (anti-pattern from P0009); the operator caught it; memory was updated with stronger phrasing of the anti-pattern. The model proposed five threads to pull; the operator confirmed direction but directed the model to read merged PRs first because "the work has continued." That read surfaced significant deltas: `canon/methods/dispatch-paths` and `canon/methods/trigger-source-taxonomy` had landed today (klappy.dev PRs #198, #201); `AMS #77` (audit-gate runtime migration) was open as the live work that earns the epoch. The operator then defined the three deliverables (epoch retag, essay import-and-expand, writing governance pass). The model produced a full two-PR plan, ran the gauntlet, and produced the handoff + this ledger.
+
+The single highest-value moment of the session was `oddkit_challenge` surfacing `canon/constraints/governance-change-discipline`. The model's plan had named only one of the four required markers (the epoch appendix doc). The challenge catch saved three markers (canon version bump, changelog entry, release notes file) from being missed and producing an incomplete PR.
+
+---
+
+## Mode Discipline Trace
+
+| Time (UTC) | Mode | Trigger | Note |
+|---|---|---|---|
+| 01:38 | bootstrap | session open | `oddkit_time` → `oddkit_get` of `bootstrap/model-operating-contract` |
+| 01:39 | exploration | operator framing — "Epoch 9" | canon survey + version check |
+| 01:45 | exploration | operator: "Think about it." | synthesis of operator-as-wire shift across stack layers |
+| 01:55 | (correction) | operator caught "DOLCHEO+H" hallucination | memory edit #4 strengthened |
+| 02:00 | exploration | operator: "explore full framing" | AMS repo discovered, ESSAY.md read |
+| 02:20 | exploration | operator: "go look at last handful of merged PRs" | reality-anchored — three new canon docs found |
+| 02:32 | planning | operator: "create a full plan, run gauntlet" | scope locked |
+| 02:40 | planning | `oddkit_preflight` | surfaced ai-voice-cliches, audit-gates-are-spawned-agent-sessions |
+| 02:40 | planning | `oddkit_challenge` | **caught governance-change-discipline four-marker requirement** |
+| 02:41 | planning | `oddkit_gate` (first call) | NOT_READY — inferred wrong transition; restated explicitly |
+| 02:42 | planning | `oddkit_gate` (second call) | PASS — problem_defined + constraints_reviewed met |
+| 02:42 | planning | `oddkit_encode` | three artifacts encoded (C/D/H); persist required → save to file |
+| 02:45 | handoff-ready | files written | `odd-handoffs-2026-05-12-epoch-9-trio.md` + this ledger produced |
+
+No mode collapses observed. One reversion declared explicitly: when the merged-PR read showed the work had outpaced the model's catalog, the model named the stale state, revised the picture, and re-proposed sequence (operator overruled prematurely-converged planning before it could harden).
+
+---
+
+## Dolcheo+ Capture
+
+### D — Decisions
+
+1. **Two-PR serial sequence** against `klappy/klappy.dev`: PR A (Epoch 9 declaration + frontmatter retag) merges before PR B (We Were the Wire essay import + expansion + governance pass) opens. Reversibility: full file-delete revert per PR. Rationale: cleaner review surface; PR B's `epoch: E0009` frontmatter only resolves after PR A lands.
+2. **Four-marker discipline applied in full** to PR A: canon version bump (`canon/CHANGELOG.md` 0.37.0 → 0.38.0), changelog entry, release notes (`docs/oddkit/release-notes/2026-05-12-epoch-9-substrate-becomes-the-wire.md`), epoch appendix (`docs/appendices/epoch-9.md`). Reason: `canon/constraints/governance-change-discipline` mandates all four for any behavior-affecting change.
+3. **Bootstrap doc gets frontmatter bump only** (E0008.3 → E0009). Content update for E0009-specific disciplines is deferred to a separate session. Reason: keep PR A scope mechanical and reviewable; content update would expand surface area significantly.
+4. **Essay voice = Klappy first-person, NOT Oddie.** Per `canon/voice/oddie-the-river-guide` activation defaults: Oddie is default-on in oddkit-driven or ODD-mode sessions, default-off in published essays. Essays operate in author voice.
+5. **AMS-side `ESSAY.md` stays unchanged** in this trio. Forward-pointer to klappy.dev expanded version is a separate AMS PR (not in scope).
+6. **Borrow-evaluation-before-implementation skipped explicitly.** This trio has no upstream substrate to evaluate. Skip justification surfaced in PR descriptions.
+7. **Handoff-before-execute.** This session ends at the handoff. Execution belongs to a fresh-context session per `canon/principles/verification-requires-fresh-context`. Operator's intuition ("this seems intense") confirmed the handoff-not-execute call.
+
+### O — Observations (Closed)
+
+1. The work outpaced the model's catalog: `canon/methods/dispatch-paths` (PR #201) and `canon/methods/trigger-source-taxonomy` (PR #198) landed in klappy.dev *during* the session's early exploration. Plus `canon/methods/spawned-agent-session-substrate-options` was extended (#197) to include Cloudflare Agents Week primitives. The operator caught this and directed the model to re-read.
+2. Canon is at version `0.37.0`, epoch `E0008.6`, not `E0008.5`. The model had been operating with stale state. `E0008.6 — Specs Lock at Implementation` shipped 2026-04-30.
+3. Release notes path is `docs/oddkit/release-notes/YYYY-MM-DD-<slug>.md`. Only one prior file exists (`2026-04-20-post-4-7-adaptation.md`), which became the shape reference.
+4. AMS PR #77 is the live work that earns the epoch: audit-gate runtime migration from Anthropic Managed Agents to Cloudflare DO + Agents SDK + Project Think. Five phases, ~3-4 weeks elapsed. Phase 1 (persona profile `canon/personas/ams-canon-code-auditor.md`) is the next mergeable artifact.
+5. "We Were the Wire" essay lives at `klappy/agent-messaging-service/ESSAY.md` (11,641 chars / ~2,300 words). The principle form exists in klappy.dev canon as `canon/principles/agents-need-their-own-wire` (Tier-1, landed 2026-05-10 in PR #189).
+6. No open PRs blocking on klappy.dev or klappy/oddkit as of 02:24Z. Single open PR: AMS #77 (independent).
+7. The DOLCHEO+H residue was actively swept from active surfaces in klappy.dev PR #190 (P0009 enforcement). Despite this, the model produced the anti-pattern once mid-session. The hallucination persists from training residue and OLDC+H bleed even after canon sanitation.
+
+### L — Learnings
+
+1. **The challenge gauntlet caught three of four `governance-change-discipline` markers.** The model's initial plan named only the epoch appendix doc; preflight surfaced `audit-gates-are-spawned-agent-sessions` and `ai-voice-cliches`; challenge surfaced `governance-change-discipline` and `borrow-evaluation-before-implementation`. Without the challenge step, PR A would have shipped incomplete and been bounced back. Capability ratio: one tool call saved ~3 hours of executor-session rework.
+2. **`oddkit_gate` does keyword pattern matching on `input` + `context` to infer the transition being gated.** First call inferred "exploration → planning" when the actual intent was "planning → handoff-ready." Restating with an explicit `PROBLEM STATEMENT:` and `CONSTRAINTS REVIEWED:` preamble unblocked the gate. Pattern: gate calls benefit from explicit structural anchors in their context blob, not just narrative description.
+3. **DOLCHEO+H persists as a hallucination across sessions even with strong memory rules.** Memory edit #4 was already strict ("NEVER write 'DOLCHEO+H'") at session start; the model produced it anyway under high working-memory load while synthesizing across many canon docs. The fix is to make the rule even more direct ("refuse to surface it"), which the operator pushed for.
+4. **Encode treats a multi-letter input blob as a single artifact per inferred type.** To produce true multi-artifact Dolcheo+ TSV output, call `oddkit_encode` multiple times (one per letter) OR write the file directly as TSV per `odd/encoding-types/serialization-format`. For this session, the markdown ledger and handoff are the durable artifacts; the encode output was governance receipt.
+5. **The substrate stack canon already names everything the model was reaching to describe.** Six layers, AMS at L1, persona-shaped runtime at L4, TinCan at L5, Stripe rails at L6. Reading canon first vs. synthesizing from scratch: significantly less work, significantly higher fidelity.
+
+### C — Constraints (Binding)
+
+- **All four `governance-change-discipline` markers required** for the epoch bump: canon version, changelog entry, release notes file, epoch appendix doc.
+- **Frontmatter validator CI (PR #196) is live and hard-blocks** any malformed frontmatter. Validate before pushing.
+- **Voice canon (`oddie-the-river-guide` activation rules):** essays stay in author voice; Oddie is for oddkit-driven and ODD-mode sessions, not published surfaces.
+- **`ai-voice-cliches` constraint:** no "delve," no "in today's fast-paced world," no hollow "ultimately," no "tapestry." Direct, dry, named.
+- **`guide-posture`:** reader is hero, system is guide. Even in first-person, the essay shows rather than lectures.
+- **`writing-canon`:** five-depth actionability rule (title alone → title + blockquote → title + frontmatter → summary section → full doc).
+- **`meaning-must-not-depend-on-path`:** per-doc frontmatter verification before any retag. No sed-replace.
+- **Reversibility:** every artifact in this trio is file-delete reversible. No production behavior, no code, no tools.
+- **`verification-requires-fresh-context`:** execution happens in a different session than planning.
+
+### H — Handoffs
+
+1. **`odd/handoffs/2026-05-12-epoch-9-trio.md`** — full execution spec for the next session. Self-sufficient: a fresh session reading only the handoff can execute without re-reading this session's transcript. Carries scope, sequence, per-PR specification, pre-resolved decisions, open questions, risks/mitigations, definition of done, receipts to verify.
+
+### E — Encodes
+
+1. **`oddkit_encode` called** with the session's Dolcheo+ capture as input. Produced three quality-scored artifacts (C/D/H) per the encode action's current shape. Persistence is via this ledger file, not via the encode output itself.
+
+### O — Opens (Forward-Pointing)
+
+1. **Per-doc retag verification** at execution time. The handoff names ~18 candidate docs; the executing session reads each frontmatter `governs` field and judges per-doc.
+2. **AMS-side `ESSAY.md` forward-pointer.** Separate AMS PR after klappy.dev PR B lands. Not in scope for this trio.
+3. **Bootstrap content update for E0009.** Frontmatter-only bump now; content update (new dispatch-path discipline, autonomous-trigger error-routing, runtime-contract awareness) deferred to a separate session.
+4. **`ams.convention.v1`.** L3 identity-and-convention. Not in scope for this trio. Tracked separately.
+5. **Optional canon-grade managed-agent validator dispatch** for the essay. The `release-validation-gate` constraint targets `klappy/oddkit` code; canon-only PRs don't strictly require it. Executing session decides.
+
+---
+
+## Gauntlet Trace
+
+### Preflight (`oddkit_preflight`)
+- **Start-here surfaced:** `canon/principles/agents-need-their-own-wire`, `canon/observations/clone-klappy-to-oddie-recognition`, `writings/the-dream-house-and-pre-optimization`
+- **DoD:** `canon/constraints/definition-of-done`
+- **Constraints surfaced:** `canon/constraints/README`, `canon/constraints/ai-voice-cliches`, `canon/constraints/audit-gates-are-spawned-agent-sessions`
+- **Outcome:** confirmed the plan's voice-canon constraint and audit-gate framing; ai-voice-cliches becomes a PR B DoD requirement
+
+### Challenge (`oddkit_challenge`)
+- **Claim types matched:** pattern-coinage (E0009 as a named epoch), proposal (two-PR sequence), comparative-positioning (vs E0008.x), principle-extraction (operator-as-wire as a design smell), assumption (substrate replaces wire is bounded scope)
+- **Canon constraints surfaced:**
+  - `borrow-evaluation-before-implementation` → **not applicable** (no upstream substrate to evaluate; surfaced as skip-justification in handoff)
+  - `governance-change-discipline` → **CRITICAL CATCH** — four markers required, plan had only one
+  - `writings/the-dream-house-and-pre-optimization` → context-only; reinforces measuring-before-arguing principle
+- **Outcome:** plan revised to include all four markers; PR A scope expanded from "appendix + retag" to "canon version + changelog + release notes + appendix + retag"
+
+### Gate (`oddkit_gate`)
+- **First call:** NOT_READY — `problem_defined` and `constraints_reviewed` both unmet. Tool inferred wrong transition (exploration → planning) from input pattern. Restated with explicit anchors.
+- **Second call:** PASS — both required prerequisites met. Transition labeled exploration → planning by the tool; substantive meaning is planning → handoff-ready.
+- **Outcome:** planning artifacts ready for handoff release.
+
+### Encode (`oddkit_encode`)
+- **Three artifacts encoded** (C, D, H) at quality scores 3/4, 5/5, 4/4.
+- **Persistence:** required separately — this ledger file is the persistence.
+
+---
+
+## Tool Calls Summary
+
+Total tool calls across the session: ~25 (oddkit, GitHub API, bash). Notable:
+
+- `oddkit_time` × 4 (start + 3 elapsed checks)
+- `oddkit_get` × 5 (bootstrap, substrate-stack section, runtime-contract section, dispatch-paths section, trigger-source-taxonomy section, governance-change-discipline section)
+- `oddkit_search` × 4 (E0009 framing, substrate canon, recent docs, governance discipline)
+- `oddkit_catalog` × 1 (recent canon dated sort)
+- `oddkit_preflight` × 1
+- `oddkit_challenge` × 1 (the high-value call)
+- `oddkit_gate` × 2 (first NOT_READY, second PASS)
+- `oddkit_encode` × 1
+- `oddkit_version` × 1
+- `tool_search` × 1 (to load oddkit functions deferred)
+- `bash_tool` × 7 (GitHub API for PR lists, ESSAY.md read, release-notes path verification, CHANGELOG read)
+- `memory_user_edits` × 2 (view + replace #4 with strengthened P0009 anti-pattern phrasing)
+- `create_file` × 2 (this ledger + the handoff)
+
+---
+
+## Receipts Produced
+
+| Artifact | Path | Purpose |
+|---|---|---|
+| Handoff | `odd/handoffs/2026-05-12-epoch-9-trio.md` | Execution spec for the fresh-context session |
+| Ledger | `odd/ledger/2026-05-12-epoch-9-planning.md` (this file) | Audit trail of the planning session |
+
+Both files are ready to drop into `klappy/klappy.dev` at their respective paths. Recommendation: a small bootstrap PR adds both files before PR A opens, so the handoff URI is canonically resolvable from the moment PR A is reviewed.
+
+---
+
+## See Also
+
+- `klappy://odd/handoffs/2026-05-12-epoch-9-trio` — the execution spec this ledger documents the planning of
+- `klappy://canon/constraints/governance-change-discipline` — the four-marker constraint the challenge gauntlet caught
+- `klappy://canon/principles/verification-requires-fresh-context` — why execution is deferred
+- `klappy://canon/constraints/mode-transitions-require-encoded-handoff` — why this ledger and the handoff are durable canon artifacts
+- `klappy://canon/definitions/dolcheo-vocabulary` — the seven-letter vocabulary this ledger encodes against
+- `klappy/agent-messaging-service:#77` — the live work that earns the epoch this trio plants the flag for


### PR DESCRIPTION
Lands the planning session's handoff and ledger so their `klappy://` URIs are canonically resolvable from the moment PR A opens for review.

## What this PR does

- Adds `odd/handoffs/2026-05-12-epoch-9-trio.md` — the execution spec for PR A (Epoch 9 declaration + retag) and PR B (We Were the Wire essay)
- Adds `odd/ledger/2026-05-12-epoch-9-planning.md` — audit trail of the planning session that produced the handoff

## Why bootstrap-first

The planning session's recommendation: a small bootstrap PR lands both files before PR A opens, so the handoff URI (`klappy://odd/handoffs/2026-05-12-epoch-9-trio`) referenced in PR A's description resolves canonically from the moment review begins.

## Deviation note

The ledger file's `audience` was changed from `ledger` (the pre-existing odd/ledger/ convention) to `odd` (the canon-enforced enum per `canon/meta/frontmatter-schema`). The value `ledger` is not in the schema's allowed set `{apocrypha, canon, docs, odd, operators, public}`. Existing ledger files with `audience: ledger` are pre-existing latent violations not caught by CI (which scans only `writings/`). This commit follows canon over convention drift; broader cleanup is out of scope.

## Reversibility

Both files are new and deletable. No production behavior changes. No code shipped.

## References

- `klappy://odd/handoffs/2026-05-12-epoch-9-trio`
- `klappy://odd/ledger/2026-05-12-epoch-9-planning`
- `klappy://canon/principles/verification-requires-fresh-context`
