### PR TITLE
fix(P0010): corpus frontmatter cleanup (52 of 58 findings)

### DIFF
--- a/canon/apocrypha/fragments-of-the-canon/META-ODD.md
+++ b/canon/apocrypha/fragments-of-the-canon/META-ODD.md
@@ -1,9 +1,10 @@
 ---
 uri: klappy://canon/apocrypha/fragments-of-the-canon/meta-odd
 title: "Meta-ODD: Writing Constraints for Fragments of the Canon"
+tier: 3
 voice: neutral
 stability: stable
-audience: internal
+audience: apocrypha
 purpose: guardrails
 exposure: hidden
 ---

--- a/docs/agents/README.md
+++ b/docs/agents/README.md
@@ -1,3 +1,14 @@
+---
+uri: klappy://docs/agents/README
+title: "Readme"
+audience: docs
+exposure: nav
+tier: 3
+voice: neutral
+stability: stable
+tags: ["docs", "agents", "index"]
+---
+
 # Agent Behavior & Contracts
 
 How agents think and behave in this system.

--- a/docs/agents/discovery/README.md
+++ b/docs/agents/discovery/README.md
@@ -1,3 +1,14 @@
+---
+uri: klappy://docs/agents/discovery/README
+title: "Readme"
+audience: docs
+exposure: nav
+tier: 3
+voice: neutral
+stability: stable
+tags: ["docs", "agents", "discovery", "index"]
+---
+
 # Discovery Agent Behavior
 
 Contracts and protocols for maturity-aware discovery sessions.

--- a/docs/agents/discovery/overlays/discovery-role-overlay.md
+++ b/docs/agents/discovery/overlays/discovery-role-overlay.md
@@ -4,6 +4,9 @@ version: v0
 stability: experimental
 applies_to: agent
 uri: klappy://agent-skill/overlays/discovery-role
+audience: docs
+exposure: nav
+tier: 3
 ---
 
 # Discovery Role Overlay

--- a/docs/agents/discovery/protocols/discovery-interview-protocol.md
+++ b/docs/agents/discovery/protocols/discovery-interview-protocol.md
@@ -1,4 +1,7 @@
 ---
+audience: docs
+exposure: nav
+tier: 3
 protocol: discovery-interview
 version: v0
 stability: experimental

--- a/docs/agents/odd-orchestrator.md
+++ b/docs/agents/odd-orchestrator.md
@@ -1,8 +1,10 @@
 ---
 title: ODD Orchestrator
+exposure: nav
+tier: 3
 uri: klappy://docs/agents/odd-orchestrator
 status: authoritative
-audience: agents
+audience: docs
 tags: [agent, guide, scribe, orchestrator]
 ---
 

--- a/docs/audits/pass-0-classification.md
+++ b/docs/audits/pass-0-classification.md
@@ -1,3 +1,14 @@
+---
+uri: klappy://docs/audits/pass-0-classification
+title: "Pass 0 Classification"
+audience: docs
+exposure: nav
+tier: 3
+voice: neutral
+stability: stable
+tags: ["docs", "audit", "classification"]
+---
+
 # Pass 0: Legacy Classification Table
 
 **Audit Date:** 2026-01-31 (T+0)

--- a/docs/audits/projection-inventory-2026-03-21.md
+++ b/docs/audits/projection-inventory-2026-03-21.md
@@ -1,5 +1,8 @@
 ---
 title: "Projection Inventory — Files That Should Be Generated, Not Hardcoded"
+audience: docs
+exposure: nav
+tier: 3
 type: audit
 date: 2026-03-21
 epoch: E0006

--- a/docs/book/governance-additions-2026-02-27.md
+++ b/docs/book/governance-additions-2026-02-27.md
@@ -1,3 +1,14 @@
+---
+uri: klappy://docs/book/governance-additions-2026-02-27
+title: "Governance Additions 2026 02 27"
+audience: docs
+exposure: nav
+tier: 3
+voice: neutral
+stability: stable
+tags: ["docs", "book", "governance", "session-notes"]
+---
+
 # Proposed Governance Additions — From Ch16 Session (2026-02-27)
 
 These additions encode process learnings from the first full chapter revision session.

--- a/docs/book/governance.md
+++ b/docs/book/governance.md
@@ -4,7 +4,7 @@ title: "Book Governance — Nothing New, Even AI"
 subtitle: "Editorial rules, chapter plan, distribution model, and definition of done"
 author: "Klappy"
 type: governance
