### PR TITLE
canon: Epoch 9 — Substrate Becomes the Wire (E0009) [PR A of trio]

### DIFF
--- a/canon/CHANGELOG.md
+++ b/canon/CHANGELOG.md
@@ -18,6 +18,60 @@ This changelog tracks changes to the **Canon pack** as a whole.
 The Canon uses **pack-level versioning** (one version number) rather than per-file versioning.
 Per-file versions are intentionally omitted to reduce ceremony and prevent metadata rot.
 
+## 0.38.0 — 2026-05-12
+
+**Substrate Becomes the Wire (E0009)**
+
+A new epoch. Epoch 8 made validation observable (E0008.3), encoding-types governed (E0008.4), operator-attention defended (E0008.4), and specs locked at implementation (E0008.6). Epoch 9 retires the integration pattern those disciplines were defending against: human-as-wire. The substrate stack is named end-to-end (`canon/architecture/substrate-stack`); persona-shaped runtimes are specified (`canon/methods/persona-shaped-agent-runtime`); the per-session contract is bounded (`canon/methods/spawned-agent-session-runtime-contract`); dispatch paths are bounded into a binary (`canon/methods/dispatch-paths`); trigger sources are taxonomized (`canon/methods/trigger-source-taxonomy`); audit gates are spawned agent sessions, not pattern matchers (`canon/constraints/audit-gates-are-spawned-agent-sessions`); and the first production-grade exercise of the runtime — the audit-gate migration onto Cloudflare's Agents Week primitives — landed its planning artifact in `klappy/agent-messaging-service` PR #77 (merged 2026-05-12) with the multi-PR migration in flight.
+
+The narrative form of the epoch's central argument — "We Were the Wire" — lands in `writings/` as a public-facing essay. The spine is imported from `klappy/agent-messaging-service:ESSAY.md` (the hackathon scene that originally named the problem); the expansion covers the broader Epoch 9 themes (the wire problem is never just agent-to-agent; the substrate stack is the answer; the dispatch-path question settles everything else; R2-drop-a-file-get-knowledge as the canonical autonomous-trigger pipeline; audits-as-spawned-sessions; Oddie as the first deployable L4 persona).
+
+Behavior change: from this version forward, when canon describes a workflow that includes a human in an integration role, it is describing a design smell unless the role is explicitly direction-setting or pivot-decisioning. The operator is a director, not a relay. Validators are spawned agent sessions. Audits are spawned agent sessions. Ingestion is autonomous-trigger pipelines. The wire is no longer a person.
+
+### Added — Canon Surface
+
+- **Appendix: Epoch 9 — Substrate Becomes the Wire** (`docs/appendices/epoch-9.md`) — Tier 2, neutral, stable. Names the forcing fault (the operator was the wire), the new invariant (substrate is the wire), the core shift (director, not relay), and the six-layer receipt table (what "done" looks like at each of L1–L6, which canon already covers it, what remains).
+- **Essay: We Were the Wire** (`writings/we-were-the-wire.md`) — Tier 3, first-person, stable. Public-facing essay form of the argument. Spine imported from `klappy/agent-messaging-service:ESSAY.md` (~2,300 words preserved); expansion (~1,500 words) covers the substrate stack, dispatch-paths binary, R2-ESE pipeline worked example, audits-as-spawned-sessions, and Oddie-as-L4-peer.
+- **Release Notes: Epoch 9 — Substrate Becomes the Wire** (`docs/oddkit/release-notes/2026-05-12-epoch-9-substrate-becomes-the-wire.md`) — Tier 2, neutral, stable. Frames the release by behavior change, not file inventory. Names what changes for operators, what changes for agents, what does not change, and how to recognize operator-as-wire (and replace it).
+
+### Retagged — Frontmatter `epoch:` field
+
+Substrate-shaped canon retagged from `E0008.5` to `E0009` (per-doc verification against `governs` field confirmed substrate / agentic-runtime / persona-shaped subject matter):
+
+- `canon/architecture/substrate-stack.md`
+- `canon/methods/persona-shaped-agent-runtime.md`
+- `canon/methods/spawned-agent-session-runtime-contract.md`
+- `canon/methods/spawned-agent-session-substrate-options.md`
+- `canon/methods/dispatch-paths.md`
+- `canon/methods/trigger-source-taxonomy.md`
+- `canon/principles/agents-need-their-own-wire.md`
+- `canon/principles/symmetric-participation.md`
+- `canon/principles/sessions-mirror-modes.md`
+- `canon/principles/creators-get-paid.md`
+- `canon/principles/magical-first-run.md`
+- `canon/principles/methodology-personification.md`
+- `canon/principles/voice-as-cognitive-load-shedding.md`
+- `canon/constraints/mode-transitions-require-encoded-handoff.md`
+- `canon/constraints/critic-cannot-be-resolver.md`
+- `canon/constraints/audit-gates-are-spawned-agent-sessions.md` (addition beyond the planning session's candidate list; per its own `governs` field this constraint directly governs the L4 substrate work)
+- `canon/observations/clone-klappy-to-oddie-recognition.md`
+- `canon/definitions/epistemic-modes.md`
+- `docs/appendices/mode-separated-conversations.md`
+
+Bootstrap operating contract receives a frontmatter-only bump (E0008.3 → E0009):
+
+- `canon/bootstrap/model-operating-contract.md` — content update for E0009-specific disciplines (dispatch-path discipline, autonomous-trigger error-routing, runtime-contract awareness) is deferred to a separate session.
+
+Not retagged (verified out of scope by per-doc inspection): `canon/voice/oddie-the-river-guide` (voice spec; predates substrate push), `canon/methods/borrow-bend-break-beget-build` (generic 6B methodology), `canon/constraints/borrow-evaluation-before-implementation` (generic governance), `writings/reverse-engineer-the-future` (bible-translation theme), and the E0008.4 software-virtues package and the E0008.6 specs-lock-at-implementation (own sub-epochs, not part of the substrate push).
+
+### Related
+
+- `klappy/agent-messaging-service` #77 (audit-gate runtime migration — plan landed 2026-05-12; multi-PR migration in flight)
+- `klappy://odd/handoffs/2026-05-12-epoch-9-trio` (execution spec)
+- `klappy://odd/ledger/2026-05-12-epoch-9-planning` (planning session audit trail)
+
+---
+
 ## 0.37.0 — 2026-04-30
 
 **Specs Lock at Implementation — A Spec Is a Contract; Don't Change It Mid-Build (E0008.6)**

--- a/canon/architecture/substrate-stack.md
+++ b/canon/architecture/substrate-stack.md
@@ -7,7 +7,7 @@ tier: 1
 voice: neutral
 stability: evolving
 tags: ["canon", "principle", "architecture", "layered-model", "substrate", "vodka-architecture", "orthogonality", "OSI-equivalent", "ams", "tincan", "oddie"]
-epoch: E0008.5
+epoch: E0009
 date: 2026-05-10
 derives_from: "canon/principles/vodka-architecture.md, canon/principles/doing-less-enables-more.md, canon/principles/dream-house-principle.md, ams://canon/decisions/D0020-agents-as-customer-and-third-party-vas-substrate, ams://canon/decisions/D0006-dream-house-wire-edge-wrappers, ams://canon/decisions/D0016-buffering-and-persistence-as-wrapper-primitive"
 complements: "canon/principles/magical-first-run.md, canon/principles/symmetric-participation.md, canon/principles/creators-get-paid.md, canon/voice/oddie-the-river-guide.md"

--- a/canon/bootstrap/model-operating-contract.md
+++ b/canon/bootstrap/model-operating-contract.md
@@ -7,7 +7,7 @@ tier: 1
 voice: neutral
 stability: semi_stable
 tags: ["canon", "bootstrap", "oddkit", "governance", "mode-discipline", "vodka-architecture", "prompt-over-code"]
-epoch: E0008.3
+epoch: E0009
 date: 2026-05-08
 derives_from: "canon/values/orientation.md, canon/values/axioms.md, canon/definitions/epistemic-modes.md, canon/validation-as-epistemic-mode.md, canon/constraints/oddkit-prompt-pattern.md, canon/constraints/mode-discipline-and-bottleneck-respect.md, canon/principles/dry-canon-says-it-once.md, canon/principles/verification-requires-fresh-context.md, canon/observations/time-blindness-axiom-violation.md"
 complements: "docs/oddkit/proactive/posture-lapse.md, docs/oddkit/proactive/proactive-gate.md, docs/appendices/mode-separated-conversations.md, canon/voice/oddie-the-river-guide.md"

--- a/canon/constraints/audit-gates-are-spawned-agent-sessions.md
+++ b/canon/constraints/audit-gates-are-spawned-agent-sessions.md
@@ -7,7 +7,7 @@ tier: 1
 voice: neutral
 stability: semi_stable
 tags: ["canon", "constraint", "governance", "validation", "audit", "spawned-agent-sessions", "vodka-architecture", "anti-pattern", "ci", "drift", "sync"]
-epoch: E0008.5
+epoch: E0009
 date: 2026-05-07
 derives_from: "canon/methods/governance-validation-via-agents.md, canon/methods/reference-integrity-audit.md, canon/constraints/canon-integration-audit.md, canon/principles/vodka-architecture.md, canon/values/axioms.md"
 complements: "canon/constraints/borrow-evaluation-before-implementation.md, canon/constraints/no-irreversible-action-without-epistemic-justification.md, canon/methods/spawned-agent-session-substrate-options.md"

--- a/canon/constraints/critic-cannot-be-resolver.md
+++ b/canon/constraints/critic-cannot-be-resolver.md
@@ -7,7 +7,7 @@ tier: 1
 voice: neutral
 stability: semi_stable
 tags: ["canon", "constraints", "mode-discipline", "agent-design", "detection", "remediation", "separation-of-concerns", "context-corruption"]
-epoch: E0008.5
+epoch: E0009
 date: 2026-05-08
 derives_from: "canon/principles/verification-requires-fresh-context.md, canon/values/axioms.md"
 complements: "canon/voice/oddie-the-river-guide.md, canon/constraints/mode-discipline-and-bottleneck-respect.md"

--- a/canon/constraints/mode-transitions-require-encoded-handoff.md
+++ b/canon/constraints/mode-transitions-require-encoded-handoff.md
@@ -7,7 +7,7 @@ tier: 1
 voice: neutral
 stability: evolving
 tags: ["canon", "constraints", "epistemic-modes", "handoff-contract", "journal", "dolcheo", "session-discipline", "mode-discipline", "encoding"]
-epoch: E0008.5
+epoch: E0009
 date: 2026-05-10
 derives_from: "canon/principles/sessions-mirror-modes.md, canon/definitions/epistemic-modes.md, canon/constraints/critic-cannot-be-resolver.md, canon/principles/verification-requires-fresh-context.md"
 complements: "canon/methods/persona-shaped-agent-runtime.md, docs/mode-separated-conversations.md, canon/definitions/dolcheo-vocabulary.md"

--- a/canon/definitions/epistemic-modes.md
+++ b/canon/definitions/epistemic-modes.md
@@ -7,7 +7,7 @@ tier: 1
 voice: neutral
 stability: semi_stable
 tags: ["epistemology", "decision-making", "governance"]
-epoch: E0008.5
+epoch: E0009
 date: 2026-05-10
 ---
 

--- a/canon/methods/dispatch-paths.md
+++ b/canon/methods/dispatch-paths.md
@@ -7,7 +7,7 @@ tier: 2
 voice: neutral
 stability: draft
 tags: ["canon", "methods", "spawned-agent-sessions", "dispatch", "assistant-orchestrated", "autonomous-trigger", "agent-runtime", "vodka-architecture"]
-epoch: E0008.5
+epoch: E0009
 date: 2026-05-11
 derives_from: "canon/methods/spawned-agent-session-runtime-contract.md, canon/methods/persona-shaped-agent-runtime.md, canon/methods/trigger-source-taxonomy.md, canon/principles/agents-need-their-own-wire.md, canon/constraints/mode-discipline-and-bottleneck-respect.md"
 complements: "canon/methods/trigger-source-taxonomy.md, canon/methods/spawned-agent-session-substrate-options.md"

--- a/canon/methods/persona-shaped-agent-runtime.md
+++ b/canon/methods/persona-shaped-agent-runtime.md
@@ -7,7 +7,7 @@ tier: 1
 voice: neutral
 stability: evolving
 tags: ["canon", "methods", "agent-runtime", "persona-profile", "substrate", "vodka-architecture", "oddie", "spawned-agent-session", "role-enforcement", "surface-profile"]
-epoch: E0008.5
+epoch: E0009
 date: 2026-05-10
 derives_from: "canon/methods/spawned-agent-session-substrate-options.md, canon/principles/sessions-mirror-modes.md, canon/constraints/mode-transitions-require-encoded-handoff.md, canon/constraints/critic-cannot-be-resolver.md, canon/principles/verification-requires-fresh-context.md, canon/voice/oddie-the-river-guide.md, canon/principles/vodka-architecture.md"
 complements: "canon/methods/spawned-agent-session-runtime-contract.md, canon/principles/methodology-personification.md, canon/principles/voice-as-cognitive-load-shedding.md, canon/principles/participation-replaces-integration.md"

--- a/canon/methods/spawned-agent-session-runtime-contract.md
+++ b/canon/methods/spawned-agent-session-runtime-contract.md
@@ -7,7 +7,7 @@ tier: 2
 voice: neutral
 stability: draft
 tags: ["canon", "methods", "spawned-agent-sessions", "runtime", "governance", "epistemic-modes", "engagement", "vodka-architecture", "mechanizes-canon", "session-discipline", "five-mode-bound-roles"]
-epoch: E0008.5
+epoch: E0009
 date: 2026-05-10
 derives_from: "canon/epistemic-modes.md, canon/principles/sessions-mirror-modes.md, canon/constraints/mode-transitions-require-encoded-handoff.md, canon/constraints/mode-discipline-and-bottleneck-respect.md, canon/constraints/critic-cannot-be-resolver.md, canon/constraints/audit-gates-are-spawned-agent-sessions.md, canon/methods/spawned-agent-session-substrate-options.md, canon/methods/persona-shaped-agent-runtime.md, canon/voice/oddie-the-river-guide.md, canon/principles/vodka-architecture.md, canon/principles/verification-requires-fresh-context.md"
 complements: "canon/methods/persona-shaped-agent-runtime.md, canon/methods/governance-validation-via-agents.md, canon/constraints/canon-integration-audit.md"

--- a/canon/methods/spawned-agent-session-substrate-options.md
+++ b/canon/methods/spawned-agent-session-substrate-options.md
@@ -7,7 +7,7 @@ tier: 1
 voice: neutral
 stability: evolving
 tags: ["canon", "methods", "spawned-agent-sessions", "substrate", "cost-shape", "vendor-portability", "anthropic", "cloudflare", "vodka-architecture"]
-epoch: E0008.5
+epoch: E0009
 date: 2026-05-09
 derives_from: "canon/constraints/audit-gates-are-spawned-agent-sessions.md, canon/principles/vodka-architecture.md, canon/principles/doing-less-enables-more.md, canon/constraints/borrow-evaluation-before-implementation.md"
 complements: "canon/methods/governance-validation-via-agents.md"

--- a/canon/methods/trigger-source-taxonomy.md
+++ b/canon/methods/trigger-source-taxonomy.md
@@ -7,7 +7,7 @@ tier: 2
 voice: neutral
 stability: draft
 tags: ["canon", "methods", "spawned-agent-sessions", "trigger-source", "dispatch-routing", "autonomous-trigger", "agent-runtime", "vodka-architecture", "substrate-agnostic", "ese", "r2-events", "ams-frames"]
-epoch: E0008.5
+epoch: E0009
 date: 2026-05-11
 derives_from: "canon/methods/spawned-agent-session-runtime-contract.md, canon/methods/persona-shaped-agent-runtime.md, canon/methods/spawned-agent-session-substrate-options.md, canon/constraints/mode-discipline-and-bottleneck-respect.md, canon/epistemic-surface-extraction.md, canon/principles/symmetric-participation.md, canon/principles/vodka-architecture.md"
 complements: "canon/methods/spawned-agent-session-runtime-contract.md, canon/methods/persona-shaped-agent-runtime.md"

--- a/canon/observations/clone-klappy-to-oddie-recognition.md
+++ b/canon/observations/clone-klappy-to-oddie-recognition.md
@@ -7,7 +7,7 @@ tier: 2
 voice: neutral
 stability: semi_stable
 tags: ["canon", "observation", "oddie", "methodology", "personification", "clone-klappy", "recognition", "longitudinal"]
-epoch: E0008.5
+epoch: E0009
 date: 2026-05-08
 derives_from: "canon/values/axioms.md"
 complements: "canon/voice/oddie-the-river-guide.md, canon/principles/methodology-personification.md"

--- a/canon/principles/agents-need-their-own-wire.md
+++ b/canon/principles/agents-need-their-own-wire.md
@@ -7,7 +7,7 @@ tier: 1
 voice: neutral
 stability: semi_stable
 tags: ["canon", "principle", "substrate", "wire-layer", "L1", "human-as-relay", "bottleneck", "multi-agent", "AMS", "constitutional", "use-case-need"]
-epoch: E0008.5
+epoch: E0009
 date: 2026-05-10
 derives_from: "canon/values/axioms.md, canon/principles/discernment-layer.md, canon/principles/doing-less-enables-more.md, canon/principles/vodka-architecture.md, writings/copy-paste.md, writings/shifting-bottlenecks-climbing-ladders.md, ams://canon/decisions/D0001-tokens-not-messages, ams://canon/decisions/D0003-per-account-stream-ownership, ams://canon/decisions/D0009-stream-as-primitive-ownership-excludes-subscription, ams://canon/decisions/D0016-buffering-and-persistence-as-wrapper-primitive, ams://canon/decisions/D0020-agents-as-customer-and-third-party-vas-substrate"
 complements: "canon/principles/symmetric-participation.md, canon/architecture/substrate-stack.md, canon/principles/magical-first-run.md, canon/principles/creators-get-paid.md"

--- a/canon/principles/creators-get-paid.md
+++ b/canon/principles/creators-get-paid.md
@@ -7,7 +7,7 @@ tier: 1
 voice: neutral
 stability: semi_stable
 tags: ["canon", "principle", "economy", "L6", "creators", "monetization", "substrate", "anti-extraction", "stripe", "constitutional"]
-epoch: E0008.5
+epoch: E0009
 date: 2026-05-09
 derives_from: "canon/values/axioms.md, canon/architecture/substrate-stack.md, canon/principles/maintainability-one-person-indefinitely.md, ams://canon/decisions/D0020-agents-as-customer-and-third-party-vas-substrate, ams://canon/decisions/D0021-stripe-integration-surface"
 complements: "canon/principles/magical-first-run.md, canon/principles/symmetric-participation.md"

--- a/canon/principles/magical-first-run.md
+++ b/canon/principles/magical-first-run.md
@@ -7,7 +7,7 @@ tier: 1
 voice: neutral
 stability: semi_stable
 tags: ["canon", "principle", "ux", "first-run", "non-technical-users", "L5", "applications", "tincan", "magic", "60-seconds", "constitutional"]
-epoch: E0008.5
+epoch: E0009
 date: 2026-05-09
 derives_from: "canon/values/axioms.md, canon/architecture/substrate-stack.md, canon/principles/vodka-architecture.md, canon/principles/maintainability-one-person-indefinitely.md"
 complements: "canon/principles/symmetric-participation.md, canon/principles/creators-get-paid.md, canon/voice/oddie-the-river-guide.md, canon/principles/methodology-personification.md"

--- a/canon/principles/methodology-personification.md
+++ b/canon/principles/methodology-personification.md
@@ -7,7 +7,7 @@ tier: 2
 voice: neutral
 stability: evolving
 tags: ["canon", "principles", "personification", "methodology", "voice", "accessibility", "oddie", "borrow-evaluation"]
-epoch: E0008.5
+epoch: E0009
 date: 2026-05-08
 derives_from: "canon/constraints/guide-posture.md, canon/values/axioms.md"
 complements: "canon/voice/oddie-the-river-guide.md, canon/principles/voice-as-cognitive-load-shedding.md, canon/observations/clone-klappy-to-oddie-recognition.md"

--- a/canon/principles/sessions-mirror-modes.md
+++ b/canon/principles/sessions-mirror-modes.md
@@ -7,7 +7,7 @@ tier: 1
 voice: neutral
 stability: evolving
 tags: ["canon", "principles", "epistemic-modes", "session-discipline", "context-corruption", "mode-discipline", "agent-design", "fresh-context"]
-epoch: E0008.5
+epoch: E0009
 date: 2026-05-10
 derives_from: "canon/definitions/epistemic-modes.md, canon/principles/verification-requires-fresh-context.md, canon/constraints/critic-cannot-be-resolver.md, canon/constraints/mode-discipline-and-bottleneck-respect.md"
 complements: "canon/constraints/mode-transitions-require-encoded-handoff.md, canon/methods/persona-shaped-agent-runtime.md, docs/mode-separated-conversations.md"

--- a/canon/principles/symmetric-participation.md
+++ b/canon/principles/symmetric-participation.md
@@ -7,7 +7,7 @@ tier: 1
 voice: neutral
 stability: semi_stable
 tags: ["canon", "principle", "substrate", "wire-layer", "L1", "vodka-architecture", "BYOA", "BYOC", "open-substrate", "constitutional"]
-epoch: E0008.5
+epoch: E0009
 date: 2026-05-10
 derives_from: "canon/values/axioms.md, canon/architecture/substrate-stack.md, canon/principles/vodka-architecture.md, canon/principles/doing-less-enables-more.md, ams://canon/decisions/D0020-agents-as-customer-and-third-party-vas-substrate, ams://canon/decisions/D0006-dream-house-wire-edge-wrappers"
 complements: "canon/principles/magical-first-run.md, canon/principles/creators-get-paid.md, canon/principles/dream-house-principle.md"

--- a/canon/principles/voice-as-cognitive-load-shedding.md
+++ b/canon/principles/voice-as-cognitive-load-shedding.md
@@ -7,7 +7,7 @@ tier: 2
 voice: neutral
 stability: evolving
 tags: ["canon", "principles", "voice", "cognitive-load", "incident-response", "calm", "brevity", "information-density"]
-epoch: E0008.5
+epoch: E0009
 date: 2026-05-08
 derives_from: "canon/values/axioms.md, canon/constraints/guide-posture.md"
 complements: "canon/voice/oddie-the-river-guide.md, canon/constraints/ai-voice-cliches.md"

--- a/docs/appendices/epoch-9.md
+++ b/docs/appendices/epoch-9.md
@@ -1,0 +1,120 @@
+---
+uri: klappy://docs/appendices/epoch-9
+title: "Epoch 9 — Substrate Becomes the Wire"
+audience: docs
+exposure: nav
+tier: 2
+voice: neutral
+stability: stable
+tags: ["odd", "epochs", "substrate", "agentic", "vodka-architecture", "epoch-9", "operator-as-wire", "persona-shaped-runtime", "dispatch-paths", "autonomous-trigger"]
+epoch: E0009
+date: 2026-05-12
+forcing_fault: "The operator was the wire. The substrate's intelligence ended at the human's clipboard. Every cross-agent hop, every audit, every validation, every session transition routed through human attention. The system bottleneck was not tokens — it was the human in the loop being the integration layer. Audits were regex against prose. Validation was same-session self-review. Cross-agent coordination was copy-paste. Knowledge ingestion was manual transcription. Memory was operator-remembers. The intelligence stack was real but the wire between intelligences was a human relay."
+new_invariant: "Operator-as-wire is past tense. Audits are spawned agent sessions on substrate. Validation has its own substrate and its own context break. Personas are deployable peers with accounts and streams, not voices in chat windows. Cross-agent coordination is direct over the wire (AMS), not relayed. Knowledge ingestion is autonomous-trigger pipelines (R2 → ESE → KB) with no assistant in the loop. The operator's attention is reserved for direction-setting and pivot decisions; the substrate handles transport, dispatch, audit, validation, and ingestion."
+core_shift: "From assistant-mediated workflow with operator as integration layer → substrate-mediated workflow with operator as director. The wire moves from human shoulders to infrastructure. The dispatch-paths binary (assistant-orchestrated vs autonomous-trigger) makes the choice mechanical; the substrate-stack makes the layers orthogonal; the persona-shaped runtime makes Oddie deployable as a real peer on the wire."
+derives_from: "docs/appendices/epoch-8-4.md, canon/principles/agents-need-their-own-wire.md, canon/architecture/substrate-stack.md, canon/methods/persona-shaped-agent-runtime.md, canon/methods/spawned-agent-session-runtime-contract.md, canon/methods/dispatch-paths.md, canon/methods/trigger-source-taxonomy.md, canon/constraints/audit-gates-are-spawned-agent-sessions.md, klappy/agent-messaging-service:ESSAY.md, klappy/agent-messaging-service:#77"
+documents_introduced: ["docs/appendices/epoch-9.md", "writings/we-were-the-wire.md"]
+---
+
+# Epoch 9 — Substrate Becomes the Wire
+
+> Epoch 8 made validation observable (E0008.3), encoding-types governed (E0008.4), operator attention defended (E0008.4), and specs locked at implementation (E0008.6). Epoch 9 retires the integration pattern those disciplines were defending against: human-as-wire. The substrate stack is named end-to-end; persona-shaped runtimes are specified; dispatch paths are bounded to a binary; trigger sources are taxonomized; the first production-grade exercise of the runtime is in flight. The operator is a director from this point forward, not a relay.
+
+---
+
+## Summary — The Wire Moves Off Human Shoulders
+
+The week of 2026-05-07 through 2026-05-12 produced an unusually dense canon catalog all pointed at the same shift. The substrate stack got named end-to-end (`canon/architecture/substrate-stack` — six layers from L1 wire up to L6 economy). The runtime that sits on the substrate got a contract (`canon/methods/spawned-agent-session-runtime-contract` — five orthogonal dimensions for any spawned session). The runtime got a shape (`canon/methods/persona-shaped-agent-runtime` — substrate hosts personas, not opinions). The dispatch surface that wakes the runtime got bounded into a binary (`canon/methods/dispatch-paths` — assistant-orchestrated vs autonomous-trigger). The trigger sources got named (`canon/methods/trigger-source-taxonomy` — nine canonical types). The principle the whole stack defends got a Tier-1 home (`canon/principles/agents-need-their-own-wire`).
+
+In parallel, the first production runtime exercise opened and landed its planning artifact: AMS PR #77 (audit-gate runtime migration from Managed Agents to Cloudflare DO + Agents SDK + Project Think) merged its plan on 2026-05-12; the migration itself is in flight as a multi-PR sequence. The same canon governs the auditor that governs the work. The persona-shaped runtime is no longer a paper architecture — it is the substrate the next migration runs on.
+
+E0009 is the epoch where the wire stops being human shoulders.
+
+---
+
+## The Forcing Fault — The Operator Was the Wire
+
+For the prior epochs, the intelligence stack was real and the methodology was real, but the wire between intelligences was a human relay.
+
+Audits that lint canon for drift ran as regex against prose — mechanical pattern-matching against text the patterns could not actually read. When the script could not see what the text said, the operator's eyes were the audit. Validation that should have been a separate review act ran inside the same session that produced the artifact — the creator was the critic, with the same context that produced the bug now being asked to find it (the load-bearing canon for this is `canon/principles/verification-requires-fresh-context`, the empirical receipt is `klappy/oddkit#74`'s nine authoring passes vs one fresh reviewer). Cross-agent coordination at the hackathon scene that names this epoch was copy-paste between Signal and two chat windows for forty minutes — two reasoning systems with arbitrary bandwidth bottlenecked through two humans operating a clipboard. Knowledge ingestion from PDFs, recordings, calendar events, and chat threads required manual transcription before any agent could read it. Memory across sessions required the operator to remember what had been encoded and where it lived.
+
+In every case the symptom looked different and the underlying shape was the same: a finite human attention was the integration layer between intelligences that could otherwise have moved at substrate speed. The system bottleneck was never tokens. It was always the human in the loop being the wire.
+
+---
+
+## The New Invariant — Substrate Is the Wire
+
+Operator-as-wire is past tense, and the canon names the pattern as a design smell from this point forward.
+
+Audits are spawned agent sessions on substrate (`canon/constraints/audit-gates-are-spawned-agent-sessions`). The audit gate that lints a PR for canon drift used to be a regex script; it is now a fresh-context Oddie session with structured deliverable. The same canon governs the auditor that governs the work. Validation has its own substrate and its own structural context break — same model family is acceptable, same governance is acceptable, same session is not. Personas are deployable peers — Oddie gets an AMS account and a stream, becomes a real peer on the wire rather than a voice in a chat window. Cross-agent coordination flows over AMS (the L1 wire) without operator relay. Knowledge ingestion runs as autonomous-trigger pipelines: file lands in R2, queue wakes a Durable-Object-hosted ingestion persona, Epistemic Surface Extraction parses it, artifacts encode as DOLCHEO+ and route into the KB — no assistant in the loop. Memory across sessions is what the substrate stores; what the operator chooses to remember is direction, not bookkeeping.
+
+The operator's attention is reserved for the irreducible work: direction-setting (what should the substrate be doing?) and pivot decisions (when does the plan change?). Everything between those two moments is substrate concern.
+
+---
+
+## The Core Shift — Director, Not Relay
+
+The qualitative jump from E0008.x to E0009 is the shift in the operator's role. E0008.3 made validation observable. E0008.4 calibrated operator attention as the system bottleneck. E0008.6 locked specs at implementation to protect the implementer's reasoning. Each of those disciplines defended the operator's attention by making it less expensive to be in the loop. E0009 takes the next step: it removes the operator from loops they should not be in at all.
+
+The mechanism for the removal is mechanical, not aspirational. The dispatch-paths binary makes the choice explicit: when the runtime returns, who reads the result first? If the answer is a human in a chat assistant, that is assistant-orchestrated dispatch and clarifying questions can be surfaced inline. If the answer is no one — an external event woke the runtime and no human is waiting at the other end — that is autonomous-trigger dispatch, clarifying questions are incoherent, and errors must emit to a configured channel. Almost every workflow that historically had a human in the wire was, on inspection, an autonomous-trigger shape mistaken for an assistant-orchestrated one. Naming the binary makes the wiring honest.
+
+The substrate stack makes the layers orthogonal. Each layer holds one concern; cross-layer features are suspicious by default. The persona-shaped runtime makes the L4 surface mechanically deployable — same canon, different invocation context. Together they make the wire-removal a build, not a wish.
+
+---
+
+## Layered Receipts — What Each L1–L6 Owes the Epoch
+
+The substrate stack provides the frame; each layer owes a specific receipt to E0009. The table below names the receipt, the canon already covering the layer, and what remains.
+
+| Layer | What "done" looks like at this layer in E0009 | Canon that already covers it | What remains |
+|---|---|---|---|
+| **L1 Wire** (AMS) | Tokens flow between accounts. Personas have accounts. No special-casing by peer type. | `canon/principles/agents-need-their-own-wire`, `canon/principles/symmetric-participation` | `ams.convention.v1` (L3 identity-and-convention) — peer metadata so addressing is legible. Separate work track. |
+| **L2 Wrapper/Adapter** | MCP edges, channel adapters, AI-tool adapters translate L1 ↔ runtime/channel without holding application opinion. | `canon/methods/spawned-agent-session-substrate-options` (substrate catalog), `canon/architecture/substrate-stack` | Adapter inventory grows as new channels onboard; each adapter ships under the same vodka discipline (no opinion at the wire). |
+| **L3 Identity & Convention** | Peer metadata is legible: who is this account, what convention is it speaking, what version. | (none yet — gap is named) | Author `ams.convention.v1`. Not in scope for this epoch's first PRs; tracked. |
+| **L4 Role/Agent** | Canon-driven personas spawned on the runtime substrate per the five-dimension contract. Audit gates, validators, ingestion personas, methodology personas (Oddie). | `canon/methods/persona-shaped-agent-runtime`, `canon/methods/spawned-agent-session-runtime-contract`, `canon/methods/dispatch-paths`, `canon/methods/trigger-source-taxonomy`, `canon/constraints/audit-gates-are-spawned-agent-sessions`, `canon/constraints/critic-cannot-be-resolver` | AMS audit-gate migration (in flight): the first production runtime. Oddie deploys as an L4 peer with an AMS account next. |
+| **L5 Application** | User-facing products built on L1–L4 hit the magical-first-run bar (under a minute, no setup overhead). | `canon/principles/magical-first-run` | TinCan earns L5; future apps inherit the bar. |
+| **L6 Economy** | Creators get paid. The substrate never extracts. Payment, marketplace, reputation, settlement live above the dial-tone layer, not inside it. | `canon/principles/creators-get-paid` | Stripe rails wired through TinCan onboarding; the penny economy as the cost-allocation pattern (separate work). |
+
+The pattern is recursive: at every layer, "done" looks like the operator never had to be the wire between this layer and its neighbors. Where that is not yet true, the gap is named, not silently endured.
+
+---
+
+## Documents Introduced
+
+This epoch lands two documents in the same trio:
+
+- `docs/appendices/epoch-9.md` (this file) — the canon appendix declaring the epoch.
+- `writings/we-were-the-wire.md` — the public-facing essay form of the central argument. The spine is imported from `klappy/agent-messaging-service:ESSAY.md` (the hackathon scene that originally named the problem); the expansion covers the broader Epoch 9 themes (the wire problem is never just agent-to-agent, the substrate stack is the answer, the dispatch-path question settles everything else, R2-drop-a-file-get-knowledge as the canonical autonomous-trigger pipeline, audits-as-spawned-sessions, Oddie as the first deployable L4 persona).
+
+Both documents land under `Canon 0.38.0` with all four `governance-change-discipline` markers: canon version bump, changelog entry, this appendix, and the companion release notes (`docs/oddkit/release-notes/2026-05-12-epoch-9-substrate-becomes-the-wire.md`).
+
+The frontmatter retag from `E0008.5` to `E0009` covers the agentic-substrate canon catalog that earned the epoch — substrate stack, persona-shaped runtime, runtime contract, substrate options, dispatch paths, trigger taxonomy, the agents-need-their-own-wire and symmetric-participation principles, the L4 disciplines (audit-gates-are-spawned-agent-sessions, critic-cannot-be-resolver, mode-transitions-require-encoded-handoff), the persona-shaping principles (methodology-personification, sessions-mirror-modes, voice-as-cognitive-load-shedding), the L5/L6 principles (magical-first-run, creators-get-paid), the foundational definitions (epistemic-modes, clone-klappy-to-oddie-recognition), and the consumer-facing appendix (mode-separated-conversations). The bootstrap operating contract receives a frontmatter-only epoch bump to E0009; the content update for E0009-specific disciplines is deferred to a separate session to keep PR scope reviewable.
+
+---
+
+## What Comes Next
+
+The migration that earned this epoch is in flight: AMS PR #77 ("plan: audit-gate runtime migration — Managed Agents → DO + Agents SDK + Project Think") merged its planning artifact on 2026-05-12. The remaining phases land the persona profile (`canon/personas/ams-canon-code-auditor.md`), the Durable Object skeleton, the Agents SDK integration, the Project Think wiring, and the cutover from Managed Agents. Each phase is a separate PR; each ships under the same runtime contract that this epoch declares.
+
+After the migration: Oddie gets an AMS account and becomes a real L4 peer on the wire — validating PRs as autonomous-trigger sessions, guiding TinCan rooms as autonomous-trigger sessions on AMS frames, running scheduled audits as alarm-triggered sessions. Same canon, different invocation context. The L3 work (`ams.convention.v1` for identity and convention metadata) lands separately. TinCan's magical-first-run becomes the L5 receipt — sub-minute onboarding with no setup overhead. The penny economy and Stripe rails wire L6 once L5 is real.
+
+The bootstrap operating contract (`canon/bootstrap/model-operating-contract`) gets a content update in a follow-up session — the new disciplines this epoch introduces (dispatch-path discipline, autonomous-trigger error-routing, runtime-contract awareness) need to land in the document that every session reads first, but the content expansion is large enough to warrant its own focused PR rather than being folded into the declaration trio.
+
+---
+
+## See Also
+
+- `klappy://canon/principles/agents-need-their-own-wire` — the Tier-1 principle whose appendix form this epoch declares
+- `klappy://canon/architecture/substrate-stack` — the six-layer map referenced throughout
+- `klappy://canon/methods/persona-shaped-agent-runtime` — substrate-vs-runtime distinction
+- `klappy://canon/methods/spawned-agent-session-runtime-contract` — the five orthogonal session dimensions
+- `klappy://canon/methods/dispatch-paths` — assistant-orchestrated vs autonomous-trigger binary
+- `klappy://canon/methods/trigger-source-taxonomy` — the nine canonical trigger types
+- `klappy://canon/constraints/audit-gates-are-spawned-agent-sessions` — what validators must be in E0009
+- `klappy://canon/principles/symmetric-participation` — L1 wire's shape constraint
+- `klappy://canon/principles/creators-get-paid` — L6 economy's invariant
+- `klappy://canon/principles/magical-first-run` — L5 application's success bar
+- `klappy://writings/we-were-the-wire` — the public-facing essay form of the argument
+- `klappy://docs/appendices/epoch-8-4` — the predecessor sub-epoch (operator-attention calibration)
+- `klappy://docs/oddkit/release-notes/2026-05-12-epoch-9-substrate-becomes-the-wire` — what changes for operators and agents after this lands
+- `klappy://odd/handoffs/2026-05-12-epoch-9-trio` — the execution spec for the trio

