### PR TITLE
E0009: Triangle of Yaps — communication canon for entry-layer presentation

### DIFF
--- a/canon/meta/triangle-of-yaps.md
+++ b/canon/meta/triangle-of-yaps.md
@@ -1,0 +1,145 @@
+---
+uri: klappy://canon/meta/triangle-of-yaps
+title: "The Triangle of Yaps — One Thought, One Illustration, One Next Step"
+audience: canon
+exposure: nav
+tier: 2
+voice: neutral
+stability: experimental
+tags: ["canon", "meta", "writing", "communication", "essays", "podcast", "scripts", "triangle-of-yaps", "rhetoric"]
+epoch: E0009
+date: 2026-06-04
+source: "Adapted from the 'Triangle of Yapping' communication framework popularized on social media by @iamjadenly. Borrowed, not invented; mapped onto ODD's creed and axioms."
+derives_from: "canon/values/axioms.md, canon/values/orientation.md, canon/meta/writing-canon.md"
+complements: "canon/meta/writing-canon.md, canon/constraints/ai-voice-cliches.md, canon/methods/choosing-the-right-narrative-container.md, canon/constraints/dual-context-writing.md"
+governs: "The rhetorical shape of any single unit of spoken or written communication produced for klappy.dev — podcast script segments, published essays, and the standalone sections within them. Governs engagement structure; subordinate to writing-canon, which governs document structure."
+constraint: "This document cannot override the axioms or the Writing Canon. Where the Triangle and progressive disclosure conflict, progressive disclosure governs structure and the axioms govern truth."
+---
+
+# The Triangle of Yaps — One Thought, One Illustration, One Next Step
+
+> Every unit of communication carries one Thought or Topic (T or T), pays it down with a Metaphor, Analogy, Example, or Story (M-A-E-S), and closes with an Application or Next step (A or N). A yap with no single thought is noise; a thought with no illustration is an unpaid claim; an illustration with no next step is a claim that never became an outcome. The three corners map one-to-one onto the creed: name what you have observed, prove it with something concrete, and discharge it into action.
+
+---
+
+## Summary — Three Corners That Turn a Yap into an Outcome
+
+The Triangle of Yaps is a constraint on the shape of a single communication unit: a podcast segment, an essay, or a self-contained section inside either. It is not a document-structure rule — that is the job of the Writing Canon (`canon/meta/writing-canon.md`). It is an engagement rule, governing whether the words earn the listener's attention and leave them able to act.
+
+The three corners are:
+
+- **T or T — Thought or Topic.** One idea, with a stance. Not a list of three things you could have said; the single thing you are saying.
+- **M-A-E-S — Metaphor, Analogy, Example, or Story.** The concrete vehicle that lets the audience verify the thought against their own experience instead of taking it on assertion.
+- **A or N — Application or Next step.** What the audience does now. This is the outcome the whole unit existed to produce.
+
+The framework is borrowed from a social-media communication format and earns its place in canon because it is the rhetorical expression of ODD's epistemics. The apex is a claim, and a claim is a debt (Axiom 2). The illustration is the proof that pays the debt (Axiom 4, and the creed's "before I confirm, I prove"). The next step is the outcome — and in Outcomes-Driven Development, a unit of communication that produces no outcome is the kind of shortcut that always costs more later (Axiom 3).
+
+Run the triangle on anything before you publish or record it. If you cannot name the one thought, find the illustration that makes it land, and state the one next step, the unit is not ready.
+
+---
+
+## The Three Corners
+
+### T or T — One Thought or Topic, Not a Pile of Points
+
+A unit carries exactly one load-bearing idea. The topic is what it is about; the thought is the stance you take on it. "Caching" is a topic. "A cache that outlives its source is a lie you tell on a schedule" is a thought. The triangle requires the thought, not just the topic.
+
+The discipline here is subtractive. Most weak segments fail because they carry three half-thoughts instead of one whole one. When you find a second load-bearing idea, it does not get crammed into the same corner — it becomes its own triangle, its own segment, its own section. One apex per triangle.
+
+This corner is the rhetorical twin of the Writing Canon's Tier 1 and Tier 2: a title that names the concept and its stance, and a blockquote that states the complete claim. If you can write the apex as one sentence a listener could repeat to a friend, the corner is satisfied.
+
+### M-A-E-S — Metaphor, Analogy, Example, or Story Pays the Claim Down
+
+The apex is an assertion, and an assertion the audience cannot check is something they have to either trust or ignore. The base-right corner removes that bind. A metaphor, analogy, example, or story re-renders the abstract claim as something concrete enough that the listener can observe it against their own experience and confirm it for themselves.
+
+The four are a menu, not a checklist — pick the one that fits the thought:
+
+- **Metaphor** — name the thing as another thing ("a stale cache is a photograph of a room you've already left").
+- **Analogy** — map the structure of a familiar thing onto the unfamiliar one ("frontmatter is to a document what a passport is to a traveler").
+- **Example** — a real, specific instance ("the three canon docs we shipped in February that failed every disclosure tier").
+- **Story** — a sequence with a turn ("I planned the write path for months, then deleted the branch — here's what changed").
+
+This corner is where the creed's fifth line bites: *what I have not verified, I will not imply.* A vivid illustration can smuggle in more certainty than the thought has earned. The story must be honest to the strength of the claim — a metaphor that overstates is a debt taken out in the audience's name.
+
+### A or N — Application or Next Step Is the Outcome the Yap Was For
+
+The base-left corner is the one most writers drop, and dropping it is why so much fluent content changes nothing. **A** is application: how the idea is used in the audience's own situation. **N** is the next step: the specific thing to do next. One of the two must be present and explicit.
+
+In Outcomes-Driven Development this corner is not a nicety — it is the point. The thought was the claim; the illustration was the proof; the next step is the outcome that discharges the whole transaction. A unit that informs without enabling action has performed communication without producing it. It feels efficient because something was said, but it leaves the real work undone, which is the exact failure mode Axiom 3 names: shortcuts on the substance always cost more than doing it properly the first time.
+
+---
+
+## How the Triangle Maps to the Creed and the Four Axioms
+
+The Triangle is not a separate value system bolted onto canon. It is the creed (`canon/values/orientation.md`) applied to the act of explaining something to another person:
+
+| Corner | Creed line | Axiom |
+|--------|-----------|-------|
+| T or T — Thought or Topic | "Before I speak, I observe." | Axiom 2 — A Claim Is a Debt |
+| M-A-E-S — illustration | "Before I confirm, I prove." | Axiom 4 — You Cannot Verify What You Did Not Observe |
+| A or N — next step | (the outcome the claim was for) | Axiom 3 — Integrity Is Non-Negotiable Efficiency |
+| Honest illustration | "What I have not verified, I will not imply." | Axiom 1 — Reality Is Sovereign |
+
+Read top to bottom, the triangle is the creed in motion: observe a real thought, prove it with something concrete, discharge it into an outcome, and never let the illustration imply more than you have earned.
+
+---
+
+## Applying the Triangle to a Podcast Script
+
+A script is a sequence of triangles, one per segment, not one triangle stretched over an episode. Outline the episode as a list of apexes first — the thoughts, in order. Each apex then gets its own illustration and its own next step before the next segment begins.
+
+A worked segment:
+
+- **T or T:** "Your videos flop when they end on the explanation instead of the instruction."
+- **M-A-E-S:** "It's like handing someone a map and walking off before you've told them where they're going."
+- **A or N:** "Before you publish your next one, write the last line first — make it the single thing you want them to do."
+
+The transition into the next segment is the previous segment's next step landing, then a new apex. If a segment has no next step, it is either filler to cut or two segments wearing one coat.
+
+## Applying the Triangle to an Essay
+
+In an essay, the triangle operates at two scales. The essay as a whole has one apex (its thesis), one governing illustration (its central example or story), and one application (what the reader does differently). Each section then runs its own smaller triangle inside that frame.
+
+Because klappy.dev essays are dual-context — the same file renders as a book chapter and a standalone web essay (`canon/constraints/dual-context-writing.md`) — the next-step corner stays grounded in the reader's own work rather than in "the next chapter." The application a reader can act on travels with them regardless of where they found the piece; a pointer to surrounding navigation does not.
+
+## Where the Triangle and Progressive Disclosure Meet
+
+The two frameworks govern different axes of the same artifact and reinforce each other. The Writing Canon governs **structure** — can each extraction tier be acted on alone. The Triangle governs **engagement** — does the prose earn attention and produce an outcome. They line up cleanly: the apex is the title-and-blockquote claim, the illustration is the body that proves it, and the next step is what the summary leaves the reader able to do. A unit that passes the Triangle but fails progressive disclosure reads well and extracts badly. A unit that passes disclosure but fails the Triangle extracts cleanly and persuades no one. Publishable work passes both.
+
+---
+
+## The Tension — Engagement Compresses, Proof Demands Room
+
+Epistemic rigor and engagement pull against each other, and the Triangle sits on the fault line. A claim is a debt (Axiom 2), and paying it down takes evidence, qualification, and detail — the very things that make a reader's attention drift. The Triangle's compression is what holds that attention, and the same compression leaves almost no room for the proof a rigorous claim requires. Push the full detail in and you lose the reader; strip it out to keep them and you have engagement resting on nothing. Both failures are real, and pretending the Triangle resolves them on its own would be its own kind of dishonesty.
+
+The resolution is to stop treating one triangle as the whole act of communication. The Triangle is the entry point, not the destination. Its job is to earn enough attention and trust that the reader chooses to go deeper, and the corner that performs the handoff is A or N. The next step of the last triangle is not "now you are done" — it is "here is where the proof lives." The engagement layer draws them in; the deeper tiers carry the evidence. This is the same descent the Writing Canon (`canon/meta/writing-canon.md`) already defines: title and blockquote are the hook, the body and its citations are the proof, and progressive disclosure is the staircase between them. The Triangle governs the top of that staircase. It is not responsible for what gets proven three flights down — only for making the first step worth taking.
+
+This is why the Triangle recurses. A whole essay is one triangle whose next step points into its sections; each section is a triangle whose next step points into its evidence; the homepage overview is a triangle whose call to action points into the essay. At every level the shape is the same — hook, illustration, handoff — and the proof is never inside the triangle. It is always one level down. The triangle's only obligation is to make the descent worth taking.
+
+So the scope is deliberately provisional: we apply the Triangle universally without claiming it is universal. It is the default lens for the entry layer of anything we present, used everywhere until a specific case disconfirms it or a better framework earns the slot. Universal application is a working practice; universal truth is not a claim being made here. The retraction condition below is what keeps the practice honest.
+
+---
+
+## Constraints — One Triangle per Unit, Honest Illustrations, Subordinate to the Axioms
+
+The Triangle is illustrative guidance for the shape of communication, not a higher authority than the values it expresses.
+
+- **One apex per unit.** A second load-bearing thought is a second triangle. Do not overload a corner.
+- **The illustration must be honest to the claim's strength.** A metaphor that implies certainty the thought has not earned violates the creed's fifth line and must be weakened or replaced.
+- **The next step must be real.** A vague "go think about this" is a dropped corner dressed as a present one. If there is genuinely no application yet, that is a signal the thought is not ready to publish, not a license to skip the corner.
+- **Subordinate to the Writing Canon and the axioms.** Where the Triangle and progressive disclosure pull in different directions, progressive disclosure governs structure. Where either pulls against the axioms, the axioms govern. This document cannot override them.
+- **Not every unit is a triangle.** Some communication is not trying to move anyone — a lament, a raw field note, a reference entry you consult rather than read. Forcing the next-step corner onto those deforms them. The Triangle governs communication meant to persuade or enable action; outside that scope it does not apply, and saying so is not a loophole.
+- **Experimental, with a named retraction condition.** This mapping rests on two worked contexts so far — the weekly audio overview and essay structure — so it is a working hypothesis, not a settled law. Retire or revise it if applying the three corners in practice produces flatter or less honest communication than unstructured drafting, or if the creed mapping starts to read as retrofitted rather than load-bearing. Drift is a signal that it is being used, not that it has failed.
+
+---
+
+## Checklist — Before Publishing an Essay or Recording a Script
+
+1. **Apex test:** Can you state the one thought as a single sentence a listener could repeat? If there are two, split into two units.
+2. **Illustration test:** Does a metaphor, analogy, example, or story let the audience verify the thought against their own experience, rather than take it on assertion?
+3. **Honesty test:** Does the illustration imply only as much certainty as the thought has earned? (Creed line five.)
+4. **Next-step test:** Is there an explicit application or next step the audience can act on? Is it real, not "go reflect"?
+5. **Outcome test:** If the audience did nothing differently after this unit, did the unit have a point? If not, the A-or-N corner is missing.
+6. **Disclosure alignment:** Does the apex match the title/blockquote, the illustration sit in the body, and the next step survive in the summary? (See `canon/meta/writing-canon.md`.)
+7. **Ghost-writer test:** Does the illustration sound like the author or like a model? Watch for clustered AI-voice patterns. (See `canon/constraints/ai-voice-cliches.md`.)
+8. **Scale test (essays):** Does the whole essay run one triangle, and does each section run its own inside it?