-audience: internal
+audience: docs
 exposure: internal
 tier: 1
 voice: neutral

--- a/docs/examples/qa-validation-odd-vs-ddd.md
+++ b/docs/examples/qa-validation-odd-vs-ddd.md
@@ -1,8 +1,8 @@
 ---
 uri: klappy://docs/examples/qa-validation-odd-vs-ddd
 title: "From Execution to Outcome: A QA Validation Case Study"
-audience: practitioners
-exposure: examples
+audience: docs
+exposure: nav
 tier: 2
 stability: evolving
 voice: neutral

--- a/docs/oddkit/WHY.md
+++ b/docs/oddkit/WHY.md
@@ -1,7 +1,7 @@
 ---
 uri: oddkit://why
 title: "Why oddkit Exists"
-audience: human
+audience: operators
 exposure: nav
 tier: 1
 voice: neutral

--- a/docs/oddkit/epistemic-instructions.md
+++ b/docs/oddkit/epistemic-instructions.md
@@ -1,6 +1,8 @@
 ---
 uri: klappy://docs/oddkit/epistemic-instructions
 title: "oddkit Epistemic Instructions"
+exposure: nav
+tier: 2
 audience: docs
 stability: stable
 ---

--- a/docs/oddkit/evidence/challenge-governance-articles-commit.md
+++ b/docs/oddkit/evidence/challenge-governance-articles-commit.md
@@ -1,3 +1,14 @@
+---
+uri: klappy://docs/oddkit/evidence/challenge-governance-articles-commit
+title: "Challenge Governance Articles Commit"
+audience: docs
+exposure: nav
+tier: 3
+voice: neutral
+stability: stable
+tags: ["docs", "oddkit", "evidence", "gauntlet"]
+---
+
 # Gauntlet Evidence — Challenge Governance Articles Commit
 
 **Branch:** `feat/challenge-governance-articles`

--- a/docs/planning/e0007-implementation-plan.md
+++ b/docs/planning/e0007-implementation-plan.md
@@ -1,3 +1,14 @@
+---
+uri: klappy://docs/planning/e0007-implementation-plan
+title: "E0007 Implementation Plan"
+audience: docs
+exposure: nav
+tier: 3
+voice: neutral
+stability: stable
+tags: ["docs", "planning", "epoch-7", "implementation"]
+---
+
 # E0007 Implementation Plan — From Passive to Proactive
 
 ## The Big Picture

--- a/docs/planning/oddkit-full-frontmatter-and-drift-audit.md
+++ b/docs/planning/oddkit-full-frontmatter-and-drift-audit.md
@@ -1,7 +1,7 @@
 ---
 uri: klappy://docs/planning/oddkit-full-frontmatter-and-drift-audit
 title: "Planning: Stop Filtering Frontmatter — Full Metadata Indexing and Automated Drift Detection"
-audience: internal
+audience: docs
 exposure: internal
 tier: 2
 voice: neutral

--- a/odd/backlog/wish-came-true-essay-stub.md
+++ b/odd/backlog/wish-came-true-essay-stub.md
@@ -1,7 +1,7 @@
 ---
 uri: klappy://odd/backlog/wish-came-true-essay-stub
 title: "Backlog — The Wish Came True (Celebration Essay Stub)"
-audience: backlog
+audience: odd
 exposure: nav
 tier: 3
 voice: first_person

--- a/odd/constraint/use-only-what-hurts.md
+++ b/odd/constraint/use-only-what-hurts.md
@@ -1,8 +1,8 @@
 ---
 uri: klappy://odd/constraint/use-only-what-hurts
 title: "Use Only What Hurts"
-audience: system
-exposure: constraint
+audience: odd
+exposure: nav
 tier: 1
 voice: direct
 stability: constrained

--- a/odd/handoffs/2026-05-14-telemetry-coverage-completeness.md
+++ b/odd/handoffs/2026-05-14-telemetry-coverage-completeness.md
@@ -1,7 +1,7 @@
 ---
 uri: klappy://odd/handoffs/2026-05-14-telemetry-coverage-completeness
 title: "Handoff — Telemetry Coverage Completeness (Phase 1)"
-audience: handoff
+audience: odd
 exposure: nav
 tier: 2
 voice: terse