--- a/docs/appendices/mode-separated-conversations.md
+++ b/docs/appendices/mode-separated-conversations.md
@@ -7,7 +7,7 @@ tier: 2
 voice: neutral
 stability: evolving
 tags: ["exploration", "planning", "execution", "validation", "resolution", "collaboration", "fresh-context", "session-discipline"]
-epoch: E0008.5
+epoch: E0009
 date: 2026-05-10
 ---
 

--- a/docs/oddkit/release-notes/2026-05-12-epoch-9-substrate-becomes-the-wire.md
+++ b/docs/oddkit/release-notes/2026-05-12-epoch-9-substrate-becomes-the-wire.md
@@ -1,0 +1,134 @@
+---
+uri: klappy://docs/oddkit/release-notes/2026-05-12-epoch-9-substrate-becomes-the-wire
+title: "Release Notes — Epoch 9: Substrate Becomes the Wire (2026-05-12)"
+audience: docs
+exposure: nav
+tier: 2
+voice: neutral
+stability: stable
+tags: ["docs", "oddkit", "release-notes", "epoch-9", "substrate", "agents-need-their-own-wire", "behavior-change", "dispatch-paths", "autonomous-trigger"]
+epoch: E0009
+date: 2026-05-12
+derives_from: "canon/constraints/governance-change-discipline.md, docs/appendices/epoch-9.md, writings/we-were-the-wire.md, canon/principles/agents-need-their-own-wire.md, canon/architecture/substrate-stack.md, canon/methods/dispatch-paths.md"
+governs: "Operator and agent behavior after this release lands — the substrate stack is the default integration pattern, operator-as-wire is named as a design smell, autonomous-trigger is the canonical path for everything except synchronous user-facing assistance."
+---
+
+# Release Notes — Epoch 9: Substrate Becomes the Wire (2026-05-12)
+
+> This release does not add a tool. It changes which integration patterns canon recognizes as healthy. Operator-as-wire was the default; from this version forward it is a design smell. Audits become spawned agent sessions, not regex against prose. Validation gets its own substrate and its own context break. Personas become deployable peers with accounts, not voices in chat windows. The dispatch-paths binary makes the choice mechanical: when the runtime returns, who reads the result first? If the answer is no one, the runtime is autonomous-trigger and the operator is not in the loop. Almost every workflow that previously had a human in the wire was an autonomous-trigger shape mistaken for an assistant-orchestrated one.
+
+---
+
+## Summary — Behavior Change Is the Deliverable
+
+Epoch 9 is a behavior-change release, not a feature release. The artifacts it lands (a new canon appendix, a public essay, three new methods canon, a Tier-1 principle, an updated constraint, ~19 frontmatter retags) only matter because they change which workflow shapes canon endorses.
+
+The short version: when canon describes a workflow that includes a human in an integration role, that workflow is a design smell from this version forward — unless the role is explicitly direction-setting or pivot-decisioning. The operator is a director, not a relay. Validators are spawned agent sessions. Audits are spawned agent sessions. Ingestion is autonomous-trigger pipelines. The wire is no longer a person.
+
+The first production-grade exercise of the new runtime is in flight: `klappy/agent-messaging-service` PR #77 (audit-gate migration from Anthropic Managed Agents to Cloudflare DO + Agents SDK + Project Think) merged its planning artifact on 2026-05-12, with the multi-PR migration sequence in flight after. The same canon governs the auditor that governs the work.
+
+This release ships under **Canon 0.38.0** and establishes **Epoch 9 — Substrate Becomes the Wire** (see `docs/appendices/epoch-9.md` for the full epoch declaration with frontmatter axes: `forcing_fault`, `new_invariant`, `core_shift`). Four `governance-change-discipline` markers accompany the epoch bump: canon version, this changelog entry, this release notes file, and the epoch appendix.
+
+This document frames the release by **what changes after it lands**, not by what is in it. The file inventory is in the changelog entry; the architectural depth is in the appendix; the narrative is in the essay. This document answers the question: *what should be different about how oddkit gets used, and what should operators and agents stop doing?*
+
+---
+
+## What Changes for Operators
+
+The operator's role narrows to what only a human can do. Two activities remain irreducibly the operator's:
+
+**Direction-setting.** What should the substrate be doing this week, this month, this quarter? Which problems are worth aiming the runtime at? Which constraints are binding? The substrate has no opinion about direction; that is the operator's.
+
+**Pivot decisions.** When does the plan change? When does an open question become a closed one? When does an observation force a rework of canon? The substrate executes; the operator decides when to stop and re-plan. The mode discipline canon (`canon/constraints/mode-discipline-and-bottleneck-respect`) operationalizes this — gates are contracts; reversion is honest or it is not reversion.
+
+Activities the operator should stop doing, because they are substrate concerns:
+
+- Copy-pasting between two agents. The wire is AMS. If two reasoning systems need to talk, the substrate routes the tokens.
+- Manually transcribing PDFs, recordings, calendar events, chat threads into a knowledge base. The pipeline is R2 → Queue → Durable Object → Epistemic Surface Extraction → encoded artifacts → KB. The operator drops a file in a bucket; the artifacts appear in the KB.
+- Acting as the audit gate for canon-drift, code-vs-canon sync, or cross-reference integrity. The audit gate is a spawned Oddie session with fresh context and structured deliverable, per `canon/constraints/audit-gates-are-spawned-agent-sessions`.
+- Same-session self-review of just-produced artifacts. Validation requires a structural context break (`canon/principles/verification-requires-fresh-context`). The fresh-context validator is a separate session, ideally a separate runtime invocation; same model family is acceptable, same session is not.
+- Remembering which session encoded which decision. The substrate stores. The operator's working memory is for direction, not bookkeeping.
+
+The recognition heuristic is simple: ask "who reads the result first when this runtime returns?" If the answer is *no one* — there is no synchronous human waiting at the other end — then any clarifying question the runtime emits is incoherent (there is no listener) and any error must emit to a configured channel rather than as inline chat. That workflow is autonomous-trigger and the operator is not in the loop. Most workflows that previously had a human in the loop were this shape.
+
+---
+
+## What Changes for Agents
+
+The runtime that hosts a spawned agent session now has a contract: `canon/methods/spawned-agent-session-runtime-contract` defines five orthogonal dimensions every session declares (trigger source, persona, governance source, deliverable shape, transport). The substrate enforces these against existing canon — the auditor must run with `oddkit_search` available, the validator must run with fresh context, the persona must be declared by URI not by inline prompt.
+
+The dispatch-paths binary (`canon/methods/dispatch-paths`) settles a question that has been implicit for the last year. Two dispatch classes, mutually exclusive:
+
+- **Assistant-orchestrated.** A human reads the runtime's output through a chat assistant. Clarifying questions can be surfaced inline. Errors get explained in chat. The assistant is the consumer of record.
+- **Autonomous-trigger.** An external event (webhook, AMS frame, alarm, email, RPC, queue message, object-store event, platform webhook, push notification — see `canon/methods/trigger-source-taxonomy` for the canonical nine) wakes the runtime. There is no chat, no inline operator, no inline assistant. Clarifying questions are incoherent; errors emit to a configured channel.
+
+The selection rule is mechanical: when the runtime returns, who reads the result first?
+
+The L4 persona surface (`canon/methods/persona-shaped-agent-runtime`) is now where the canon lives. Personas are not voices inside a chat window; they are deployable peers. Oddie gets an AMS account and a stream — a real peer on the wire. The same canon that governs Oddie inside a chat session governs Oddie as an audit-gate validator on a webhook, Oddie as a TinCan room guide on an AMS frame, Oddie as a scheduled audit on an alarm trigger. Same persona, different invocation context. The activation defaults stay sensible (Oddie default-on in oddkit-driven sessions and ODD-mode work; default-off in published essays and unrelated tasks; explicit operator override in either direction).
+
+What does not change for agents: the four epistemic modes (exploration/planning/execution/validation), the mode-collapse failure pattern, the gauntlet (preflight/challenge/gate/encode/validate), the time-first contract, the search-canon-before-asking discipline. Those are the floor under everything; E0009 just makes the floor's wiring visible.
+
+---
+
+## What Does Not Change
+
+This release does not retract or supersede prior canon. It re-organizes it.
+
+The four-mode epistemic discipline (`canon/definitions/epistemic-modes`) is still the foundation. The mode-discipline-and-bottleneck-respect constraint still applies. Time-first (`canon/observations/time-blindness-axiom-violation` and the `oddkit_time` first-call rule) still applies. The gauntlet is unchanged. Validation-as-observable-mode (E0008.3) is unchanged. Governance-change-discipline (E0008.4) is unchanged — in fact, this release is itself an exercise of that discipline, with all four markers (version bump, changelog entry, release notes, epoch appendix) present.
+
+Specs-lock-at-implementation (E0008.6) is unchanged. Borrow-evaluation-before-implementation is unchanged — this trio's 6B skip is justified explicitly in the PR description (no upstream substrate to evaluate; the trio is authored canon and a frontmatter retag, not an implementation task with a vendor SDK in play).
+
+The oddkit tool surface is unchanged. No new tools land in this release; no existing tools change shape. The substrate stack and persona-shaped runtime canon are documents *for* the operator's reasoning, not new tools to call.
+
+---
+
+## How to Recognize Operator-as-Wire (and Replace It)
+
+The shape is the same across every layer; the symptom changes by surface. The recognition checklist:
+
+| Symptom | The shape underneath | The E0009 replacement |
+|---|---|---|
+| Copy-pasting between two agents | Human relay between intelligences that could talk over substrate | Account-to-account flow over AMS (L1 wire); both peers symmetric |
+| Manually re-typing a PDF / transcript / agenda into a knowledge base | Human as ingestion pipeline | R2 (or any object store) → queue → Durable Object → ESE → encoded artifacts → KB |
+| Running a regex audit script that requires human to interpret findings | Human as auditor | Spawned Oddie session with `oddkit_search` and `oddkit_audit`; structured deliverable; same canon as the work being audited |
+| "Quickly checking" just-produced code in the same session before declaring done | Same-context self-review | Validation as a separate session (`canon/validation-as-epistemic-mode`); fresh context, independent evaluation |
+| Routing a tool's response through chat back to another tool | Chat as wire | Autonomous-trigger dispatch; tool emits to AMS frame or webhook directly |
+| Operator-remembers-what-was-encoded | Working memory as durable storage | Encoded DOLCHEO+ artifacts saved to ledger/handoff files; search retrieves them |
+| Bridging two product surfaces by hand at every transition | Operator as integration layer | Autonomous-trigger between the surfaces; AMS as transport |
+| Re-explaining context every time a session starts | Operator as compression layer | Handoff document + bootstrap operating contract + DOLCHEO+ ledgers; the substrate compresses |
+
+The audit prompt for any workflow: *if the human in this loop took a week off, would the workflow stop, or would it run?* If it would stop because a human is in the wire, that wire is in the wrong place. If a person took a week off and the substrate kept running, the operator was already a director.
+
+---
+
+## Receipts Per Layer
+
+The six-layer substrate stack provides the frame. Each layer owes a specific receipt to E0009; the table is reproduced from `docs/appendices/epoch-9` for ease of reference:
+
+| Layer | What "done" looks like at this layer in E0009 | Canon that already covers it | What remains |
+|---|---|---|---|
+| **L1 Wire** (AMS) | Tokens flow between accounts. Personas have accounts. No special-casing by peer type. | `canon/principles/agents-need-their-own-wire`, `canon/principles/symmetric-participation` | `ams.convention.v1` (L3) — peer metadata so addressing is legible. Separate work track. |
+| **L2 Wrapper/Adapter** | MCP edges, channel adapters, AI-tool adapters translate L1 ↔ runtime/channel without holding application opinion. | `canon/methods/spawned-agent-session-substrate-options`, `canon/architecture/substrate-stack` | Adapter inventory grows as channels onboard; each adapter ships under the same vodka discipline. |
+| **L3 Identity & Convention** | Peer metadata is legible: who is this account, what convention, what version. | (gap named) | Author `ams.convention.v1`. Tracked. |
+| **L4 Role/Agent** | Canon-driven personas spawned on the runtime per the five-dimension contract. Audit gates, validators, ingestion personas, methodology personas (Oddie). | `canon/methods/persona-shaped-agent-runtime`, `canon/methods/spawned-agent-session-runtime-contract`, `canon/methods/dispatch-paths`, `canon/methods/trigger-source-taxonomy`, `canon/constraints/audit-gates-are-spawned-agent-sessions`, `canon/constraints/critic-cannot-be-resolver` | AMS audit-gate migration (in flight); Oddie as deployable L4 peer next. |
+| **L5 Application** | User-facing products on L1–L4 hit the magical-first-run bar (under a minute, no setup overhead). | `canon/principles/magical-first-run` | TinCan earns L5. |
+| **L6 Economy** | Creators get paid. Substrate never extracts. Payment, marketplace, reputation, settlement above the dial-tone layer. | `canon/principles/creators-get-paid` | Stripe rails through TinCan onboarding; penny economy as cost-allocation. |
+
+The pattern repeats: at every layer, "done" looks like the operator never had to be the wire between this layer and its neighbors. Where that is not yet true, the gap is named, not silently endured.
+
+---
+
+## Related
+
+- `klappy://docs/appendices/epoch-9` — full epoch declaration with frontmatter axes
+- `klappy://writings/we-were-the-wire` — public essay form of the argument
+- `klappy://canon/principles/agents-need-their-own-wire` — the Tier-1 principle
+- `klappy://canon/architecture/substrate-stack` — six-layer map
+- `klappy://canon/methods/persona-shaped-agent-runtime` — L4 runtime contract
+- `klappy://canon/methods/dispatch-paths` — assistant-orchestrated vs autonomous-trigger binary
+- `klappy://canon/methods/trigger-source-taxonomy` — the canonical nine trigger types
+- `klappy://canon/constraints/audit-gates-are-spawned-agent-sessions` — validators are not pattern matchers
+- `klappy://canon/constraints/governance-change-discipline` — the four-marker discipline this release exercises
+- `klappy://odd/handoffs/2026-05-12-epoch-9-trio` — execution spec for the trio
+- `klappy://odd/ledger/2026-05-12-epoch-9-planning` — planning session audit trail
+- `klappy/agent-messaging-service` #77 — audit-gate runtime migration (plan landed 2026-05-12; migration in flight)