--- a/canon/methods/triangle-pass.md
+++ b/canon/methods/triangle-pass.md
@@ -1,0 +1,104 @@
+---
+uri: klappy://canon/methods/triangle-pass
+title: "The Triangle Pass — Introduce a Topic as a Door Into the Proof, Not a Replacement for It"
+audience: canon
+exposure: nav
+tier: 2
+voice: neutral
+stability: experimental
+tags: ["canon", "methods", "triangle-of-yaps", "presentation", "introduction", "guide-posture", "audio-overview", "podcast", "entry-layer"]
+epoch: E0009
+date: 2026-06-04
+derives_from: "canon/meta/triangle-of-yaps.md, canon/constraints/guide-posture.md, canon/meta/writing-canon.md"
+complements: "canon/methods/choosing-the-right-narrative-container.md, canon/constraints/ai-voice-cliches.md, docs/audits/guide-posture-audit.md"
+governs: "How any topic is introduced and presented at the entry layer for klappy.dev — the weekly audio overview, the opening of an essay or section, a talk intro, a tool or onboarding intro. Governs the entry and the handoff, not the proof the handoff points to."
+constraint: "Subordinate to canon/meta/triangle-of-yaps.md, canon/constraints/guide-posture.md, canon/meta/writing-canon.md, and the axioms. Where any of those conflict with this method, they govern."
+---
+
+# The Triangle Pass — Introduce a Topic as a Door Into the Proof, Not a Replacement for It
+
+> Introducing a topic is one move with two failure modes: prove too much and the audience leaves before you finish; prove too little and you have attention resting on nothing. The Triangle Pass resolves this by treating the introduction as a door, not the house. Five moves: name one thought, open on the audience's stake, make it land once, point the door at where the proof actually lives, and stop before you prove. The introduction's whole job is to make the next step worth taking — not to settle the matter.
+
+---
+
+## Summary — A Five-Step Pass for Opening a Topic Without Trying to Prove It
+
+An introduction lives at the entry layer, where the audience has not yet agreed to spend their attention. That layer has its own discipline, and it is mostly restraint. The Triangle Pass is the reusable production step for getting it right.
+
+The pass runs the Triangle of Yaps (`canon/meta/triangle-of-yaps.md`) in the one place it is most tempted to overreach: the opening. It enforces the resolution to the engagement-versus-proof tension — the introduction is the door, the proof is the house, and the next-step corner is the threshold between them. You win enough attention and trust to make someone step through, then you point them at where the evidence actually lives. You do not drag the proof out onto the doorstep.
+
+The five moves are: (1) name the one thought, (2) open on the audience's stake, not the system, (3) make it land once with a single illustration, (4) point the door at real proof, (5) stop before you prove. Run them in order, then check the result against the pass checklist before you publish or record. The pass applies at every scale, because introductions nest: a weekly overview opens the door to an essay, an essay opens the door to a section, a section opens the door to its evidence.
+
+---
+
+## What the Pass Is For — The Entry Layer, Where Attention Is Won or Lost
+
+Most presentation advice assumes the audience is already listening. The entry layer cannot assume that. A homepage visitor, a podcast listener in the first ten seconds, a reader scanning the opening paragraph — none of them have committed. The job of an introduction is narrow and specific: convert a non-committed audience into one that chooses to go deeper.
+
+This is not the place to be thorough. Thoroughness is what the audience earns access to by stepping through the door. An introduction that front-loads evidence has confused the entry layer with the destination, and it loses the people it was built to bring in. The Triangle Pass exists to hold that line.
+
+## The Pass — Five Moves From Cold Open to Open Door
+
+### One — Name the One Thought
+
+State the single framing claim of the topic in a sentence the audience could repeat to someone else. If the introduction covers several items, the whole introduction still gets one framing thought, and each item underneath it gets its own. If you cannot say it in one sentence, you are holding more than one topic and the opening will blur.
+
+### Two — Open on Their Stake, Not the System
+
+The audience is the hero (`canon/constraints/guide-posture.md`). Lead with what is at stake for them — the friction they feel, the question they already have — before any system name, feature, or internal concept. The moment the first thing they encounter is "here is what we built," posture is broken and the door is heavier to open.
+
+### Three — Make It Land Once
+
+Pay the thought down with exactly one illustration: a metaphor, analogy, example, or story (the M-A-E-S corner). One. The illustration's job at the entry layer is recognition, not proof — it lets the audience feel the thought is real enough to be worth pursuing. A second illustration is a sign you are trying to win the argument in the doorway.
+
+### Four — Point the Door at Real Proof
+
+The next step (the A-or-N corner) names where the proof lives: read the essay, open the canon doc, see the data, listen to the full segment. This is the threshold. The introduction does not carry the evidence; it carries the address of the evidence. The handoff is the entire reason the entry layer is allowed to be light.
+
+### Five — Stop Before You Prove
+
+This is the move that takes discipline. The instant you find yourself explaining the evidence, qualifying the claim, or walking through the detail, you have crossed your own threshold and pulled the audience past it. Cut it. Move it behind the door. An introduction that proves is no longer an introduction.
+
+## Running the Pass on the Weekly Audio Overview
+
+The weekly "this week on Klappy.dev" overview is the canonical surface for this method, because audio punishes overreach faster than text — a listener cannot skim past a paragraph of proof, they just leave.
+
+Structure the overview as nested triangles:
+
+- **Open (one framing thought + their stake).** One or two sentences on why this week is worth ninety seconds to the listener, not a table of contents of what shipped.
+- **Each item (one thought, one illustration, one door).** Roughly fifteen to twenty-five seconds: the single thought, one quick illustration that makes it land, and the door — "the full story is in this week's essay." Three to five items, each its own triangle.
+- **Close (one next step).** The single thing to read or do first. Not a recap of everything; the one door you most want opened.
+
+The overview is the purest test of the method, because its only legitimate output is doors. Nothing in it should be the proof. Everything in it should make a specific piece of proof worth opening.
+
+## The Door Must Open Onto Something Real
+
+The one way this method fails dishonestly: a door that opens onto nothing. If the next step points to an essay that does not exist, a dataset that was never published, or a claim that is not actually supported anywhere downstream, the introduction has faked its strongest corner. A claim is a debt (`canon/values/axioms.md`, Axiom 2), and the door is a promise that the debt is paid somewhere the audience can reach. Promising proof you have not produced is the entry-layer version of lying.
+
+So the pass has a precondition as well as a checklist: before you point a door, confirm the proof behind it is real and reachable. If it is not, you do not have an introduction yet — you have an unpaid claim wearing a confident opening.
+
+---
+
+## Constraints — Restraint at the Entry Layer, Subordinate to the Triangle and the Axioms
+
+This method governs the introduction and the handoff. It does not govern the proof, and it cannot override the documents it derives from.
+
+- **The entry layer is for restraint.** When the pull to prove conflicts with the pull to be heard, at the entry layer being heard wins — because the proof is not lost, it is one step away behind the door.
+- **Every door must open onto real, reachable proof.** No exceptions. A door onto nothing is a faked next-step corner.
+- **One framing thought, one illustration per unit.** Overloading the opening is the most common way the pass is broken.
+- **The audience is the hero.** If the introduction centers the system before the audience's stake, it fails guide posture regardless of how well it runs the other four moves.
+- **Sounds like a person, not a model.** Especially in audio. Run the result against the ghost-writer test (`canon/constraints/ai-voice-cliches.md`).
+- **Restraint is the right bias for uncommitted audiences; it is the wrong bias for two specific cases.** When the audience is skeptical or adversarial — a technical reviewer, an investor, someone who needs a credential before they trust the hook — light engagement before proof can read as hand-wavy and undermine rather than earn trust. Proof first may be correct there. When the audience is already inside — returning canon readers, the internal team — the door framing is unnecessary and can feel patronizing. The pass governs the entry layer for audiences who have not yet committed; it does not govern surfaces where commitment is already established or where credibility must precede engagement. If the restraint bias is wrong for a given surface, the whole pass is the wrong tool — what falls is not one move but the method's premise. Name the audience clearly before applying it.
+- **Experimental, applied universally until disconfirmed.** This is the default method for the entry layer, used everywhere until a specific case disconfirms it or a better one earns the slot. Universal use is the practice; universal truth is not the claim. Retire or revise it if introductions built this way consistently convert worse than introductions that do not, or if a topic type emerges where the door-and-house split does not hold.
+
+---
+
+## Checklist — Before You Publish or Record an Introduction
+
+1. **One thought:** Can the audience repeat the framing claim in a sentence? (For multi-item formats: one framing thought overall, one per item.)
+2. **Their stake first:** Does the opening lead with the audience's pain or question, not the system?
+3. **One illustration:** Is there exactly one metaphor, analogy, example, or story, and is it honest to the claim's strength?
+4. **The door:** Does the next step name where the proof lives — and does that proof actually exist and reach?
+5. **Restraint:** Did you stop before proving? If evidence or qualification crept in, cut it and move it behind the door.
+6. **Recursion:** At this scale, does the door hand off to the right next scale — overview to essay, essay to section, section to evidence?
+7. **Ghost-writer:** Read aloud, does it sound like a person talking? (See `canon/constraints/ai-voice-cliches.md`.)