--- a/odd/handoffs/2026-05-16-mcp-bearer-token-middleware.md
+++ b/odd/handoffs/2026-05-16-mcp-bearer-token-middleware.md
@@ -1,7 +1,7 @@
 ---
 uri: klappy://odd/handoffs/2026-05-16-mcp-bearer-token-middleware
 title: "Handoff — MCP Server Bearer-Token Middleware (Supabase JWT + PAT Validation)"
-audience: handoff
+audience: odd
 exposure: nav
 tier: 2
 voice: terse

--- a/odd/ledger/2026-03-21-drift-audit-session.md
+++ b/odd/ledger/2026-03-21-drift-audit-session.md
@@ -1,8 +1,9 @@
 ---
 uri: klappy://odd/ledger/2026-03-21-drift-audit-session
 title: "Session Ledger — Drift Audit, Supersession Method, and Learning in Public"
+tier: 3
 type: ledger
-audience: internal
+audience: odd
 exposure: internal
 epoch: E0006
 date: 2026-03-21

--- a/odd/ledger/2026-04-03-e0007-the-gauntlet-should-run-itself.md
+++ b/odd/ledger/2026-04-03-e0007-the-gauntlet-should-run-itself.md
@@ -1,3 +1,14 @@
+---
+uri: klappy://odd/ledger/2026-04-03-e0007-the-gauntlet-should-run-itself
+title: "2026 04 03 E0007 The Gauntlet Should Run Itself"
+audience: odd
+exposure: nav
+tier: 3
+voice: neutral
+stability: stable
+tags: ["odd", "ledger", "session", "epoch-7"]
+---
+
 # OLDC+H — 2026-04-03 — E0007 Declared: The Gauntlet Should Run Itself
 
 ## Observations

--- a/odd/ledger/2026-04-09-managed-agents-session.md
+++ b/odd/ledger/2026-04-09-managed-agents-session.md
@@ -1,3 +1,14 @@
+---
+uri: klappy://odd/ledger/2026-04-09-managed-agents-session
+title: "2026 04 09 Managed Agents Session"
+audience: odd
+exposure: nav
+tier: 3
+voice: neutral
+stability: stable
+tags: ["odd", "ledger", "session", "managed-agents"]
+---
+
 # DOLCHE — One Hour with Claude Managed Agents
 
 **Date:** 2026-04-09

--- a/odd/ledger/2026-04-13-swarm-spike.md
+++ b/odd/ledger/2026-04-13-swarm-spike.md
@@ -1,3 +1,14 @@
+---
+uri: klappy://odd/ledger/2026-04-13-swarm-spike
+title: "2026 04 13 Swarm Spike"
+audience: odd
+exposure: nav
+tier: 3
+voice: neutral
+stability: stable
+tags: ["odd", "ledger", "session", "swarm", "truthkit"]
+---
+
 # Session Journal — April 13, 2026
 
 ## TruthKit Swarm Architecture Review & Spike Planning

--- a/odd/ledger/2026-04-20-p1-3-3-challenge-canon-parity-landed.md
+++ b/odd/ledger/2026-04-20-p1-3-3-challenge-canon-parity-landed.md
@@ -1,7 +1,7 @@
 ---
 uri: klappy://odd/ledger/2026-04-20-p1-3-3-challenge-canon-parity-landed
 title: "P1.3.3 Closeout — Challenge Canon-Parity (D5 + D9 + Cache-Fetches-and-Parses), Plus the Process Failure That Made the Release-Validation-Gate Canon Necessary"
-audience: ledger
+audience: odd
 exposure: nav
 tier: 3
 voice: neutral

--- a/odd/ledger/2026-04-20-p1-3-4-encode-canon-parity-landed.md
+++ b/odd/ledger/2026-04-20-p1-3-4-encode-canon-parity-landed.md
@@ -1,7 +1,7 @@
 ---
 uri: klappy://odd/ledger/2026-04-20-p1-3-4-encode-canon-parity-landed
 title: "P1.3.4 Closeout — Encode Canon-Parity (D5 Phrase-Subset Matcher + D9 cachedEncodingTypes Removal), Plus Second Application of Release-Validation-Gate Canon, Plus the 0.22.0-Parallel-Release Version Collision"
-audience: ledger
+audience: odd
 exposure: nav
 tier: 3
 voice: neutral

