### PR TITLE
canon: telemetry coverage completeness (PR 1, Phase 1)

### DIFF
--- a/canon/constraints/telemetry-governance.md
+++ b/canon/constraints/telemetry-governance.md
@@ -105,6 +105,45 @@ The `X-Oddkit-Trace` response header and the `debug.trace` field in tool respons
 
 ---
 
+## Emission Contract — Per-Tool Wrapper at Registration Site
+
+> This is the load-bearing rule for *how* telemetry is emitted. The "What Is Tracked" section above documents *which* dimensions are recorded. This section documents *where in the code* and *at what granularity* the recording happens. The two sections together define the full telemetry surface.
+
+Every `server.tool()` registration in `workers/src/index.ts` is wrapped with `withTelemetry(toolName, handler)` at registration time. The wrapper is the single emission point for tool-call telemetry. No other code in the worker writes `event_type='tool_call'` data points. Wire-edge instrumentation in the `/mcp` POST handler does not exist — it was removed when this contract was adopted.
+
+### Mandatory Rules
+
+1. **One emission point per tool.** Every `server.tool()` call must pass its handler through `withTelemetry`. New tools without the wrapper are a CI failure and a release blocker. The wrapper name (`toolName` parameter) must match the `server.tool()` first-argument name exactly.
+
+2. **In-memory measurement, never wire-edge.** The wrapper measures the `args` object on entry (after Zod validation, before handler invocation) and the returned `{ content: [...] }` envelope on exit (after handler resolution, before MCP transport framing). Both measurements operate on in-memory JavaScript values, serialized via `JSON.stringify`. The wrapper never reads `request.body` or `response.body` streams.
+
+3. **Per `tools/call` granularity.** One Analytics Engine data point is written per individual `tools/call` JSON-RPC message. For batches, each message in the batch produces its own data point with its own per-call shape. Batches do not share rows. Earlier emission paths that attributed full HTTP payload shape to every message in a batch are non-compliant with this contract.
+
+4. **Failure swallowed, never propagated.** If measurement throws (tokenizer load failure, JSON serialization edge case, `writeDataPoint` rejection), the error is caught inside the wrapper and the row is silently dropped. The tool result is returned to the caller unchanged. Telemetry must never break MCP requests. This contract is identical to the prior wire-edge swallow behavior, applied per-call.
+
+5. **No domain opinion in the wrapper.** The wrapper records what passes through it. It does not interpret tool arguments, inspect content shape, or apply tool-specific logic. Anything that requires domain knowledge (extracting `document_uri` for `get` calls, `result_grouping` for `search`) is handled by helpers the wrapper calls, not by the wrapper itself. The wrapper stays at one screen of code.
+
+### Why This Contract
+
+Three failure modes in the prior wire-edge instrumentation motivated this contract:
+
+- **Streaming-response race.** Reading `response.clone().text()` against MCP SSE bodies inside `ctx.waitUntil` produced empty strings on ~27% of calls in the 30 days preceding adoption, biased toward heavy-response tools. See `klappy://canon/observations/2026-05-14-telemetry-coverage-gap-quantified` for the diagnostic.
+- **Dispatcher bypass.** Tools that built their response envelopes inline in `createServer` (notably `telemetry_policy` at 93% missing) inherited the same race exposure but had no shared chokepoint to instrument.
+- **Batch attribution fiction.** The recording function attributed full HTTP payload shape to every JSON-RPC message in a batch, multiplying the recorded usage by the batch fan-out. Documented as a known imprecision in the code.
+
+The wrapper resolves all three because it measures per-call on in-memory objects. The full architectural rationale and alternatives considered are recorded in `klappy://canon/decisions/DR-20260514-0001-telemetry-wrapper-pattern`.
+
+### Cutover Boundary
+
+When the wrapper contract was adopted (date recorded in the linked observation), the emission semantics changed in two ways simultaneously:
+
+- **Per-call, not per-HTTP-request.** Each `tools/call` produces its own row with its own shape. Batches stop multiplying.
+- **In-memory, not wire-edge.** Heavy-response tools that previously recorded zero shape now record their actual shape.
+
+Historical Analytics Engine data crossing the cutover date mixes two different units of measurement. Queries that compare time windows spanning the cutover must treat it as a data-accuracy boundary. The 3-month Analytics Engine retention ages this out naturally — three months after cutover, all queryable data uses the post-cutover semantics.
+
+---
+
 ## What Is Excluded (Safety Boundary)
 
 The following are never collected under any circumstance:
@@ -268,6 +307,8 @@ This is not the standard telemetry social contract. The standard contract is: a 
 
 ## See Also
 