--- a/writings/the-triangle-i-found-while-scrolling.md
+++ b/writings/the-triangle-i-found-while-scrolling.md
@@ -1,0 +1,88 @@
+---
+uri: klappy://writings/the-triangle-i-found-while-scrolling
+title: "The Triangle I Found While Scrolling — A Lens for Making What You Know Land"
+subtitle: "A borrowed framework that sharpened the layer I was weakest at: presenting what I already knew"
+author: Klappy
+type: essay
+audience: public
+exposure: public
+public: true
+tier: 3
+voice: first_person
+stability: draft
+tags: ["writings", "essay", "triangle-of-yaps", "communication", "guide-posture", "storybrand", "presentation", "podcast", "borrow"]
+epoch: E0009
+date: 2026-06-04
+derives_from: "canon/meta/triangle-of-yaps.md, canon/constraints/guide-posture.md, canon/values/orientation.md"
+complements: "canon/meta/writing-canon.md, writings/the-feature-i-never-shipped.md"
+status: active
+hook: "You know your material cold. So why does it slide right off people the moment you present it? I kept hitting that wall — and a 60-second video handed me the lens I reach for now."
+description: "A reader-first origin story for the Triangle of Yaps in Klappy canon. A borrowed social-media framework — one thought, one illustration, one next step — didn't replace disciplined thinking; it added the presentation layer that turns a correct point into one people stay with."
+slug: the-triangle-i-found-while-scrolling
+og_title: "The Triangle I Found While Scrolling — A Lens for Making What You Know Land"
+og_description: "You can be right and still lose the room. A 60-second video gave me the lens I reach for now: one thought, one illustration, one next step."
+---
+
+# The Triangle I Found While Scrolling — A Lens for Making What You Know Land
+
+> You've done the work. You know your material cold. So why does it slide right off people the moment you present it — on a call, on a page, in the overview nobody finishes? I kept hitting that wall turning written work into something worth hearing. A 60-second video handed me the piece I'd been missing: one thought, one illustration, one next step. It didn't change what I knew. It sharpened the layer I'd always been weakest at — the move from *true* to *lands*.
+
+---
+
+## Summary — A Borrowed Lens That Layers Onto What You Already Do Well
+
+Have you ever been completely right and still watched the room drift? That gap usually opens one layer up from your knowledge — in how the idea gets presented, the work of turning a correct thought into one a listener stays with.
+
+This essay hands you a filter I borrowed from a stranger on the internet and brought into our canon. Three corners: a single thought, an illustration that makes it land, and a next step the audience can act on. It doesn't replace the way you already structure your thinking. It sits on top of it as a new lens — and for me, it sharpened the exact layer I was least fluent in. If you make anything meant to hold attention, you can put this lens over your next piece today.
+
+---
+
+## You Can Be Right and Still Lose the Room
+
+Think about the last time you explained something you knew well and felt it not connect. You weren't wrong. You probably weren't even unclear. So what was missing?
+
+For me the answer kept showing up in the same place. Our homepage is meant to greet you with a short spoken rundown — what moved this week, in a voice you'd actually want in your ears for ninety seconds. I'd build it from material I knew was solid, and it would come out as a list of true things with no reason to keep listening. Every sentence was accurate. None of them earned the next one. Has that ever happened to you — each point correct, the whole thing somehow inert?
+
+That's not a knowledge problem. That's a presentation problem, and knowing your subject doesn't fix it on its own.
+
+## The Video That Stopped My Scroll
+
+I wasn't hunting for a framework. I was scrolling. A guy with a microphone drew a yellow triangle and labeled its corners: at the top, *Thought or Topic*; bottom right, a cluster — *Metaphor, Analogy, Example, Story*; bottom left, *Application or Next steps*.
+
+I stopped. I watched it again, then a third time, and saved it — which, he'd noted, is exactly what happens when the framework is working on you. The clip about holding attention was holding mine, using its own three corners to do it. Fair enough. When something demonstrates itself that cleanly, it's worth a closer look.
+
+## Why It Worked — A New Layer on Familiar Ground
+
+Here's the honest version, because the temptation is to overclaim. I didn't invent this, and it didn't reveal some secret I'd been carrying all along.
+
+What it did was map cleanly onto the way I already try to work — observe before you assert, treat a claim as a debt you owe evidence for, aim at the outcome rather than the noise. The triangle lined up with all of that. What it added was vocabulary for the part I'd always fumbled: the move from a point being correct to a point landing. A single thought is a claim. The illustration is how you let someone check it against their own experience instead of taking it on faith. The next step is the outcome the whole thing was for.
+
+So it isn't a replacement. It's a lens you set over the design that's already there. We already have one layer for how a document is structured, and another for whose story we're telling. The triangle is the layer in between: how a single point earns the attention it needs to be heard at all.
+
+## How to Put the Lens Over Your Own Work
+
+You don't need our canon to use this. Take the next thing you have to explain — a message, a section, a thirty-second answer — and run it past three questions:
+
+- **What's the one thought?** Can you say it in a sentence someone could repeat to a friend? If it takes three, you have three things, not one — split them.
+- **What makes it land?** A metaphor, an analogy, a concrete example, or a short story. Which one lets your listener see it, not just hear it?
+- **What do they do next?** If nothing changes for them after you've spoken, what was the point of speaking?
+
+If a piece can't answer all three, is it really ready to be heard? That's the whole filter. You are the one doing the work here; the triangle just shows you which corner is missing.
+
+## It's the Door, Not the House
+
+There's a catch I had to make peace with, and it's worth handing to you straight. If your idea is worth explaining, it has depth — evidence, caveats, the details that make it actually true. Three corners can't hold all of that. Try to cram it in and you lose the attention you were working to win; leave it out and you've got a catchy point standing on nothing. Have you felt that pull — the choice between being thorough and being heard?
+
+Here's the way through: the triangle is the door, not the house. It isn't the whole conversation; it's the way in. Its last move — the next step — is an invitation, not a finish line. You hook them, you make it land, and then you point them at where the proof actually lives: the full piece, the data, the deeper read. Use the triangle to get someone to lean in. Once they have, give them everything. And notice it repeats at every scale — a homepage blurb opens the door to an essay, a section opens the door to its evidence. Same three corners, one floor down each time.
+
+## Giving Credit Where I Found It
+
+The framework isn't mine, and I won't pretend it is. I learned it from a creator who goes by iamjadenly, who built the format and told everyone watching to take it and run. He wasn't guarding a secret. So I'm naming where I got it and using it in the open — which is the honest shape of borrowing, and a habit worth keeping whatever you make.
+
+---
+
+## See Also
+
+- [The Triangle of Yaps — One Thought, One Illustration, One Next Step](klappy://canon/meta/triangle-of-yaps) — the canon article this essay is the public face of
+- [Guide Posture — We Enter Their Story, Not the Other Way Around](klappy://canon/constraints/guide-posture) — why you are the hero of this essay, not the framework
+- [Writing Canon — Progressive Disclosure and Topographic Navigation](klappy://canon/meta/writing-canon) — the structural layer the triangle sits on top of


### PR DESCRIPTION
## What this adds

Three new documents bringing the Triangle of Yaps framework into Klappy.dev canon.

### `canon/meta/triangle-of-yaps.md`
Governance doc mapping the Triangle's three corners (T or T / M-A-E-S / A or N) to the ODD creed and four axioms. Defines the engagement-versus-proof tension and its resolution: the Triangle is the entry point, not the destination. The A-or-N corner is the threshold — it points to where the proof lives, not the proof itself. Includes the creed/axiom mapping table, worked podcast and essay applications, and a named retraction condition. Stability: experimental.

### `writings/the-triangle-i-found-while-scrolling.md`
Public essay: origin story of finding the framework on Instagram, mapping it onto existing methodology as a new presentation layer (not a replacement), and handing the reader the lens. Guide posture throughout — reader is the hero. Includes the 'door not house' resolution of the engagement-vs-proof tension. Stability: draft (flip to stable on publish).

### `canon/methods/triangle-pass.md`
Operational method for the entry layer. Five-move pass: name the one thought, open on the audience's stake, one illustration, point the door at real proof, stop before proving. Governs the weekly audio overview and any topic introduction. Includes the 7-point production checklist, named counter-examples (skeptical/adversarial audiences, already-committed audiences), and a retraction condition. Stability: experimental.

## Epoch
E0009

## Derives from
- `canon/values/axioms.md`
- `canon/values/orientation.md`
- `canon/meta/writing-canon.md`
- `canon/constraints/guide-posture.md`

## Source
Framework borrowed from @iamjadenly (Triangle of Yapping). Credit given in both the canon doc (frontmatter `source:` field) and the public essay body.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only governance and a draft public essay; no executable or security surface, though new `governs` fields will shape future content reviews.
> 
> **Overview**
> This PR **adds three E0009 documents** that introduce the borrowed “Triangle of Yaps” framework into klappy.dev as **presentation-layer canon**, layered on (not above) the Writing Canon, guide posture, and axioms.
> 
> **`canon/meta/triangle-of-yaps.md`** defines the three corners (**T or T**, **M-A-E-S**, **A or N**), maps them to the creed and axioms, and positions the triangle as an **engagement** rule for single units (segments, essays, sections)—with explicit subordination to progressive disclosure. It adds the **engagement vs. proof** tension and the **door-not-house** resolution (entry layer hooks; proof lives one level down), recursion across scales, podcast/essay guidance, constraints, retraction conditions, and a pre-publish checklist.
> 
> **`canon/methods/triangle-pass.md`** operationalizes that for the **entry layer**: a five-move pass (one thought, audience stake first, one illustration, point to real proof, stop before proving), weekly audio overview structure, the requirement that doors open on reachable proof, audience exceptions (skeptical vs. already committed), and a production checklist.
> 
> **`writings/the-triangle-i-found-while-scrolling.md`** is the **public draft essay**—origin story, reader-as-hero framing, practical three-question filter, door-not-house for readers, and credit to @iamjadenly—with `klappy://` links back to canon.
> 
> All three are marked **experimental** (canon) or **draft** (essay); no runtime, auth, or build changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e7c4cc0bd0499ec5bf634e2a183623ceffba6aa6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->