--- a/odd/ledger/2026-04-20-post-4-7-proactive-loop-experience.md
+++ b/odd/ledger/2026-04-20-post-4-7-proactive-loop-experience.md
@@ -1,6 +1,8 @@
 ---
 uri: klappy://odd/ledger/2026-04-20-post-4-7-proactive-loop-experience
 title: "Observation — Six Sessions of Proactive Loop Since Opus 4.7: Trust Gained, Verbosity Cost, Checkpoint Shape Revealed"
+audience: odd
+exposure: nav
 date: 2026-04-20
 tags:
   - odd

--- a/odd/ledger/2026-04-30-encode-vodka-refactor-phase-2-landed.md
+++ b/odd/ledger/2026-04-30-encode-vodka-refactor-phase-2-landed.md
@@ -1,7 +1,7 @@
 ---
 uri: klappy://odd/ledger/2026-04-30-encode-vodka-refactor-phase-2-landed
 title: "E0008.4 Phase 2 Closeout — Encode Items 1–4 (governance_uris Plural, (letter,facet) Dedup, Open in Fallback, governance_extended Self-Teaching), Item 5 Deferred to 0.29.0, Two Bugbot Findings Autofix-Forwarded, Validator PASS, Prod Promotion Outstanding"
-audience: ledger
+audience: odd
 exposure: nav
 tier: 3
 voice: neutral

--- a/odd/ledger/2026-05-07-pr177-validation-review.md
+++ b/odd/ledger/2026-05-07-pr177-validation-review.md
@@ -1,7 +1,8 @@
 ---
 uri: klappy://odd/ledger/2026-05-07-pr177-validation-review
 title: "PR #177 Validation Review — Audit Gates Are Managed Agents (klappy.dev)"
-audience: ledger
+tier: 3
+audience: odd
 exposure: nav
 voice: neutral
 stability: stable

--- a/odd/ledger/2026-05-10-software-virtues-canon-package.md
+++ b/odd/ledger/2026-05-10-software-virtues-canon-package.md
@@ -1,7 +1,7 @@
 ---
 uri: klappy://odd/ledger/2026-05-10-software-virtues-canon-package
 title: "Ledger — Software Virtues Canon Package + Essay (Session 2026-05-10)"
-audience: ledger
+audience: odd
 exposure: nav
 tier: 3
 voice: neutral

--- a/odd/ledger/2026-05-11-agent-runtime-exploration.md
+++ b/odd/ledger/2026-05-11-agent-runtime-exploration.md
@@ -1,7 +1,7 @@
 ---
 uri: klappy://odd/ledger/2026-05-11-agent-runtime-exploration
 title: "Journal — 2026-05-11 Exploration: agent-runtime, Project Think, and Canon Alignment"
-audience: ledger
+audience: odd
 exposure: nav
 tier: 3
 voice: neutral

--- a/odd/ledger/2026-05-11-trigger-taxonomy-drafting.md
+++ b/odd/ledger/2026-05-11-trigger-taxonomy-drafting.md
@@ -1,7 +1,7 @@
 ---
 uri: klappy://odd/ledger/2026-05-11-trigger-taxonomy-drafting
 title: "Session Ledger — 2026-05-11 Drafting trigger-source-taxonomy"
-audience: ledger
+audience: odd
 exposure: nav
 tier: 3
 voice: neutral

--- a/odd/ledger/2026-05-14-telemetry-coverage-planning-session.md
+++ b/odd/ledger/2026-05-14-telemetry-coverage-planning-session.md
@@ -1,7 +1,7 @@
 ---
 uri: klappy://odd/ledger/2026-05-14-telemetry-coverage-planning-session
 title: "Session Journal — Telemetry Coverage Completeness Planning"
-audience: journal
+audience: odd
 exposure: nav
 tier: 3
 voice: terse

--- a/odd/ledger/2026-05-15-cutover-validation-session.md
+++ b/odd/ledger/2026-05-15-cutover-validation-session.md
@@ -1,7 +1,7 @@
 ---
 uri: klappy://odd/ledger/2026-05-15-cutover-validation-session
 title: "Session Ledger — Cutover Validation, Canon Authoring, Wrapper Smoke (2026-05-15 to 2026-05-16)"
-audience: ledger
+audience: odd
 exposure: nav
 tier: 3
 voice: neutral

