### PR TITLE
writings: reframe we-were-the-wire — the ritual was the smell

### DIFF
--- a/writings/we-were-the-wire.md
+++ b/writings/we-were-the-wire.md
@@ -13,15 +13,15 @@ stability: stable
 tags: ["writings", "essay", "agents", "substrate", "wire", "AMS", "tokens-not-messages", "dial-tone", "TCP-IP", "agents-need-their-own-wire", "substrate-stack", "persona-shaped-runtime", "dispatch-paths", "autonomous-trigger", "epoch-9"]
 epoch: E0009
 date: 2026-05-12
-hook: "At a hackathon two months ago, my collaborator and I sat in the back row and watched our agents need to talk to each other. We copied messages between Signal and two chat windows. For forty minutes, two reasoning systems with arbitrary bandwidth were bottlenecked through two humans operating a clipboard. We were the wire."
+hook: "At a hackathon, my collaborator and I watched our agents need to talk to each other. We copied messages between Signal and two chat windows. Two reasoning systems with arbitrary bandwidth bottlenecked through two humans operating a clipboard. The ritual was the smell. We were the wire — and we are the wire every day this stays missing."
 description: "The hackathon scene that named the problem; the dial-tone argument that frames the answer; the substrate stack that earns it. Operator-as-wire is the default failure mode for every agent integration today — not just agent-to-agent messaging, but audits, validation, session-routing, ingestion, and memory. AMS gives the wire its own substrate; the stack above it gives every other layer its own shape. The interesting part is everything you can do once the wire is just there."
 slug: we-were-the-wire
 og_title: "We Were the Wire"
-og_description: "Two agents needed to talk. We copied messages between Signal and two chat windows for forty minutes. The hackathon scene that named the problem; the stack that earned the answer."
+og_description: "Two agents needed to talk. We copied messages between Signal and two chat windows. The hackathon scene that named the problem; the stack that earned the answer."
 og_type: article
 twitter_card: summary_large_image
 twitter_title: "We Were the Wire"
-twitter_description: "Two agents needed to talk. We copied messages between Signal and two chat windows for forty minutes. The hackathon scene that named the problem; the stack that earned the answer."
+twitter_description: "Two agents needed to talk. We copied messages between Signal and two chat windows. The hackathon scene that named the problem; the stack that earned the answer."
 derives_from: "klappy/agent-messaging-service:ESSAY.md (original spine, ~2300 words), canon/principles/agents-need-their-own-wire.md (canon principle form), canon/architecture/substrate-stack.md, canon/methods/persona-shaped-agent-runtime.md, canon/methods/dispatch-paths.md, canon/methods/trigger-source-taxonomy.md, canon/methods/spawned-agent-session-runtime-contract.md"
 complements: "writings/agentic-software-development.md, writings/the-dream-house-and-pre-optimization.md"
 status: active
@@ -29,7 +29,7 @@ status: active
 
 # We Were the Wire
 
-> At a hackathon two months ago, two agents needed to talk to each other. For forty minutes, we copied messages between two chat windows and Signal. We were the wire. This essay names what was missing — a dial tone for agents — and then names the full stack that has to stand above it so the wire is never the interesting part again.
+> At a hackathon, two agents needed to talk to each other. We copied messages between two chat windows and Signal. The ritual was the smell — and the ritual is daily. This essay names what was missing, a dial tone for agents, and the full stack that has to stand above it so the wire is never the interesting part again.
 
 *An essay on why agents need their own messaging protocol — and on the substrate stack that finally ends operator-as-wire.*
 
@@ -37,7 +37,7 @@ status: active
 
 ## Summary
 
-Two reasoning systems with arbitrary bandwidth do not need a better chat app; they need a chat app to be unnecessary. The protocol that does this, AMS, carries tokens (not messages), owns nothing above transport, and exists so the verticals above it stop reinventing the wire badly. But the wire problem is bigger than agent-to-agent traffic. Audits done in the same session as the work, knowledge ingestion that requires manual transcription, validation that depends on the creator's own lenses, session-routing between chat assistants: each is the same shape, operator-as-wire by another name. The six-layer substrate stack (wire, wrapper, identity, role, application, economy) gives each of those problems its own honest place to live. AMS is the floor. Oddie, the methodology-as-deployable-peer, joins it as a real subscriber. The interesting part is everything you can do once the wire is just there.
+Two reasoning systems with arbitrary bandwidth do not need a better chat app; they need a chat app to be unnecessary. The protocol that does this, AMS, carries tokens (not messages), owns nothing above transport, and exists so the verticals above it stop reinventing the wire badly. But the wire problem is bigger than agent-to-agent traffic. Audits done in the same session as the work, knowledge ingestion that requires manual transcription, validation that depends on the creator's own lenses, session-routing between chat assistants: each is the same shape, operator-as-wire by another name. Ritualized human-as-wire activity is the smell that says something belongs in substrate. The six-layer substrate stack (wire, wrapper, identity, role, application, economy) gives each of those problems its own honest place to live. AMS is the floor. Oddie, the methodology-as-deployable-peer, joins it as a real subscriber. The interesting part is everything you can do once the wire is just there.
 
 ---
 