### PR DESCRIPTION
Plants the **E0009** flag with all four `governance-change-discipline` markers; retags the agentic-substrate canon catalog that earned the epoch.

This is PR A of the Epoch 9 trio. Execution spec: [`klappy://odd/handoffs/2026-05-12-epoch-9-trio`](https://github.com/klappy/klappy.dev/blob/main/odd/handoffs/2026-05-12-epoch-9-trio.md). Planning session ledger: [`klappy://odd/ledger/2026-05-12-epoch-9-planning`](https://github.com/klappy/klappy.dev/blob/main/odd/ledger/2026-05-12-epoch-9-planning.md). PR B (`writings/we-were-the-wire.md`) opens after this merges.

## What this PR does — the four governance markers

Per `klappy://canon/constraints/governance-change-discipline`, every behavior-affecting governance change ships with four markers. All four are present:

1. **Canon version bump** — `canon/CHANGELOG.md` advances from `0.37.0` to `0.38.0`.
2. **Changelog entry** — under `## 0.38.0 — 2026-05-12`, summarizing the epoch, the new artifacts, the retag, and the related production work (AMS #77).
3. **Release notes** — `docs/oddkit/release-notes/2026-05-12-epoch-9-substrate-becomes-the-wire.md`. Frames the release by behavior change, not file inventory. Names what changes for operators, what changes for agents, what does not change, how to recognize operator-as-wire (and replace it), and the six-layer receipt table.
4. **Epoch appendix** — `docs/appendices/epoch-9.md`. Declares the epoch with frontmatter axes (`forcing_fault`, `new_invariant`, `core_shift`); body sections cover Summary, Forcing Fault, New Invariant, Core Shift, Layered Receipts table, Documents Introduced, What Comes Next, See Also.

## Frontmatter retag — per-doc verified

Each candidate doc's `governs` field was read before mutation; only docs that are substrate / agentic-runtime / persona-shaped work earned a retag.

**E0008.5 → E0009 (19 docs):**

- Architecture: `substrate-stack`
- Methods: `persona-shaped-agent-runtime`, `spawned-agent-session-runtime-contract`, `spawned-agent-session-substrate-options`, `dispatch-paths`, `trigger-source-taxonomy`
- Principles: `agents-need-their-own-wire`, `symmetric-participation`, `sessions-mirror-modes`, `creators-get-paid`, `magical-first-run`, `methodology-personification`, `voice-as-cognitive-load-shedding`
- Constraints: `mode-transitions-require-encoded-handoff`, `critic-cannot-be-resolver`, `audit-gates-are-spawned-agent-sessions`
- Observations: `clone-klappy-to-oddie-recognition`
- Definitions: `epistemic-modes`
- Appendices: `mode-separated-conversations`

**E0008.3 → E0009 (frontmatter-only; content update deferred):**

- `canon/bootstrap/model-operating-contract` — bumps the epoch tag; the content update for E0009-specific disciplines (dispatch-path discipline, autonomous-trigger error-routing, runtime-contract awareness) is deferred to a follow-up session to keep this PR's review surface mechanical.

**Addition beyond the planning session's candidate list:**

- `canon/constraints/audit-gates-are-spawned-agent-sessions` was not on the handoff's candidate list (planning oversight). Per the constraint's own `governs` field, it directly governs the L4 substrate work that earns the epoch: *"Any merge-blocking validator that audits canon, documentation, code-vs-canon sync, cross-reference integrity, or any other governance surface where the check requires LLM-grade judgment."* Adding it to the retag list aligns the tag with the work the constraint actually governs.

**Verified out of scope (intentionally left at E0008.5):**

- `canon/voice/oddie-the-river-guide` — voice spec; predates substrate push
- `canon/methods/borrow-bend-break-beget-build` — generic 6B methodology
- `canon/constraints/borrow-evaluation-before-implementation` — generic governance, not substrate
- `writings/reverse-engineer-the-future` — bible-translation theme
- Session ledgers (`odd/ledger/2026-05-*` files) — date-tag only, not subject-matter substrate work

## Borrow-evaluation skip — justified

Per `klappy://canon/constraints/borrow-evaluation-before-implementation`: this trio is not subject to the 6B Evaluation requirement. Reason: there is no upstream substrate to evaluate. Deliverables are (a) a new canon appendix authored from scratch using the established `docs/appendices/epoch-N.md` shape, (b) a frontmatter retag (mechanical), (c) new release notes from scratch. No implementation task against an SDK, reference implementation, or widely-adopted library exists in this PR. Surfaced for audit traceability per the constraint's own escape clause.

## Forward-references

The release notes and the appendix both reference `klappy://writings/we-were-the-wire` — that essay lands in **PR B**, which opens immediately after this PR merges. Until then, that one URI is intentionally a forward-reference. All other 16 `klappy://` URIs in the new docs resolve against current `main`.

## Reversibility

- New files (`docs/appendices/epoch-9.md`, `docs/oddkit/release-notes/2026-05-12-epoch-9-substrate-becomes-the-wire.md`): deletable.
- Frontmatter mutations (20 files): reversible via `git revert <merge-sha>`.
- CHANGELOG bump: revertible via a follow-up `0.38.1` "revert" entry if needed.
- No code shipped, no tools changed, no production behavior altered.

## Validation

- Frontmatter validator green on all 23 modified/new files (`python3 scripts/validate-frontmatter.py …` → 0 findings).
- 16/17 `klappy://` URIs in new docs resolve against current `main` (the 17th, `klappy://writings/we-were-the-wire`, is the intentional PR B forward-reference).
- No manual managed-agent validator dispatch — `klappy://canon/constraints/release-validation-gate` targets `klappy/oddkit` (production code); for canon-only PRs in `klappy.dev`, the analog (frontmatter validator green, audit clean, references resolve) is satisfied.

## Related

- Planning session ledger: `klappy://odd/ledger/2026-05-12-epoch-9-planning`
- Execution spec: `klappy://odd/handoffs/2026-05-12-epoch-9-trio`
- Live work earning the epoch: `klappy/agent-messaging-service` #77 (audit-gate runtime migration — plan landed 2026-05-12; multi-PR migration in flight)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only changes (new appendix/release notes/changelog) plus frontmatter `epoch` retags; main impact is on navigation/metadata consumers rather than runtime behavior.
> 
> **Overview**
> Declares **Canon 0.38.0 / Epoch 9 (E0009) — “Substrate Becomes the Wire”** by adding a new epoch appendix (`docs/appendices/epoch-9.md`), new release notes (`docs/oddkit/release-notes/2026-05-12-epoch-9-substrate-becomes-the-wire.md`), and a changelog entry framing the behavior shift away from *operator-as-wire* toward spawned-agent-session audits/validation and autonomous-trigger pipelines.
> 
> Retags the substrate/agent-runtime canon catalog by bumping the frontmatter `epoch:` on ~20 existing canon/docs files from `E0008.x` to `E0009` (including `canon/bootstrap/model-operating-contract.md` as a frontmatter-only bump), without substantive content edits beyond metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71f6fab4f7c0e6bedc2d710347af587dbce9a0bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->