--- a/odd/ledger/e0007-handoff-bootstrap.md
+++ b/odd/ledger/e0007-handoff-bootstrap.md
@@ -1,3 +1,14 @@
+---
+uri: klappy://odd/ledger/e0007-handoff-bootstrap
+title: "E0007 Handoff Bootstrap"
+audience: odd
+exposure: nav
+tier: 3
+voice: neutral
+stability: stable
+tags: ["odd", "ledger", "handoff", "epoch-7", "bootstrap"]
+---
+
 # E0007 Handoff Bootstrap — From Passive to Proactive
 
 ## What happened

--- a/odd/odd-compared.md
+++ b/odd/odd-compared.md
@@ -1,3 +1,14 @@
+---
+uri: klappy://odd/odd-compared
+title: "Odd Compared"
+audience: odd
+exposure: nav
+tier: 2
+voice: neutral
+stability: stable
+tags: ["odd", "comparison", "methodology", "overview"]
+---
+
 # ODD Compared: What It Is, What It Isn't, and How It Relates to Everything Else
 
 > ODD is about preserving intent without freezing execution. The measure of success is not how elegant the artifact is, but whether the outcome holds up in the real world.

--- a/writings/README.md
+++ b/writings/README.md
@@ -1,6 +1,7 @@
 ---
 uri: klappy://writings
 title: "Writings"
+tier: 3
 audience: public
 exposure: nav
 tags: ["writings", "index", "essays"]


### PR DESCRIPTION
## P0010 corpus cleanup — 52 of 58 retrieval-readiness findings

Fixes the structural-field drift the retrieval-readiness audit (#219) surfaced, clearing the path for the contract to eventually enforce. **6 findings deliberately left** — the `about/` pages (`tier: 0`, `kind: unknown`) stay flagged because they are slated to move to a separate KB rather than be patched with schema changes. The audit keeps surfacing them as a standing marker of that unfinished split.

### Fixes by pattern (37 files)

| Pattern | Count | Fix |
|---|---|---|
| `fm-missing` | 11 | Added complete frontmatter (READMEs, planning, audit, book-session notes, gauntlet evidence, 5 pre-schema ledger docs) |
| `audience-invalid` | 20 | `ledger`/`handoff`/`journal`/`system`/`backlog` → `odd`; `agents` → `docs`; `practitioners` → `docs`; `human` → `operators`; `internal` → `docs`/`apocrypha` per role |
| `tier-missing` | 9 | Backfilled from directory convention (`odd/*` = 3, `docs/*` = 3) |
| `exposure-missing` | 6 | Backfilled (`nav`) |
| `audience-missing` | 4 | Backfilled from path |
| `exposure-invalid` | 2 | `examples`/`constraint` → `nav` |

### Verification
- Existing `validate-frontmatter.py` still passes on `writings/` (41 files, 0 findings) — the hard-block gate is unaffected
- All edited YAML parses cleanly (0 errors)
- Retrieval-readiness audit drops **58 → 6** blocking (the 6 remaining are all `about/`, by design)

### What this does NOT do
- Does not touch `about/` — that's the KB-split debt, kept visible
- Does not change the schema — every fix uses existing valid enum values
- Does not change `stability` values flagged informally (out of the audit's scope)

Depends on #219 (the audit) for context but is independently mergeable. Next: once both land, flip the audit to `--strict` for the knowledge corpus (excluding `about/` until the split).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only YAML edits using existing enum values; no application code, schema changes, or `about/` pages touched.
> 
> **Overview**
> This PR normalizes **YAML frontmatter** across the knowledge corpus so retrieval and future strict audits can rely on consistent **`audience`**, **`tier`**, and **`exposure`** (and related fields) without changing document bodies or the schema.
> 
> **Eleven files** that had no frontmatter now get full blocks (agent READMEs, audits, planning, gauntlet evidence, several **`odd/ledger`** entries). **Twenty files** replace non-schema **`audience`** values (`internal`, `handoff`, `ledger`, `agents`, `practitioners`, `human`, `system`, `backlog`, etc.) with allowed values—mostly **`odd`** for handoffs/ledgers/constraints and **`docs`** for agent/orchestrator material; **`operators`** for **`docs/oddkit/WHY.md`**; **`apocrypha`** for Meta-ODD. **`tier`** and **`exposure`** are backfilled where missing (typically **`nav`** and tier **3** per path convention). Invalid **`exposure`** values like **`examples`** / **`constraint`** move to **`nav`**.
> 
> Per the PR description, **six `about/` findings stay open** on purpose (KB split debt). Existing **`writings/`** frontmatter validation is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8faeab7afd0a2d79da6cedf502d2caee1fa49b9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->