+- [DR-20260514-0001 — Telemetry Wrapper Pattern](klappy://canon/decisions/DR-20260514-0001-telemetry-wrapper-pattern) — Decision record for the Emission Contract section
+- [Telemetry Coverage Gap Quantified](klappy://canon/observations/2026-05-14-telemetry-coverage-gap-quantified) — The diagnostic that motivated the Emission Contract
 - [Vodka Architecture](klappy://canon/principles/vodka-architecture) — The design pattern telemetry must not violate
 - [Maintainability — One Person, Indefinitely](klappy://canon/principles/maintainability-one-person-indefinitely) — The principle telemetry serves
 - [KISS — Simplicity Is the Ceiling](klappy://canon/principles/kiss-simplicity-is-the-ceiling) — Why two tools, not twenty

--- a/canon/decisions/DR-20260514-0001-telemetry-wrapper-pattern.md
+++ b/canon/decisions/DR-20260514-0001-telemetry-wrapper-pattern.md
@@ -1,0 +1,129 @@
+---
+uri: klappy://canon/decisions/DR-20260514-0001-telemetry-wrapper-pattern
+title: "DR-20260514-0001 — Telemetry Emission Moves to a Per-`server.tool` Wrapper"
+audience: canon
+exposure: nav
+tier: 2
+voice: neutral
+stability: semi_stable
+tags: ["canon", "decision", "adr", "telemetry", "instrumentation", "wrapper-pattern", "vodka-architecture", "billing-prerequisite", "epoch-8"]
+epoch: E0008
+date: 2026-05-14
+status: active
+derives_from: "canon/constraints/telemetry-governance.md, canon/principles/vodka-architecture.md, canon/principles/maintainability-one-person-indefinitely.md, canon/observations/2026-05-14-telemetry-coverage-gap-quantified.md"
+complements: "odd/handoffs/2026-05-14-telemetry-coverage-completeness.md, docs/oddkit/internals/telemetry-architecture.md"
+governs: "All telemetry emission in workers/src — every server.tool() registration must go through withTelemetry"
+---
+
+# DR-20260514-0001 — Telemetry Emission Moves to a Per-`server.tool` Wrapper
+
+> Locks the architectural choice that closes the verified 27% telemetry coverage gap. Every `server.tool()` registration in `workers/src/index.ts` is wrapped with `withTelemetry(toolName, handler)`. The wrapper measures the `args` object on entry and the returned `{content: [...]}` envelope on exit — both as in-memory objects, before any SSE framing. The wire-edge instrumentation block at `index.ts:1029-1071` is deleted. This decision is the load-bearing fix for the gap recorded in `canon/observations/2026-05-14-telemetry-coverage-gap-quantified` and the prerequisite for any paid-tier observability that follows.
+
+---
+
+## Status
+
+Active. Adopted 2026-05-14. Implementation in `klappy/oddkit` PR 2, scheduled to open after canon PR 1 merges.
+
+---
+
+## Context
+
+The telemetry instrumentation added in E0008 Phase 2 tokenizes the cloned HTTP request and response bodies inside a wire-edge `ctx.waitUntil` block. A verified diagnostic (`canon/observations/2026-05-14-telemetry-coverage-gap-quantified`) shows that 27% of `event_type='tool_call'` rows over the past 30 days carry zero shape (`bytes_in`, `bytes_out`, `tokens_in`, `tokens_out` all zero). The gap distribution is biased toward heavy-response tools — `oddkit_challenge` is 79% missing, `oddkit_gate` 75%, `oddkit_encode` 73%, `telemetry_policy` 93%. Three root causes are confirmed in code: a streaming-response race against SSE, dispatcher-bypass for the two inline telemetry tools, and an acknowledged batch-attribution fiction where the full HTTP payload shape is attributed to every JSON-RPC message in a batch.
+
+The proximate motivation is a paid-tier observability requirement: pricing models cannot be derived from data that is missing the heaviest workloads. The deeper motivation is correctness — the existing telemetry is lying about coverage in a way that compounds over time.
+
+---
+
+## Decision
+
+Adopt a `withTelemetry(toolName, handler)` wrapper applied at every `server.tool()` registration site. The wrapper:
+
+1. Serializes `args` via `JSON.stringify` on entry. Measures bytes via `TextEncoder` and tokens via `countTokensSafe`. This is the per-tool-call ingress shape.
+2. Calls the wrapped handler. Captures the returned `{ content: [...] }` envelope.
+3. Serializes the content array on exit. Measures bytes and tokens the same way. This is the per-tool-call egress shape — measured on the in-memory object before any SSE framing, eliminating the streaming-response race.
+4. Computes `duration_ms` from a closure-scoped `startTime`.
+5. Resolves `consumerLabel` and `consumerSource` per call from the `request` object (passed through `createServer`'s closure).
+6. Writes one AE data point via `env.ODDKIT_TELEMETRY.writeDataPoint({...})` with `event_type='tool_call'`, reusing existing blob/double slot mappings. No schema change.
+7. Returns the handler's return value unchanged.
+
+The wire-edge `ctx.waitUntil` instrumentation block at `workers/src/index.ts:1029-1071` is deleted. Envelope-level `mcp_request` events (for `initialize`, `tools/list`, etc.) are no longer auto-emitted. Re-adding them later is a separate change if needed; current data shows essentially zero analysis depends on them.
+
+The `createServer` signature changes from `createServer(env, tracer, consumerSource?)` to `createServer(env, request, tracer?)`. `consumerSource` is derived per call inside the wrapper because the underlying parse is cheap and structural.
+
+Tokenizer remains `cl100k_base` from `gpt-tokenizer`. Drift versus Claude tokenizer is acceptable shape noise for obs. Billing-grade tokenizer selection is a Phase 3 decision and out of scope here.
+
+The pattern follows the conventional middleware/decorator shape used in Express, Fastify, and OpenTelemetry SDKs. There is no novelty in the pattern itself; the novelty is only its application to MCP `server.tool` registrations.
+
+---
+
+## Alternatives Considered
+
+### (A) Keep wire-edge measurement, fix the streaming-response race
+
+Buffer the response fully before returning (`new Response(await response.arrayBuffer(), {...})`) to eliminate the SSE clone race. Single localized change; preserves the current architecture.
+
+**Rejected because** the race is only one of three root causes. The dispatcher bypass (`telemetry_public`, `telemetry_policy`) and batch attribution fiction would remain. Per-tool-call accuracy is impossible from the wire edge regardless of race fixes — the wire edge sees only HTTP-level shape. For paid-tier observability, per-tool-call accuracy is non-negotiable.
+
+### (B) Instrument inside `handleUnifiedAction`
+
+Move tokenization to the dispatcher return point in `orchestrate.ts:handleUnifiedAction`, where every routed action passes through one `switch` statement. In-memory measurement, per-call accuracy, no race.
+
+**Rejected because** `telemetry_public` and `telemetry_policy` build envelopes inline in `createServer` and never reach the dispatcher. The data confirms this matters — `telemetry_policy` is currently 93% missing, the worst per-tool gap. Any fix that doesn't cover the two inline telemetry tools is incomplete. A dispatcher-only fix would also create asymmetric handling (some tools measured at dispatch, others at the wire edge) which is a maintenance liability.
+
+### (C) Per-`server.tool` wrapper — chosen
+
+Single chokepoint at the tool-registration site. Every registered tool covered, including the two inline telemetry tools. In-memory measurement eliminates the race. Per-call shape eliminates batch attribution fiction. The pattern is conventional; reviewers and future maintainers recognize it immediately.
+
+---
+
+## Consequences
+
+**Positive.**
+
+- **Coverage gate.** With the wrapper in place, every registered tool is measured at the same point in its lifecycle. The gap reduces to whatever residual edge cases remain (cancelled requests, OOM, isolate restarts). DoD targets ≥95% per-tool coverage on every registered tool, ≥99% aggregate.
+- **Per-tool-call accuracy.** Each AE row reflects exactly one `tools/call`'s ingress and egress. Batches produce one row per message with each row carrying only that message's shape. This is the correct primitive for billing.
+- **Vodka compliance.** Net code delta is negative — deletes ~45 lines of wire-edge instrumentation, adds ~30 lines of wrapper. Same number of telemetry call sites (one), now correctly placed. The wrapper is structural; it adds no domain opinion.
+- **Test surface.** Wrapper logic is testable in isolation in `workers/test/telemetry.test.mjs`. Coverage assertions are per-tool, not per-batch.
+
+**Negative.**
+
+- **Lost framing bytes.** Per-tool-call args measurement excludes JSON-RPC envelope overhead. Acceptable — framing overhead is platform cost, captured separately if needed.
+- **Closure-scope change.** `createServer` signature changes. Single call site (`index.ts:1006`), single-point change, but it is a public-ish signature of the file.
+- **Cutover boundary.** Historical AE rows use per-HTTP-request shape attributed across batches. Post-cutover rows use per-tool-call shape. Anyone running trend analysis across the cutover date must treat it as a data-accuracy boundary. AE retention is 3 months, so the discontinuity ages out naturally.
+- **Loss of `mcp_request` rows.** Envelope-level events for non-`tools/call` JSON-RPC methods are no longer emitted. If reintroduced later, that is a separate change.
+
+**Neutral.**
+
+- **Wrapper failure pattern matches current behavior.** Today's swallowed `catch` in `ctx.waitUntil` silently drops telemetry on error. The wrapper preserves the same contract — if measurement fails, log nothing and return the handler result. The tool result is never affected by telemetry failure.
+
+---
+
+## Reversibility
+
+Reversible. The wire-edge code path is preserved in git history at the commit immediately before its deletion. Rollback recipe is `git revert` on PR 2's merge commit. Canon (this DR, the governance update, the observation) does not need to revert — it accurately describes both the intended architecture and the failure modes that motivated it.
+
+The decision becomes harder to reverse only once Phase 3 (billing meter) starts emitting from the wrapper. At that point, billing records depend on the per-tool-call accuracy. But Phase 3 is gated separately and out of scope here.
+
+---
+
+## Validation
+
+DoD per `odd/handoffs/2026-05-14-telemetry-coverage-completeness`:
+
+- Per-tool coverage ≥95% on every registered tool, measured via dispatched Sonnet 4.6 read-only Managed Agent over the prior 1 hour, three consecutive warm-cache queries to filter resolver-cache transients.
+- Aggregate coverage ≥99% (informational, not gating).
+- 24-hour soak on prod confirms coverage holds.
+
+If any tool falls below 95%, promotion halts. A new diagnostic observation is added identifying the unfound root cause, and planning reopens.
+
+---
+
+## See Also
+
+- `klappy://canon/observations/2026-05-14-telemetry-coverage-gap-quantified` — The diagnostic this decision responds to
+- `klappy://odd/handoffs/2026-05-14-telemetry-coverage-completeness` — The execution handoff implementing this decision
+- `klappy://canon/constraints/telemetry-governance` — Updated to describe the emission contract this decision establishes
+- `klappy://canon/principles/vodka-architecture` — Design constraint this decision respects
+- `klappy://canon/principles/maintainability-one-person-indefinitely` — Principle the telemetry system serves
+- `klappy://canon/decisions/decision-record-standard` — Format for this DR

--- a/canon/observations/2026-05-14-telemetry-coverage-gap-quantified.md
+++ b/canon/observations/2026-05-14-telemetry-coverage-gap-quantified.md
@@ -1,0 +1,151 @@
+---
+uri: klappy://canon/observations/2026-05-14-telemetry-coverage-gap-quantified
+title: "Observation — Telemetry Coverage Gap Quantified (27%, Heavy-Response Bias)"
+audience: canon
+exposure: nav
+tier: 2
+voice: neutral
+stability: stable
+tags: ["canon", "observation", "diagnostic", "telemetry", "coverage", "instrumentation-gap", "reproducible-analysis", "epoch-8"]
+epoch: E0008
+date: 2026-05-14
+status: active
+derives_from: "workers/src/index.ts, workers/src/telemetry.ts, workers/src/tokenize.ts"
+complements: "odd/handoffs/2026-05-14-telemetry-coverage-completeness.md, canon/decisions/DR-20260514-0001-telemetry-wrapper-pattern.md"
+governs: "Diagnostic baseline for telemetry coverage; cutover boundary marker"
+---
+
+# Observation — Telemetry Coverage Gap Quantified (27%, Heavy-Response Bias)
+
+> Diagnostic record for the telemetry coverage gap that motivated PR 1 (canon) and PR 2 (code) under Phase 1 of the paid-tier observability work. 27% of `event_type='tool_call'` rows over the past 30 days carry zero shape (`bytes_in`, `bytes_out`, `tokens_in`, `tokens_out` all zero). Three confirmed root causes in `workers/src/index.ts:1000-1071` and `workers/src/telemetry.ts:269-275`. This observation is the receipts behind the decision recorded in `DR-20260514-0001-telemetry-wrapper-pattern`. It also marks the cutover date as a data-accuracy boundary for anyone running historical analysis.
+
+---
+
+## Summary — What the Data Said When Queried Directly
+
+A user-facing question about token usage per consumer surfaced an instrumentation gap that prior session memory had recorded as roughly 5% missing coverage. Direct query against `oddkit_telemetry` showed the actual gap is 27%: 7,106 of 26,228 `tool_call` rows over a 30-day window carry zero `bytes_in`, zero `bytes_out`, zero `tokens_in`, and zero `tokens_out`. The four shape columns are perfectly correlated: when one is zero, all four are zero. This rules out per-direction tokenizer failure and points to the recording path itself either being skipped entirely or running with empty inputs on both sides. The gap is biased toward heavy-response tools — `oddkit_challenge` is 79% missing, `oddkit_gate` 75%, `oddkit_encode` 73%, `telemetry_policy` 93%, while `telemetry_public` is only 1.5% missing. The heaviest tools are the most invisible, which is the opposite of what billable observability requires. Three root causes were verified against the worker source: a streaming-response race in `ctx.waitUntil`, dispatcher-bypass for two inline tool handlers, and a documented batch-attribution fiction in the recording function. This observation records the data, the queries that produced it, and the code lines that explain it, so the analysis is reproducible by any reader.
+
+---
+
+## The Numbers (Past 30 Days)
+
+**Aggregate coverage.**
+
+| Metric | Value |
+|--------|------:|
+| Total `tool_call` rows | 26,228 |
+| Rows with non-zero `bytes_in` | 19,122 |
+| Rows with non-zero `tokens_in` | 19,122 |
+| Rows with non-zero `bytes_out` | 19,016 |
+| Rows with non-zero `tokens_out` | 19,016 |
+| Coverage rate (non-zero shape) | 73% |
+| Missing rate (zero shape) | **27%** |
+
+The `bytes_in`/`tokens_in` numerator (19,122) is identical, and the `bytes_out`/`tokens_out` numerator (19,016) is identical. The small difference between in and out (106 rows) is the only direction-specific signal — it represents rows where the request body was measured but the response body was not. The dominant pattern is correlated-zero: 7,106 rows where all four columns are zero.
+
+**Per-tool distribution.**
+
+| Tool | Total | With `bytes_in` | Missing | Missing % |
+|------|------:|----------------:|--------:|----------:|
+| oddkit_challenge | 2,379 | 495 | 1,884 | **79%** |
+| oddkit_gate | 1,101 | 276 | 825 | **75%** |
+| oddkit_encode | 976 | 264 | 712 | **73%** |
+| oddkit (router) | 3,182 | 2,186 | 996 | 31% |
+| oddkit_search | 3,309 | 2,601 | 708 | 21% |
+| oddkit_catalog | 2,685 | 2,218 | 467 | 17% |
+| oddkit_time | 1,428 | 983 | 445 | 31% |
+| telemetry_policy | 250 | 17 | 233 | **93%** |
+| oddkit_get | 1,290 | 1,073 | 217 | 17% |
+| oddkit_validate | 381 | 170 | 211 | 55% |
+| telemetry_public | 8,160 | 8,035 | 125 | **1.5%** |
+| oddkit_orient | 282 | 158 | 124 | 44% |
+| oddkit_version | 98 | 61 | 37 | 38% |
+| oddkit_preflight | 112 | 85 | 27 | 24% |
+
+The pattern: streaming-response-heavy tools (`oddkit_challenge`, `oddkit_gate`, `oddkit_encode`) lose the most. SQL-result-shaped responses (`telemetry_public`) lose almost none. This is consistent with the SSE streaming-response race hypothesis below.
+
+---
+
+## Reproducible Queries
+
+Run these against `oddkit_telemetry` via the `telemetry_public` tool. They are the same queries used to produce the tables above.
+
+**Aggregate coverage:**
+
+```sql
+SELECT
+  SUM(_sample_interval) AS total_calls,
+  SUM(IF(bytes_in > 0, _sample_interval, 0)) AS calls_with_bytes_in,
+  SUM(IF(tokens_in > 0, _sample_interval, 0)) AS calls_with_tokens_in,
+  SUM(IF(bytes_out > 0, _sample_interval, 0)) AS calls_with_bytes_out,
+  SUM(IF(tokens_out > 0, _sample_interval, 0)) AS calls_with_tokens_out
+FROM oddkit_telemetry
+WHERE timestamp > NOW() - INTERVAL '30' DAY
+  AND event_type = 'tool_call'
+```
+
+**Per-tool coverage:**
+
+```sql
+SELECT
+  method,
+  tool_name,
+  SUM(_sample_interval) AS total,
+  SUM(IF(bytes_in > 0, _sample_interval, 0)) AS instrumented,
+  SUM(IF(bytes_in = 0, _sample_interval, 0)) AS missing
+FROM oddkit_telemetry
+WHERE timestamp > NOW() - INTERVAL '30' DAY
+  AND event_type = 'tool_call'
+GROUP BY method, tool_name
+ORDER BY missing DESC
+LIMIT 15
+```
+
+---
+
+## Three Confirmed Root Causes
+
+### Cause 1 — Streaming-Response Race (`workers/src/index.ts:1042-1066`)
+
+The wire-edge handler clones the response synchronously and reads `responseClone.text()` inside `ctx.waitUntil`. The MCP handler returns Streamable HTTP (SSE), and `await handler(...)` resolves with the Response object before the tool handler closure has finished writing the body. The fix attempt in PR #138 added `ctx.waitUntil` to wait for body drain, but the race re-surfaces when:
+
+- The SSE stream errors mid-body.
+- The worker context unwinds before the body fully drains.
+- The response body uses keep-alive frames that error on text decoding.
+
+When any of these happens, `responseText` is `""`, the swallowed `catch` at line 1067 silently writes shape zeros, and `bytes_in`/`bytes_out`/`tokens_in`/`tokens_out` all record zero. The heavier the response, the more likely. This is why `oddkit_challenge` (79% missing) is the worst — it returns the largest SSE bodies in the corpus.
+
+### Cause 2 — Dispatcher Bypass (`workers/src/index.ts:469-573` and `575+`)
+
+`telemetry_public` and `telemetry_policy` register their handlers inline in `createServer` and build their response envelopes directly. They do not route through `handleUnifiedAction`. The wire-edge instrumentation block still fires for them, so they get the same race exposure as everything else — `telemetry_policy` is 93% missing because its short responses are most often empty by the time `responseClone.text()` reads. Any fix that instruments only `handleUnifiedAction` (one of the alternatives considered in the DR) would leave these two tools permanently un-instrumented.
+
+### Cause 3 — Batch Attribution Fiction (`workers/src/telemetry.ts:269-275`)
+
+The `recordTelemetry` function explicitly attributes the full HTTP payload shape to every JSON-RPC message in a batch. The code comment is direct: *"for batches we attribute the full payload shape to each message rather than fabricating a split."* For obs this is imprecise. For billing this is unacceptable — a customer who sends a five-message batch is billed five times the actual payload. Per-tool-call accuracy is impossible from the wire edge because the wire edge sees only HTTP-level shape.
+
+---
+
+## Working Learning — Tagged for Graduation
+
+**Measure HTTP-level metrics on in-memory objects, not wire-edge streams.** When a metric can be computed either at the wire edge (on serialized streams) or one layer in (on in-memory objects), prefer the in-memory path. The wire edge is subject to streaming races, per-request rather than per-operation accuracy, and batch attribution fiction. The in-memory path is exact, race-free, per-operation.
+
+This is recorded here as a working learning, not a canon principle, per the third-recurrence rule. One case (this telemetry gap) is not enough to canonize a principle. Tag for graduation when a second case appears in any context — telemetry, tracing, audit logging, billing meter, anywhere the same wire-edge-vs-in-memory choice presents itself.
+
+---
+
+## Cutover Boundary — Data-Accuracy Notice
+
+When PR 2 lands (the code change implementing the `withTelemetry` wrapper), the emission semantics change:
+
+- **Before cutover.** One AE row per JSON-RPC message in a batch. Each row carries the full HTTP-level payload shape attributed identically to every message. Shape columns are zero on ~27% of rows due to the wire-edge race.
+- **After cutover.** One AE row per `tools/call`. Each row carries that call's `args` shape on ingress and its `content` shape on egress. Shape columns are non-zero by gate (≥95% per-tool floor). Aggregate ≥99% expected.
+
+Anyone running historical analysis across the cutover date must treat it as a data-accuracy boundary. Trend lines computed across the boundary mix two different units of measurement. The cutover date will be recorded at the top of this document once PR 2 promotes to prod. Analytics Engine retention is 3 months, so the discontinuity ages out naturally — by August 2026, all queryable data uses the post-cutover semantics.
+
+---
+
+## See Also
+
+- `klappy://odd/handoffs/2026-05-14-telemetry-coverage-completeness` — The handoff this observation supports
+- `klappy://canon/decisions/DR-20260514-0001-telemetry-wrapper-pattern` — The decision this observation justifies
+- `klappy://canon/constraints/telemetry-governance` — The governance constraint that documents the emission contract

--- a/odd/handoffs/2026-05-14-telemetry-coverage-completeness.md
+++ b/odd/handoffs/2026-05-14-telemetry-coverage-completeness.md
@@ -1,0 +1,216 @@
+---
+uri: klappy://odd/handoffs/2026-05-14-telemetry-coverage-completeness
+title: "Handoff — Telemetry Coverage Completeness (Phase 1)"
+audience: handoff
+exposure: nav
+tier: 2
+voice: terse
+stability: draft
+tags: ["handoff", "session", "telemetry", "observability", "billing-prerequisite", "epoch-8", "execution-contract"]
+epoch: E0008
+date: 2026-05-14
+status: draft-for-gate
+derives_from: "canon/constraints/telemetry-governance.md, canon/principles/vodka-architecture.md, canon/principles/maintainability-one-person-indefinitely.md, canon/constraints/release-validation-gate.md, docs/oddkit/release-notes/2026-05-12-epoch-9-substrate-becomes-the-wire.md"
+governs: "workers/src/index.ts, workers/src/telemetry.ts, workers/src/tokenize.ts"
+---
+
+# Handoff — Telemetry Coverage Completeness (Phase 1)
+
+> Close the 27% byte/token instrumentation gap so paid-tier pricing can be derived from data that doesn't lie. Move payload measurement from the HTTP wire edge (where a streaming-response race zeros out the shape on heavy-payload tools) to a thin wrapper around every `server.tool()` handler (where args and result are in-memory objects). Single pattern, every tool path, no schema change, no policy change.
+
+---
+
+## Summary
+
+A paid-tier pricing model requires obs data that is trustworthy across every surface, every tool, every transport. The current `/mcp` wire-edge instrumentation, added in E0008 Phase 2, tokenizes the cloned HTTP request and response bodies inside `ctx.waitUntil`. Three classes of failure produce a measured 27% rate of zero-byte/zero-token tool_call rows over the past 30 days (19,122 of 26,228 calls carry shape data): a streaming-response race in which `responseClone.text()` resolves empty against MCP SSE bodies; tools whose handlers bypass `handleUnifiedAction` (notably `telemetry_public` and `telemetry_policy`); and request-body clone failures that propagate to both ingress and egress zeros in a single row. The gap correlates with response heaviness — `oddkit_challenge` is 79% missing, `oddkit_gate` 75%, `oddkit_encode` 73% — which is the opposite of what billable observability needs: the heaviest tools are the most invisible.
+
+The fix is one architectural change with no public-surface impact. A `withTelemetry(handler)` wrapper at every `server.tool()` registration site measures the `args` object on entry and the returned `{content: [...]}` envelope on exit, both as in-memory objects, before any SSE framing or stream serialization. The wrapper writes the AE data point directly using `env` captured from `createServer`'s closure. The wire-edge `ctx.waitUntil` block is deleted. Vodka-shaped: one chokepoint, no domain opinion, deletes more code than it adds. Coverage gate: every registered tool ≥95% non-zero shape on `bytes_in`/`bytes_out`/`tokens_in`/`tokens_out` over a 1-hour post-deploy window and a 24-hour prod soak, verified by a dispatched Sonnet 4.6 validator agent rather than operator-run SQL (per E9 `substrate-becomes-the-wire`).
+
+This plan is scoped to Phase 1 (obs completeness). Phase 1.5 (identity cohorting), Phase 2 (pricing analysis), and Phase 3 (billing meter) are noted but separately gated. Phase 1 unblocks Phase 2 by making the data trustworthy enough to analyze; it does not enable billing.
+
+---
+
+## Problem — Verified Against Code and Data
+
+**Symptom.** Of 26,228 `event_type='tool_call'` rows in oddkit_telemetry over the past 30 days, 19,122 (73%) carry non-zero `bytes_in`/`tokens_in`/`bytes_out`/`tokens_out`. The remaining 7,106 (27%) record zero shape. The four shape columns are perfectly correlated — when one is zero, all four are zero — which rules out per-direction tokenizer failure and points to the recording path itself being skipped or zeroed.
+
+**Gap distribution is biased toward heavy responses:**
+
+| Tool | Total | With shape | Missing % |
+|------|------:|-----------:|----------:|
+| oddkit_challenge | 2,379 | 495 | 79% |
+| oddkit_gate | 1,101 | 276 | 75% |
+| oddkit_encode | 976 | 264 | 73% |
+| oddkit_search | 3,309 | 2,601 | 21% |
+| oddkit_catalog | 2,685 | 2,218 | 17% |
+| telemetry_policy | 250 | 17 | 93% |
+| telemetry_public | 8,160 | 8,035 | 1.5% |
+
+**Three confirmed root causes (verified against `workers/src/index.ts` and `workers/src/orchestrate.ts`):**
+
+1. **Streaming-response race.** `index.ts:1042-1066` clones the response synchronously, then reads `responseClone.text()` inside `ctx.waitUntil`. The MCP handler returns Streamable HTTP (SSE). When the SSE stream errors, closes early, or the worker context unwinds before the body fully drains, `responseText` is `""` and the swallowed catch at line 1067 (`// Telemetry must never break MCP requests`) writes shape zeros. The heavier the response, the more likely.
+
+2. **Dispatcher bypass.** `telemetry_public` (`index.ts:469-573`) and `telemetry_policy` (`index.ts:575+`) build envelopes inline without routing through `handleUnifiedAction`. They still get wire-edge measurement, but their failure rates (93% missing on `telemetry_policy`, 1.5% on `telemetry_public`) suggest a different streaming pattern — likely the shorter response paths complete before the clone race resolves, while the larger SQL result responses succeed. Either way, the dispatcher is not the chokepoint it appears to be.
+
+3. **Batch attribution fiction.** `telemetry.ts:269-275` explicitly attributes the full HTTP payload shape to every JSON-RPC message in a batch (`"for batches we attribute the full payload shape to each message rather than fabricating a split"`). For pricing this is unacceptable: a customer who sends a five-message batch is billed 5x the actual payload.
+
+**Why each of these is incompatible with paid-tier billing.** Pricing requires per-tool-call accuracy. Wire-edge measurement gives per-HTTP-request accuracy, which then gets multiplied across batches. A customer's bill computed from this data would be wrong by an arbitrary multiplier any time a client batches calls (which the MCP SDK does opportunistically). The race makes the wrong number a soft floor — heavy tools just disappear. Combined, you have a billing system that systematically under-bills heavy users and over-bills batch users.
+
+---
+
+## Design — The `withTelemetry` Wrapper
+
+**Single pattern, applied at every `server.tool()` registration site:**
+
+```ts
+server.tool(
+  name,
+  description,
+  schema,
+  annotations,
+  withTelemetry(name, async (args) => {
+    // existing handler body
+  })
+);
+```
+
+**What `withTelemetry(toolName, handler)` does:**
+
+1. On entry: serialize `args` (`JSON.stringify(args)`), measure bytes via TextEncoder and tokens via `countTokensSafe` from `tokenize.ts`. This is the per-tool-call ingress shape — more accurate than today's per-HTTP-request shape divided naively across batches.
+2. Call the wrapped handler, capture the returned `{ content: [...] }`.
+3. On exit: serialize the content array, measure bytes and tokens the same way. This is the per-tool-call egress shape — measured on the in-memory object before any SSE framing, eliminating the streaming-response race entirely.
+4. Compute `duration_ms` from a closure-scoped `startTime`.
+5. Resolve `consumerLabel` and `consumerSource` from `request` (passed through `createServer`'s closure — see signature change below).
+6. Write one AE data point via `env.ODDKIT_TELEMETRY.writeDataPoint({...})` with `event_type='tool_call'`, the measured shape, and existing blob/double slot mappings. Reuses `recordTelemetry`'s data-point shape; does not add new slots.
+7. Return the handler's return value unchanged.
+
+**Closure scope change.** `createServer(env, tracer, consumerSource)` becomes `createServer(env, request, tracer)`. `consumerSource` is re-derived inside `withTelemetry` per-call (cheap; the resolution is structural). `request` is needed so the wrapper can read headers and URL params for consumer-label resolution. No other signature changes.
+
+**Wire-edge code deleted.** `index.ts:1029-1071` (the `if (telemetryClone)` block and its `ctx.waitUntil` callback) is removed entirely. The wire edge keeps only its existing job of routing the request and returning the response. Envelope-level `mcp_request` events (non-tool-call JSON-RPC traffic like `initialize`, `tools/list`) are no longer auto-emitted; if any are needed for diagnostics, they get an explicit per-method wrapper on the MCP handler (deferred — current data shows essentially all useful telemetry is at the tool_call level).
+
+**Tokenizer unchanged.** Still `cl100k_base` from `gpt-tokenizer`. Drift versus Claude tokenizer is acceptable shape noise for obs. Billing-grade tokenizer selection is a Phase 3 canon decision, not this plan.
+
+**Vodka compliance check (the three questions from `canon/principles/vodka-architecture`):**
+
+1. *Server thicker?* No. Net code delta is negative: deletes ~45 lines of wire-edge instrumentation, adds ~30 lines of wrapper. Same number of telemetry call sites (one), now correctly placed.
+2. *New domain opinion?* No. The wrapper is structural — it measures and records, it does not interpret. Tool names, args, and results pass through unchanged.
+3. *Removable without consequence?* No more than before. Telemetry is already load-bearing per the governance constraint. The change improves correctness, not coupling.
+
+### Alternatives Rejected
+
+**(A) Keep wire-edge measurement, fix the streaming-response race.** Use `new Response(await response.arrayBuffer(), {...})` to fully buffer the response before returning it, eliminating the SSE clone race. Rejected: solves only the race (root cause #1) and leaves dispatcher bypass (root cause #2) and batch attribution fiction (root cause #3) intact. Per-tool-call accuracy is still impossible because the wire edge sees only HTTP-level shape.
+
+**(B) Instrument inside `handleUnifiedAction`.** Move tokenization to the dispatcher's return point, where every routed action passes through one switch statement. Rejected: `telemetry_public` and `telemetry_policy` build envelopes inline in `createServer` and never reach the dispatcher — they would remain uninstrumented. The data confirms this matters: `telemetry_policy` is currently 93% missing, the worst per-tool gap in the dataset. Any fix that doesn't cover these two tools is incomplete.
+
+**(C) Per-`server.tool` wrapper.** Chosen. Single chokepoint, every registered tool, no dispatcher dependency, in-memory measurement eliminates the race, per-call shape eliminates batch attribution fiction.
+
+---
+
+## Touch List
+
+### Code (workers/src in `klappy/oddkit`)
+
+| File | Change | LOC delta |
+|------|--------|----------:|
+| `workers/src/telemetry.ts` | Export new `withTelemetry(toolName, handler, env, request)` wrapper. Keep `recordTelemetry` as a lower-level helper the wrapper calls. | +30 |
+| `workers/src/index.ts` | Update `createServer` signature (add `request`, remove `consumerSource` from outer scope — derive per-call). Wrap every `server.tool()` registration. Delete `if (telemetryClone)` block at lines 1000-1071. | −45/+25 |
+| `workers/src/tokenize.ts` | No change. `measurePayloadShape` is still useful; new wrapper calls `countTokensSafe` directly with per-direction strings. | 0 |
+| `workers/test/telemetry.test.mjs` | Add wrapper coverage tests: ingress measured, egress measured, both non-zero on synchronous handlers, both non-zero on streaming-response handlers, errors swallowed without breaking the handler return. | +80 |
+| `workers/test/integration.test.mjs` | Add end-to-end test: invoke each registered tool through the MCP handler, assert telemetry row has non-zero shape. | +60 |
+
+**Net code delta:** approximately −30 lines of wire-edge instrumentation, +95 lines of wrapper + tests. Reduces total instrumentation surface area while increasing coverage.
+
+### Canon (in `klappy/klappy.dev`)
+
+| Path | Change | Purpose |
+|------|--------|---------|
+| `canon/decisions/DR-20260514-0001-telemetry-wrapper-pattern.md` | **New.** Tier 2. Locks the wrapper pattern as the canonical telemetry emission point. Alternatives considered: (A) keep wire-edge, fix the race — rejected, doesn't solve dispatcher bypass; (B) instrument inside `handleUnifiedAction` — rejected, misses telemetry tools; (C) per-tool wrapper — chosen. Records the verified 27% gap as the trigger, the four shape columns being correlated-zero as the diagnostic, and the per-tool-call accuracy gain as the consequence. Notes prior art: per-handler middleware/decorator is the conventional pattern in Express, Fastify, OpenTelemetry SDKs; the novelty here is only its application to MCP `server.tool` registrations. | Decision lock for the architecture. |
+| `canon/constraints/telemetry-governance.md` | **Update.** Two changes: (1) The "Structural Dimensions (Blobs)" and "Numeric Values (Doubles)" tables predate E0008 Phase 2 — add `bytes_in`, `bytes_out`, `tokens_in`, `tokens_out`, `cache_hits`, `cache_lookups`. (2) New section `## Emission Contract — Per-Tool Wrapper at Registration Site` describing the load-bearing rule: every `server.tool` registration goes through `withTelemetry`; measurement is per tool call on in-memory args and result objects, never on wire-edge streams; one AE data point per `tools/call`, never per HTTP request; batches produce one row per message. This is the section future tools, TruthKit additions, and future maintainers read to know how to emit telemetry correctly. | Schema parity AND emission governance — the canon describing how it works now. |
+
+### Observations (in `klappy/klappy.dev`)
+
+| Path | Change | Purpose |
+|------|--------|---------|
+| `canon/observations/2026-05-14-telemetry-coverage-gap-quantified.md` | **New.** Tier 2. Records the diagnostic: 27% rate, four-column-zero correlation, distribution biased toward heavy responses, the three confirmed root causes with code-line citations. Cites the queries used so the analysis is reproducible. Records the cutover date as a "data-accuracy boundary" — pre-cutover rows attribute per-HTTP-request shape across batches; post-cutover rows are per-tool-call. Includes a working learning: *measure in-memory objects, not wire-edge streams* — tagged for graduation to a canon principle on the second case. | Diagnostic record — the receipts for the decision. |
+
+### Session ledger (in `klappy/klappy.dev`)
+
+| Path | Change | Purpose |
+|------|--------|---------|
+| `odd/ledger/2026-05-14-telemetry-coverage-planning-session.md` | **New.** Tier 3. DOLCHEO session journal capturing decisions, observations, learnings, constraints, handoffs, encodes, and open threads from this planning conversation. Saved as the milestone artifact before opening PR 1. | Session record of the planning that produced the DR and handoff. |
+
+**Note on this document.** This handoff itself is the execution contract for the code work. It lives at `odd/handoffs/2026-05-14-telemetry-coverage-completeness.md` and is merged in the canon PR before the code PR opens. No separate handoff file is created.
+
+### Docs (in `klappy/klappy.dev`) — DEFERRED TO PR 2
+
+These doc updates describe how telemetry behaves *after* the wrapper lands. They cannot ship in PR 1 without describing future behavior as if it were current. They move to PR 2 alongside the code change.
+
+| Path | Change | Purpose | PR |
+|------|--------|---------|----|
+| `docs/oddkit/tools/telemetry_public.md` | **Update.** Refresh the "0 for SSE streams" language in the schema. Add a cutover-boundary note referencing the new observation. Add cross-link to the new internals doc. | Doc-truth parity. | PR 2 |
+| `docs/oddkit/tools/telemetry_policy.md` | **Update.** Reference the new principle doc and the updated governance constraint. | Cross-link freshening. | PR 2 |
+| `docs/oddkit/internals/telemetry-architecture.md` | **New.** Internals doc describing the wrapper pattern, the closure-scope contract, the deleted wire-edge block, and the data-point shape. Audience: future maintainer. One-screen doc, no narrative. | Architecture record for future grep. | PR 2 |
+
+---
+
+## Definition of Done
+
+**PR sequencing — canon-first-absolute applies:**
+
+- **PR 1 (canon, `klappy/klappy.dev`)** — five files: this handoff, the session journal, the DR, the telemetry-governance update (adding the Emission Contract section), and the observation. Merges first. No code, no doc-of-current-tool-behavior changes.
+- **PR 2 (code + implementation docs, `klappy/oddkit` + `klappy/klappy.dev`)** — wrapper + tests + wire-edge delete in `klappy/oddkit`. Internals doc, telemetry_public.md schema refresh, and telemetry_policy.md cross-link refresh in `klappy/klappy.dev`. Opens only after PR 1 merges. Promotion gated by per-tool ≥95% coverage verified via dispatched validator agent.
+
+**Completion criteria:**
+
+1. **PR 1 merged** to `klappy/klappy.dev:main` with all canon and doc changes, passing canon-quality CI.
+2. **PR 2 merged** to `klappy/oddkit:main` with all five code changes and both test suites green.
+3. Wrangler deploy to main preview (`main-oddkit.klappy.workers.dev`) confirms the worker boots and serves a smoke call through every registered tool.
+4. **Validator agent dispatched** (per E9 `substrate-becomes-the-wire` and `release-validation-gate` canon) — Sonnet 4.6 read-only Managed Agent runs the post-deploy coverage query against `oddkit_telemetry` over the prior 1 hour and reports per-tool aggregates. Agent runs three consecutive warm-cache queries to filter resolver-cache transients (per known bug #149). Operator does not run SQL by hand.
+5. **Per-tool coverage gate.** Promotion is blocked unless every registered tool shows ≥95% non-zero `bytes_in`/`bytes_out`/`tokens_in`/`tokens_out` in the validator's report. Aggregate ≥99% is informational, not gating — it masks per-tool failures. If any tool falls below 95%, halt promotion, add a new diagnostic observation identifying the unfound root cause, and reopen planning.
+6. Promotion PR `main → prod` in `klappy/oddkit`, squash merge after Cursor Bugbot reaches `completed`.
+7. **24-hour soak dispatched as a second validator agent session** — separate Managed Agent, same query, against prod. Coverage holds per the same per-tool gate. Operator receives the agent's final report; does not poll AE directly.
+
+---
+
+## Out of Scope (Stated for Boundary Clarity)
+
+- **Phase 1.5 — Identity cohorting.** Optional `client_id` JSON-RPC param, cohort view over consumer_label patterns, `?consumer=` URL-param disambiguation between human/agent/CI. Separate PR, separate decision record. This plan does not improve the question "who is the customer" — only "how many tokens did this call cost."
+- **Phase 2 — Pricing analysis.** Cohort × tool × time-window analysis. Determination of natural tier breaks. Cost-side reconciliation against Cloudflare Workers, R2, AE costs. Maintainer's analytic work, no code.
+- **Phase 3 — Billing meter.** Authenticated `account_id`, non-sampled storage (D1 or R2), idempotency on JSON-RPC id, Claude tokenizer (not cl100k), dispute trail. Requires its own canon decision records before any code.
+- **Tokenizer choice for billing.** This plan keeps cl100k. The ~3–4% drift versus Claude tokenizer is acceptable for obs and unacceptable for billing; the decision lives in Phase 3.
+
+---
+
+## Risks and Tradeoffs
+
+**R1 — Lost framing bytes.** Per-tool-call args measurement excludes JSON-RPC envelope overhead. *Mitigation:* this is the correct primitive for billing. Framing overhead is platform cost, captured separately if needed via wire-edge `mcp_request` events on a separate, cheaper path.
+
+**R2 — Closure-scope change breaks tests.** Adding `request` to `createServer` is a signature change touching every call site. *Mitigation:* there is one call site (`index.ts:1006`). Single-point change.
+
+**R3 — Wrapper failure pattern equals current swallowed-catch pattern.** If `withTelemetry` throws, the tool result is lost. *Mitigation:* wrap the measurement in try/catch — if measurement fails, log nothing and return the handler result. Same swallow contract as today, applied per-call rather than per-request.
+
+**R4 — Cursor Bugbot may flag the dead-code removal.** Deleting the wire-edge block is a large diff. *Mitigation:* preserve in git history; rollback recipe is `git revert`.
+
+**R5 — Batch attribution change creates a data-accuracy boundary on the cutover date.** Anyone querying `bytes_in` historically gets per-HTTP-request shape attributed to N messages; after the change, per-message shape. *Mitigation:* document the cutover date in the observation doc. Pre-cutover trend analysis treats the boundary explicitly. AE retention is 3 months so the discontinuity ages out naturally.
+
+---
+
+## Open Questions Before Gate
+
+These should be resolved in this planning conversation, not surfaced during execution:
+
+1. **Do we want envelope-level `mcp_request` rows preserved?** Current wire-edge block emits them for `initialize`, `tools/list`, etc. Proposed delete kills them. Recommendation: kill them — the data shows essentially zero analysis depends on them.
+2. **Should `withTelemetry` write directly or return a shape for centralized recording?** Recommendation: write directly. Centralized recording reintroduces the closure-scope coupling problem.
+3. **Coverage gate threshold — 99% strict, or 95% per-tool minimum with no max-floor?** Recommendation: 95% per-tool minimum. The 99% aggregate masks per-tool failures.
+
+---
+
+## See Also
+
+- `klappy://canon/constraints/telemetry-governance` — Authority for what is tracked and why
+- `klappy://canon/constraints/release-validation-gate` — Validator-agent dispatch contract used in DoD
+- `klappy://canon/principles/vodka-architecture` — Design pattern this change must respect
+- `klappy://canon/principles/maintainability-one-person-indefinitely` — Principle telemetry serves
+- `klappy://canon/principles/cache-fetches-and-parses` — Same family of "measure where the data lives" reasoning
+- `klappy://docs/oddkit/release-notes/2026-05-12-epoch-9-substrate-becomes-the-wire` — Substrate shift driving the validator-agent DoD
+- `klappy://canon/decisions/decision-record-standard` — Format for the new DR

--- a/odd/ledger/2026-05-14-telemetry-coverage-planning-session.md
+++ b/odd/ledger/2026-05-14-telemetry-coverage-planning-session.md
@@ -1,0 +1,103 @@
+---
+uri: klappy://odd/ledger/2026-05-14-telemetry-coverage-planning-session
+title: "Session Journal — Telemetry Coverage Completeness Planning"
+audience: journal
+exposure: nav
+tier: 3
+voice: terse
+stability: stable
+tags: ["journal", "ledger", "dolcheo", "session", "telemetry", "observability", "planning", "epoch-8", "phase-1"]
+epoch: E0008
+date: 2026-05-14
+status: complete
+derives_from: "odd/handoffs/2026-05-14-telemetry-coverage-completeness.md, canon/constraints/telemetry-governance.md"
+complements: "canon/decisions/DR-20260514-0001-telemetry-wrapper-pattern.md, canon/observations/2026-05-14-telemetry-coverage-gap-quantified.md"
+---
+
+# Session Journal — Telemetry Coverage Completeness Planning
+
+> Planning session that produced the Phase 1 handoff for closing the 27% telemetry coverage gap. Started from a token-usage query, converged through one challenge cycle and one revision cycle into a locked architecture (per-`server.tool` `withTelemetry` wrapper) and a two-PR sequence (canon first, code second). This journal records the decisions, observations, learnings, and constraints captured during the session. Saved as the milestone artifact before opening PR 1.
+
+---
+
+## [D] Decisions
+
+**D1. Per-`server.tool` `withTelemetry` wrapper.** Adopt as the canonical telemetry emission point. Measures `args` on entry and the returned content array on exit as in-memory objects, eliminating the streaming-response race and per-batch attribution fiction simultaneously. Rejects two alternatives:
+- (A) Wire-edge race fix — addresses only one of three confirmed root causes; leaves dispatcher bypass and batch attribution intact.
+- (B) `handleUnifiedAction` instrumentation — misses inline tool handlers (`telemetry_policy` at 93% missing, `telemetry_public` inline as well).
+
+**D2. Two-PR sequence — canon first.** PR 1 lands in `klappy/klappy.dev` with the handoff, DR, telemetry-governance update, observation, internals doc, this journal, and two tool-doc refreshes. PR 2 in `klappy/oddkit` opens only after PR 1 merges. Per `canon-first-absolute`.
+
+**D3. Demote `measure-in-memory-not-wire-edge`.** Originally proposed as a tier-2 canon principle. Demoted to a working learning in the observation doc, tagged for graduation to a canon principle when a second case appears. Per the third-recurrence rule.
+
+**D4. DoD coverage gate is per-tool 95% floor, not aggregate 99%.** Aggregate coverage masks per-tool failures. Per-tool floor catches the case where one tool regresses to zero shape while everything else stays high.
+
+**D5. Validator agent dispatch for coverage verification.** Sonnet 4.6 read-only Managed Agent runs the post-deploy and 24-hour soak coverage queries against `oddkit_telemetry`. Operator does not run SQL by hand. Per E9 `substrate-becomes-the-wire` and `release-validation-gate`.
+
+---
+
+## [O] Observations
+
+**O1. Telemetry coverage gap quantified.** 27% of `tool_call` rows over the past 30 days carry zero `bytes_in`/`bytes_out`/`tokens_in`/`tokens_out` — 7,106 of 26,228. The four shape columns are perfectly correlated-zero: when one is zero, all four are zero, which rules out per-direction tokenizer failure and points to the recording path itself being skipped. Gap distribution biased toward heavy-response tools:
+
+| Tool | Total | With shape | Missing % |
+|------|------:|-----------:|----------:|
+| oddkit_challenge | 2,379 | 495 | 79% |
+| oddkit_gate | 1,101 | 276 | 75% |
+| oddkit_encode | 976 | 264 | 73% |
+| oddkit_search | 3,309 | 2,601 | 21% |
+| oddkit_catalog | 2,685 | 2,218 | 17% |
+| telemetry_policy | 250 | 17 | 93% |
+| telemetry_public | 8,160 | 8,035 | 1.5% |
+
+**O2. Three confirmed root causes in `workers/src/index.ts:1029-1071`:**
+1. Streaming-response race — `responseClone.text()` resolves empty on SSE bodies when the worker context unwinds before the body fully drains.
+2. Dispatcher bypass — `telemetry_public` (lines 469-573) and `telemetry_policy` (lines 575+) build envelopes inline in `createServer` and never reach `handleUnifiedAction`.
+3. Batch attribution fiction — `telemetry.ts:269-275` attributes the full HTTP payload shape to every JSON-RPC message in a batch (the code comment acknowledges this).
+
+---
+
+## [L] Learnings
+
+**L1. Measure HTTP-level metrics on in-memory objects, not wire-edge streams.** When a metric can be computed either at the wire edge (on serialized streams) or one layer in (on in-memory objects), prefer in-memory. The wire edge is subject to streaming races, per-request rather than per-operation accuracy, and batch attribution fiction. The in-memory path is exact, race-free, per-operation. One case so far — graduate to canon principle when a second case appears.
+
+**L2. `oddkit_challenge` stacks claim types.** A plan that combines proposal + principle-extraction + pattern-coinage + comparative-positioning + observation + assumption surfaces six matched types. Use the `matched_types` list to triage which prerequisite gaps are real (sample size, alternatives, irreversibility, validation tests) versus generic.
+
+**L3. Stale memory must yield to live data.** The "5% coverage" figure carried from prior session memory was wrong by 5x. Live telemetry query found 27%. When the question is verifiable, memory is not authoritative — query and cite the query with the analysis.
+
+---
+
+## [C] Constraints
+
+**C1. `canon-first-absolute`.** Canon doc changes merge before any code PR opens. PR 2 (workers/src wrapper) must not open until PR 1 (canon) merges.
+
+**C2. `release-validation-gate`.** Cursor Bugbot must reach `completed` before merge. Load-bearing surface changes require a dispatched read-only Sonnet 4.6 validator before promotion. Encoded into PR 1's DoD steps 4, 5, and 7.
+
+**C3. E9 `substrate-becomes-the-wire`.** Operator-as-wire is a design smell. Coverage verification dispatched as Managed Agent sessions, not operator-run SQL.
+
+---
+
+## [H] Handoffs
+
+**H1. PR 1 execution starts after this journal saves.** Five files into `klappy/klappy.dev`:
+- This journal: `odd/ledger/2026-05-14-telemetry-coverage-planning-session.md`
+- Handoff: `odd/handoffs/2026-05-14-telemetry-coverage-completeness.md`
+- DR: `canon/decisions/DR-20260514-0001-telemetry-wrapper-pattern.md`
+- Telemetry-governance update: `canon/constraints/telemetry-governance.md`
+- Observation: `canon/observations/2026-05-14-telemetry-coverage-gap-quantified.md`
+
+PR 2 (in `klappy/oddkit` plus follow-up updates in `klappy/klappy.dev`) carries the wrapper code, the internals doc, and the schema-refresh updates to `docs/oddkit/tools/telemetry_public.md` and `docs/oddkit/tools/telemetry_policy.md`. After PR 1 merges, re-plan PR 2 against the final canon text and gate planning → execution again.
+
+---
+
+## [E] Encodes
+
+**E1.** This journal is encoded at `klappy://odd/journals/2026-05-14-telemetry-coverage-planning-session` per the DOLCHEO vocabulary at `klappy://canon/definitions/dolcheo-vocabulary`. Encoded as the milestone artifact before opening PR 1, per the operating contract's session-journal capture rule.
+
+---
+
+## [O-open] Open Threads
+
+**P1. PR 2 (code) scope.** Pending PR 1 merge. Wrapper signature: `withTelemetry(toolName, handler, env, request)`. `createServer` signature change: add `request`, derive `consumerSource` per call. Wire-edge `ctx.waitUntil` block at `index.ts:1029-1071` deleted. Tests: unit coverage for ingress/egress measurement; integration coverage for every registered tool. Cutover date recorded as data-accuracy boundary in the observation.
+
+**P2. Later phases.** Phase 1.5 — identity cohorting (voluntary `client_id` JSON-RPC param plus cohort categorization). Phase 2 — pricing analysis (cohort × tool × time-window analysis, reconciled against Cloudflare cost data). Phase 3 — billing meter (separate canon decision records required for unit of charge, authoritative tokenizer, identity binding, free-tier definition, drift contract).


### PR DESCRIPTION
## Summary

Phase 1 of the paid-tier observability work. Closes the verified 27% telemetry instrumentation gap by establishing the canon contract for per-`server.tool` wrapper emission. **This is the canon-only PR.** Code change (the `withTelemetry` wrapper itself plus tests and wire-edge deletion) follows in PR 2 against `klappy/oddkit` after this PR merges.

## Why

A direct query against `oddkit_telemetry` revealed that 27% of `tool_call` rows over the past 30 days carry zero `bytes_in`/`bytes_out`/`tokens_in`/`tokens_out` — 7,106 of 26,228. The four shape columns are perfectly correlated-zero. Distribution is biased toward heavy-response tools: `oddkit_challenge` 79% missing, `oddkit_gate` 75%, `oddkit_encode` 73%, `telemetry_policy` 93%. This blocks any paid-tier pricing analysis because the heaviest workloads are the most invisible.

Three confirmed root causes in `workers/src` (cited at line level in the observation):
1. **Streaming-response race** at `index.ts:1042-1066` — `responseClone.text()` resolves empty on SSE bodies.
2. **Dispatcher bypass** at `index.ts:469-573` and `575+` — `telemetry_public` and `telemetry_policy` build envelopes inline, never reach `handleUnifiedAction`.
3. **Batch attribution fiction** at `telemetry.ts:269-275` — full HTTP payload shape attributed to every JSON-RPC message in a batch.

## What's in this PR (5 files)

| File | Change | Purpose |
|------|--------|---------|
| `canon/decisions/DR-20260514-0001-telemetry-wrapper-pattern.md` | NEW (tier 2) | Locks the architecture. Rejects (A) wire-edge race fix and (B) `handleUnifiedAction` instrumentation with reasons. Adopts (C) per-tool wrapper. |
| `canon/constraints/telemetry-governance.md` | UPDATE | Adds new `## Emission Contract — Per-Tool Wrapper at Registration Site` section as the load-bearing governance. Documents the five mandatory rules: one emission point per tool, in-memory measurement, per-tools/call granularity, failure swallowed, no domain opinion. Cross-links to DR and observation. |
| `canon/observations/2026-05-14-telemetry-coverage-gap-quantified.md` | NEW (tier 2) | Diagnostic with reproducible queries and code-line citations. Records cutover date as data-accuracy boundary. Includes working learning *measure in-memory objects, not wire-edge streams* tagged for graduation to canon principle on the second case. |
| `odd/handoffs/2026-05-14-telemetry-coverage-completeness.md` | NEW (tier 2) | Execution contract for PR 2. DoD includes per-tool 95% coverage floor verified by dispatched Sonnet 4.6 read-only Managed Agent per E9 `substrate-becomes-the-wire` and `release-validation-gate`. |
| `odd/ledger/2026-05-14-telemetry-coverage-planning-session.md` | NEW (tier 3) | DOLCHEO session journal: 5 decisions, 2 observations, 3 learnings, 3 constraints, 1 handoff, 2 open threads. |

## What's NOT in this PR (deferred to PR 2)

- The `withTelemetry` wrapper code in `workers/src/telemetry.ts`.
- The `createServer` signature change and per-tool wrapping in `workers/src/index.ts`.
- The wire-edge `ctx.waitUntil` block deletion.
- Tests in `workers/test/`.
- The internals doc `docs/oddkit/internals/telemetry-architecture.md` (describes post-cutover behavior, ships with the code).
- Schema-language refresh in `docs/oddkit/tools/telemetry_public.md` and `docs/oddkit/tools/telemetry_policy.md` (same reason).

## Sequence

Per `canon-first-absolute`:
1. This PR merges first.
2. PR 2 opens against `klappy/oddkit` after this merges, against the now-final canon text.
3. PR 2 gated separately under `release-validation-gate` with per-tool 95% coverage floor and dispatched validator agent.

## Validation

- `oddkit_challenge` ran clean in planning (`block_until_addressed: false`, `governance_source: knowledge_base`, all four governance surfaces resolved from canon).
- Plan revised through one challenge cycle and one scope-consolidation cycle.
- `oddkit_gate` PASS for the planning → execution transition (prerequisites 2/2 met).
- No tier-1 canon tensions surfaced.
- Frontmatter follows native YAML types per `canon/meta/frontmatter-schema`.

## See Also

- DR: `canon/decisions/DR-20260514-0001-telemetry-wrapper-pattern.md`
- Diagnostic: `canon/observations/2026-05-14-telemetry-coverage-gap-quantified.md`
- Handoff: `odd/handoffs/2026-05-14-telemetry-coverage-completeness.md`
- Session journal: `odd/ledger/2026-05-14-telemetry-coverage-planning-session.md`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that formalize telemetry emission semantics and add planning/diagnostic records; no runtime behavior or data handling code changes in this repo.
> 
> **Overview**
> Establishes a canon contract that `tool_call` telemetry must be emitted via a per-`server.tool` `withTelemetry` wrapper (in-memory, per-`tools/call`, batch-safe) and documents the resulting cutover as a data-accuracy boundary.
> 
> Adds a decision record and a quantified observation (27% zero-shape rows with heavy-response bias) plus a Phase 1 execution handoff and session journal that define how PR 2 will implement and gate the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 449d0a073a7bd1934c804643e973f70356f8708f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->