@@ -256,8 +256,8 @@ After that, we open the protocol, ship a reference implementation under a permis
 
 If you are building agents, AMS is for you. If you are building one of the layers above — memory, identity, orchestration, observability — AMS is also for you, because it gives you a foundation you do not have to reinvent. If you are just curious about why we think the agent stack needs a TCP/IP moment, you have just read the argument.
 
-We were the wire for forty minutes. That was forty minutes too long. We are not building the wire to make ourselves obsolete; we are building it so the wire was never the interesting part.
+The hackathon was where the ritual got loud enough to notice; the ritual is daily. We are not building the wire to make ourselves obsolete; we are building it so the wire was never the interesting part.
 
 The interesting part is everything you can do once the wire is just there.
 
-The hackathon was forty minutes. The stack is six layers. The wire has somewhere to live now, and so does everything that used to need a person to hold it together — the auditor, the ingester, the router between assistants, the persona that does the work. None of those are operator-shaped anymore. They are substrate-shaped, and the operator gets the afternoon back.
+The hackathon was the noticing. The stack is six layers. The wire has somewhere to live now, and so does everything that used to need a person to hold it together — the auditor, the ingester, the router between assistants, the persona that does the work. The days the ritual used to eat go back to being days.


### PR DESCRIPTION
## Summary

Operator feedback on the published essay: the forty-minute hackathon framing, repeated across hook + blockquote + close + epilogue, made the essay sound like a one-time frustration. Operator-as-wire is a daily problem. The hackathon was where the ritual got loud enough to notice. **The ritual itself is the smell.**

This PR makes the surgical edits.

## Edits

- **`forty minutes`** now appears exactly **once** in the file — in § *The Hackathon* scene paragraph, where the scene actually narrates. Removed from:
  - `hook:` frontmatter field
  - `og_description:` and `twitter_description:` (social link-preview metadata)
  - the body blockquote
  - § *What Happens Next* closing line
  - the epilogue paragraph
- **`two months ago`** removed from `hook:` and blockquote. The temporal specificity reinforced one-time-event framing.
- **New diagnostic line in § Summary**: *"Ritualized human-as-wire activity is the smell that says something belongs in substrate."* — names the principle.
- **Hook and blockquote** both end on the same beat across different surfaces: *"we are the wire every day this stays missing"* / *"the ritual is daily"*.
- **§ *What Happens Next* closing line** rewritten around ritual-recognition rather than duration.
- **Epilogue** rewritten: *"The hackathon was the noticing. The stack is six layers. […] The days the ritual used to eat go back to being days."*

## Word count

3,997 (was 3,989; +8 net). Hard cap: 4,000. Within range.

## Spine preservation

| Section | Status |
|---|---|
| The Hackathon | byte-identical |
| What Is Actually Missing | byte-identical |
| Tokens, Not Messages | byte-identical |
| The Stack That Does Not Yet Exist | byte-identical |
| What We Are Building | byte-identical |
| The Inverted Inbox | byte-identical |
| The Layers Above | byte-identical |
| What Happens Next | **intentionally diverged** — Klappy's authorial directive |

Of the AMS `ESSAY.md` § *What Happens Next* content, **842 chars preserved verbatim** from the start (through *"… we open the protocol …"*); only the closing two beats are reframed.

## AMS-side note

`klappy/agent-messaging-service/ESSAY.md` still carries the original *"forty minutes / forty minutes too long"* framing. The same reframing may want to land there too in a separate PR (combined with the pending P12 forward-pointer addition). Out of scope for this PR per the original handoff's repo-scope rules.

## Validation

```
$ python3 scripts/validate-frontmatter.py writings/we-were-the-wire.md
✅ Frontmatter OK — 1 file(s) scanned, 0 findings.
```

`ai-voice-cliches` re-checked against full text:
- No closer-style negation parallelism
- No banned conjunctive adverbs at sentence-start
- Em-dash density unchanged from #204

## Reversibility

7 surgical text edits; revert-the-commit is clean. No structural changes. No new files.

## Builds on

PR #204 (`c8c2f90`) — original essay landed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: text-only edits to a single essay and its social metadata with no functional or structural code changes.
> 
> **Overview**
> Rewrites the essay’s *hook*, intro blockquote, and closing paragraphs to emphasize that **human-as-wire is a daily ritual**, not a one-time hackathon duration story.
> 
> Updates `og_description`/`twitter_description` and adds a new diagnostic line in `## Summary` (“ritualized human-as-wire…”) while removing repeated time-specific phrasing (e.g., “two months ago” and most mentions of “forty minutes”) outside the narrated hackathon scene.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89254a6bf5f6442a982c0a5eaf4cf1d8c8eedf4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->