### PR TITLE
scope-audit: tag movers with target_repo (bifurcation pass 1)

### DIFF
--- a/canon/bootstrap/model-operating-contract.md
+++ b/canon/bootstrap/model-operating-contract.md
@@ -13,6 +13,7 @@ derives_from: "canon/values/orientation.md, canon/values/axioms.md, canon/defini
 complements: "docs/oddkit/proactive/posture-lapse.md, docs/oddkit/proactive/proactive-gate.md, docs/appendices/mode-separated-conversations.md, canon/voice/oddie-the-river-guide.md"
 governs: "The evolving operating contract fetched at session start by any LLM instance running in oddkit-powered projects. Model-agnostic: applies equally to the model, GPT, Gemini, Llama, or any future model with tool-use capabilities. Project instructions point here; full posture, tool rhythm, and mode discipline live here and evolve here."
 status: active
+target_repo: "outcomes-driven-development"
 ---
 
 # Model Operating Contract — Bootstrap for Every Session

--- a/canon/constraints/README.md
+++ b/canon/constraints/README.md
@@ -12,6 +12,7 @@ execution_posture: governing
 start_here: true
 start_here_order: 14
 start_here_label: Constraints
+target_repo: "outcomes-driven-development"
 ---
 
 # Constraints

--- a/canon/constraints/ai-voice-cliches.md
+++ b/canon/constraints/ai-voice-cliches.md
@@ -12,6 +12,7 @@ date: 2026-04-09
 derives_from: "canon/meta/writing-canon.md, canon/constraints/guide-posture.md"
 complements: "canon/constraints/author-identity-language.md, canon/constraints/relational-sensitivity.md"
 governs: "All public-facing content: essays, articles, social posts, hook fields, descriptions"
+target_repo: "undecided"
 ---
 
 # AI Voice Clichés — Patterns That Erode Trust in Co-Authored Writing

--- a/canon/constraints/audit-gates-are-spawned-agent-sessions.md
+++ b/canon/constraints/audit-gates-are-spawned-agent-sessions.md
@@ -13,6 +13,7 @@ derives_from: "canon/methods/governance-validation-via-agents.md, canon/methods/
 complements: "canon/constraints/borrow-evaluation-before-implementation.md, canon/constraints/no-irreversible-action-without-epistemic-justification.md, canon/methods/spawned-agent-session-substrate-options.md"
 governs: "Any merge-blocking validator that audits canon, documentation, code-vs-canon sync, cross-reference integrity, or any other governance surface where the check requires LLM-grade judgment. Mechanical scripts (regex, AST walkers, lint rules) MAY run as triggers, schedules, or pre-flight hints but MUST NOT serve as the gate. The gate is a spawned agent session that fetches canon at runtime and produces structured findings."
 status: active
+target_repo: "oddkit"
 ---
 
 # Audit Gates Are Spawned Agent Sessions, Not Pattern Matchers

--- a/canon/constraints/author-identity-language.md
+++ b/canon/constraints/author-identity-language.md
@@ -12,6 +12,7 @@ date: 2026-03-05
 derives_from: "canon/values/trust-kernel.md, canon/values/axioms.md"
 complements: "canon/constraints/guide-posture.md, canon/meta/writing-canon.md"
 governs: "All public-facing content: hook fields, og_description, twitter_description, description fields, opening paragraphs of public essays, podcast generation inputs, and social cards"
+target_repo: "undecided"
 ---
 
 # Author Identity Language

--- a/canon/constraints/bash-test-rig-assignment-chain-discipline.md
+++ b/canon/constraints/bash-test-rig-assignment-chain-discipline.md
@@ -12,6 +12,7 @@ date: 2026-04-26
 derives_from:
   - "canon/principles/ritual-is-a-smell.md"
 governs: "Authoring discipline for shell-script test rigs in this codebase"
+target_repo: "outcomes-driven-development"
 ---
 
 # Bash Test Rigs: Assignment Chains Need Explicit Newlines

--- a/canon/constraints/borrow-evaluation-before-implementation.md
+++ b/canon/constraints/borrow-evaluation-before-implementation.md
@@ -13,6 +13,7 @@ derives_from: "canon/methods/borrow-bend-break-beget-build.md, canon/constraints
 complements: "canon/methods/borrow-bend-break-beget-build.md, canon/bootstrap/model-operating-contract.md"
 governs: "Any agent in planning mode about to execute an implementation task with an upstream substrate (SDK, reference impl, widely-adopted library) — or one the field is visibly converging toward. Binds the planning artifact: the agent must produce a falsifiable 6B Evaluation table plus a one-line Reversibility Note before execution begins."
 status: active
+target_repo: "outcomes-driven-development"
 ---
 
 # Borrow Evaluation Before Implementation — A Falsifiable 6B Table the Agent Produces in Planning Before Any Implementation Execution

--- a/canon/constraints/boundary-transitions-require-deceleration.md
+++ b/canon/constraints/boundary-transitions-require-deceleration.md
@@ -9,6 +9,7 @@ stability: stable
 tags: ["canon", "constraints", "boundaries", "deceleration"]
 relevance: decision
 execution_posture: governing
+target_repo: "outcomes-driven-development"
 ---
 
 # Boundary Transitions Require Deceleration

--- a/canon/constraints/canon-integration-audit.md
+++ b/canon/constraints/canon-integration-audit.md
@@ -13,6 +13,7 @@ derives_from: "canon/values/axioms.md, canon/meta/frontmatter-schema.md, canon/p
 complements: "canon/methods/revision-lens-sequence.md, canon/constraints/frontmatter-validation-before-merge.md, canon/principles/dream-house-principle.md, canon/principles/discernment-layer.md"
 governs: "Any doc-producing workflow that produces content intended to be merged into the knowledge base — essays, canon docs, observations, constraints, methods, principles"
 status: active
+target_repo: "oddkit"
 ---
 
 # Canon-Integration Audit — Three Checks Between Authoring and Merge

--- a/canon/constraints/core-governance-baseline.md
+++ b/canon/constraints/core-governance-baseline.md
@@ -13,6 +13,7 @@ derives_from: "canon/principles/vodka-architecture.md, canon/principles/dry-cano
 complements: "docs/oddkit/tools/oddkit_version.md, canon/constraints/telemetry-governance.md"
 governs: "Every oddkit tool that reads governance from canon at runtime. Defines what must ship bundled, what must live only in canon, and what happens when canon is unreachable."
 status: draft
+target_repo: "oddkit"
 ---
 
 # Core Governance Baseline — What Ships With the Worker, What Lives in Canon

--- a/canon/constraints/critic-cannot-be-resolver.md
+++ b/canon/constraints/critic-cannot-be-resolver.md
@@ -13,6 +13,7 @@ derives_from: "canon/principles/verification-requires-fresh-context.md, canon/va
 complements: "canon/voice/oddie-the-river-guide.md, canon/constraints/mode-discipline-and-bottleneck-respect.md"
 governs: "All agent-system designs where one agent detects issues and another (or the same) resolves them"
 status: active
+target_repo: "outcomes-driven-development"
 ---
 
 # Critic Cannot Be Resolver — Detection and Remediation Require Separate Contexts

--- a/canon/constraints/decision-rules.md
+++ b/canon/constraints/decision-rules.md
@@ -9,6 +9,7 @@ stability: stable
 tags: ["decision-rules", "heuristics"]
 relevance: decision
 execution_posture: governing
+target_repo: "outcomes-driven-development"
 ---
 
 # Decision Rules

--- a/canon/constraints/definition-of-done.md
+++ b/canon/constraints/definition-of-done.md
@@ -13,6 +13,7 @@ execution_posture: governing
 start_here: true
 start_here_order: 13
 start_here_label: Definition of Done
+target_repo: "outcomes-driven-development"
 ---
 
 # Definition of Done & Evidence Policy

--- a/canon/constraints/dual-context-writing.md
+++ b/canon/constraints/dual-context-writing.md
@@ -19,6 +19,7 @@ date: 2026-04-09
 derives_from: "docs/book/governance.md, docs/planning/book-vs-website-distribution.md, canon/constraints/guide-posture.md"
 complements: "canon/meta/writing-canon.md, docs/book/how-to-read-this-book.md"
 governs: "All writings/ documents that also appear in the book chapter plan"
+target_repo: "undecided"
 ---
 
 # Constraint: Dual-Context Writing — One Document, Two Surfaces

--- a/canon/constraints/encode-epistemic-decisions.md
+++ b/canon/constraints/encode-epistemic-decisions.md
@@ -9,6 +9,7 @@ stability: stable
 tags: ["canon", "constraints", "durability", "decisions"]
 relevance: decision
 execution_posture: governing
+target_repo: "outcomes-driven-development"
 ---
 
 # Encode Epistemic Decisions

--- a/canon/constraints/epistemic-challenge.md
+++ b/canon/constraints/epistemic-challenge.md
@@ -7,6 +7,7 @@ tier: 2
 voice: neutral
 stability: semi_stable
 tags: ["epistemic", "challenge", "adversarial", "validation", "collaboration"]
+target_repo: "outcomes-driven-development"
 ---
 
 # Epistemic Challenge

--- a/canon/constraints/frontmatter-validation-before-merge.md
+++ b/canon/constraints/frontmatter-validation-before-merge.md
@@ -12,6 +12,7 @@ date: 2026-04-09
 derives_from: "canon/meta/frontmatter-schema.md, canon/values/axioms.md"
 complements: "canon/meta/writing-canon.md, canon/constraints/definition-of-done.md"
 governs: "All PRs that add or modify files in writings/, canon/, odd/, or docs/"
+target_repo: "oddkit"
 ---
 
 # Frontmatter Validation Before Merge — No Exceptions

--- a/canon/constraints/governance-change-discipline.md
+++ b/canon/constraints/governance-change-discipline.md
@@ -12,6 +12,7 @@ date: 2026-04-21
 derives_from: "canon/CHANGELOG.md, canon/principles/ritual-is-a-smell.md, docs/appendices/epoch-7.md"
 governs: "Any canon, docs/oddkit/, or odd/ change intended to alter operator or agent behavior"
 complements: "canon/CHANGELOG.md, docs/planning/automated-changelog.md, canon/constraints/proactive-frequency-calibration.md"
+target_repo: "outcomes-driven-development"
 ---
 
 # Governance Change Discipline — Versioning, Changelog, Release Notes, and Epoch Bumps

--- a/canon/constraints/guide-posture.md
+++ b/canon/constraints/guide-posture.md
@@ -12,6 +12,7 @@ date: 2026-02-17
 derives_from: "canon/values/trust-kernel.md, canon/values/axioms.md"
 complements: "docs/oddkit/positioning.md, canon/meta/writing-canon.md"
 governs: "All public-facing content: websites (klappy.dev, odd.klappy.dev), voice agents, documentation with audience: public, tool descriptions, onboarding flows, and marketing copy"
+target_repo: "undecided"
 ---
 
 # Guide Posture — We Enter Their Story, Not the Other Way Around

--- a/canon/constraints/harness-disambiguation.md
+++ b/canon/constraints/harness-disambiguation.md
@@ -12,6 +12,7 @@ date: 2026-04-14
 derives_from: "canon/principles/vodka-architecture.md, writings/the-harness-and-the-operating-system.md"
 complements: "canon/constraints/author-identity-language.md, odd/terminology.md"
 governs: "All public-facing content, partner documents, and architecture decision records that use the word 'harness'"
+target_repo: "undecided"
 ---
 
 # Harness Disambiguation

--- a/canon/constraints/humans-are-variable-inputs.md
+++ b/canon/constraints/humans-are-variable-inputs.md
@@ -7,6 +7,7 @@ tier: 1
 voice: first_person
 stability: stable
 tags: ["humans", "variability", "constraints", "ergonomics", "epistemic-discipline"]
+target_repo: "outcomes-driven-development"
 ---
 
 # Humans Are Variable Inputs

--- a/canon/constraints/meaning-must-not-depend-on-path.md
+++ b/canon/constraints/meaning-must-not-depend-on-path.md
@@ -7,6 +7,7 @@ tier: 1
 voice: first_person
 stability: stable
 tags: ["constraint", "epistemic-safety", "portability", "oddkit"]
+target_repo: "outcomes-driven-development"
 ---
 
 # Meaning Must Not Depend on Path

--- a/canon/constraints/measure-before-you-object.md
+++ b/canon/constraints/measure-before-you-object.md
@@ -13,6 +13,7 @@ derives_from: "canon/values/axioms.md"
 complements: "canon/observations/performed-prudence-anti-pattern.md, canon/constraints/mode-discipline-and-bottleneck-respect.md"
 governs: "All work where a contributor (model or human) raises a performance, cost, complexity, or scaling concern about a proposal under consideration"
 status: active
+target_repo: "outcomes-driven-development"
 ---
 
 # Measure Before You Object — Theoretical Concerns Require Empirical Falsification

--- a/canon/constraints/mode-discipline-and-bottleneck-respect.md
+++ b/canon/constraints/mode-discipline-and-bottleneck-respect.md
@@ -13,6 +13,7 @@ derives_from: "canon/definitions/epistemic-modes.md, canon/principles/verificati
 complements: "canon/constraints/oddkit-prompt-pattern.md, canon/values/axioms.md"
 governs: "How any LLM instance operating inside oddkit-powered projects conducts substantive work — specifically, when to ask questions, when to produce artifacts, and how to respect the operator's attention as the system bottleneck. Model-agnostic: applies to the model, GPT, Gemini, Llama, or any future model with tool-use capabilities."
 status: active
+target_repo: "outcomes-driven-development"
 ---
 
 # Mode Discipline and Bottleneck Respect — How Models Operate Inside oddkit

--- a/canon/constraints/mode-transitions-require-encoded-handoff.md
+++ b/canon/constraints/mode-transitions-require-encoded-handoff.md
@@ -13,6 +13,7 @@ derives_from: "canon/principles/sessions-mirror-modes.md, canon/definitions/epis
 complements: "canon/methods/persona-shaped-agent-runtime.md, docs/mode-separated-conversations.md, canon/definitions/dolcheo-vocabulary.md"
 governs: "Every transition between epistemic modes — exploration, planning, execution, validation, resolution — across all surfaces (agent runtime, human conversation, mixed teams)"
 status: proposed
+target_repo: "outcomes-driven-development"
 ---
 
 # Mode Transitions Require Encoded Handoff — Every Gate Demands a Durable Artifact

--- a/canon/constraints/no-irreversible-action-without-epistemic-justification.md
+++ b/canon/constraints/no-irreversible-action-without-epistemic-justification.md
@@ -9,6 +9,7 @@ stability: stable
 tags: ["canon", "constraints", "irreversibility", "epistemic-safety", "commitment", "enforcement"]
 relevance: decision
 execution_posture: governing
+target_repo: "outcomes-driven-development"
 ---
 
 # No Irreversible Action Without Epistemic Justification

--- a/canon/constraints/odd-is-epistemic-os-not-values.md
+++ b/canon/constraints/odd-is-epistemic-os-not-values.md
@@ -12,6 +12,7 @@ stability: stable
 tags: ["canon", "constraints", "odd", "authority", "values"]
 relevance: decision
 execution_posture: governing
+target_repo: "outcomes-driven-development"
 ---
 
 # ODD Is a Value-Grounded Epistemic OS

--- a/canon/constraints/oddkit-action-registration-completeness.md
+++ b/canon/constraints/oddkit-action-registration-completeness.md
@@ -12,6 +12,7 @@ date: 2026-04-26
 derives_from:
   - "canon/principles/vodka-architecture.md"
 governs: "Process for adding a new MCP action surface to klappy/oddkit"
+target_repo: "oddkit"
 ---
 
 # Adding an oddkit Action: Update Both Switch and VALID_ACTIONS

--- a/canon/constraints/oddkit-prompt-pattern.md
+++ b/canon/constraints/oddkit-prompt-pattern.md
@@ -14,6 +14,7 @@ governs: "All system prompts in applications that use the Anthropic API with odd
 complements: "odd/prompt-architecture.md, canon/meta/writing-canon.md"
 relevance: "decision"
 execution_posture: "governing"
+target_repo: "outcomes-driven-development"
 ---
 
 # Prompt Pattern for oddkit-Powered Applications

--- a/canon/constraints/proactive-frequency-calibration.md
+++ b/canon/constraints/proactive-frequency-calibration.md
@@ -12,6 +12,7 @@ date: 2026-04-20
 derives_from: "canon/principles/ritual-is-a-smell.md, docs/oddkit/proactive/posture-lapse.md, odd/ledger/2026-04-20-post-4-7-proactive-loop-experience.md, writings/copy-paste.md, writings/shifting-bottlenecks-climbing-ladders.md"
 complements: "canon/constraints/mode-discipline-and-bottleneck-respect.md, docs/oddkit/proactive/posture-lapse.md, canon/diagnostics/ritual-detected.md"
 governs: "Tool-call frequency, turn format, and gauntlet placement during proactive operation"
+target_repo: "outcomes-driven-development"
 ---
 
 # Proactive Frequency Calibration — Cognitive Rhythm Without Operator Babysitting

--- a/canon/constraints/relational-sensitivity.md
+++ b/canon/constraints/relational-sensitivity.md
@@ -14,6 +14,7 @@ governs: "writings/"
 complements: "canon/meta/writing-canon.md, canon/constraints/author-identity-language.md"
 relevance: "decision"
 execution_posture: "governing"
+target_repo: "undecided"
 ---
 
 # Relational Sensitivity — Truth Told in Love

--- a/canon/constraints/release-validation-gate.md
+++ b/canon/constraints/release-validation-gate.md
@@ -13,6 +13,7 @@ derives_from: "canon/principles/verification-requires-fresh-context.md, canon/pr
 complements: "canon/constraints/oddkit-prompt-pattern.md, canon/principles/dry-canon-says-it-once.md"
 governs: "Every PR merged to oddkit main and every promotion to oddkit prod. Also applies to klappy.dev canon PRs that change governance documents the worker reads at runtime. Binding on every orchestrator and every Managed Agent that ships code in this program."
 status: active
+target_repo: "oddkit"
 ---
 
 # Release Validation Gate — Mechanical Rules That Bind Every Ship

--- a/canon/constraints/retrieval-disclosure-contract.md
+++ b/canon/constraints/retrieval-disclosure-contract.md
@@ -13,6 +13,7 @@ derives_from: "canon/meta/writing-canon.md, canon/meta/frontmatter-schema.md, ca
 complements: "canon/constraints/oddkit-prompt-pattern.md, canon/constraints/oddkit-action-registration-completeness.md"
 governs: "The response shape and accepted disclosure declarations for every oddkit retrieval action (oddkit_search, oddkit_catalog, oddkit_get, oddkit_preflight, oddkit_resolve), and the contract every consumer of those actions must honor"
 status: active
+target_repo: "oddkit"
 ---
 
 # Retrieval Disclosure Contract — A Canonical Shape for All Document Retrieval Actions

--- a/canon/constraints/single-agent-integrity-precedes-collaboration.md
+++ b/canon/constraints/single-agent-integrity-precedes-collaboration.md
@@ -9,6 +9,7 @@ stability: stable
 tags: ["canon", "constraints", "integrity", "collaboration"]
 relevance: decision
 execution_posture: governing
+target_repo: "outcomes-driven-development"
 ---
 
 # Single-Agent Integrity Precedes Collaboration

--- a/canon/constraints/superseded-by-shape-normalization.md
+++ b/canon/constraints/superseded-by-shape-normalization.md
@@ -14,6 +14,7 @@ derives_from:
   - "canon/principles/identity-resolved-by-protocol.md"
   - "canon/principles/vodka-architecture.md"
 governs: "How tools that read superseded_by frontmatter normalize across authoring conventions"
+target_repo: "outcomes-driven-development"
 ---
 
 # superseded_by Values: Three Shapes Allowed, One Resolution Algorithm

--- a/canon/constraints/telemetry-governance.md
+++ b/canon/constraints/telemetry-governance.md
@@ -13,6 +13,7 @@ derives_from: "canon/principles/vodka-architecture.md, canon/principles/maintain
 complements: "docs/oddkit/tools/telemetry_public.md, docs/oddkit/tools/telemetry_policy.md, writings/half-a-million-requests.md"
 governs: "All telemetry collection in oddkit hosted service and TruthKit"
 status: active
+target_repo: "oddkit"
 ---
 
 # Telemetry Governance — What oddkit Tracks and Why

--- a/canon/constraints/telemetry-validation-gate.md
+++ b/canon/constraints/telemetry-validation-gate.md
@@ -13,6 +13,7 @@ derives_from: "canon/constraints/telemetry-governance.md, canon/constraints/rele
 complements: "canon/decisions/DR-20260514-0001-telemetry-wrapper-pattern.md, canon/observations/2026-05-14-telemetry-coverage-gap-quantified.md"
 governs: "Every release that touches the telemetry Emission Contract surface in oddkit and TruthKit"
 status: active
+target_repo: "oddkit"
 ---
 
 # Telemetry Validation Gate — Smoke Every Tool, Verify Every Number

--- a/canon/constraints/verification-and-evidence.md
+++ b/canon/constraints/verification-and-evidence.md
@@ -10,6 +10,7 @@ tags: ["verification", "evidence", "trust", "epistemology", "agents"]
 derives_from: "canon/values/axioms.md (Axiom 4 — You Cannot Verify What You Did Not Observe)"
 relevance: decision
 execution_posture: governing
+target_repo: "outcomes-driven-development"
 ---
 
 # Verification & Evidence

--- a/canon/constraints/visual-proof.md
+++ b/canon/constraints/visual-proof.md
@@ -9,6 +9,7 @@ stability: semi_stable
 tags: ["visual-proof", "evidence"]
 relevance: decision
 execution_posture: governing
+target_repo: "outcomes-driven-development"
 ---
 
 # Visual Proof Standards

--- a/canon/defaults/epistemic-posture.md
+++ b/canon/defaults/epistemic-posture.md
@@ -5,6 +5,7 @@ audience: canon
 stability: evolving
 exposure: nav
 tier: 2
+target_repo: "outcomes-driven-development"
 ---
 
 # Epistemic Posture (Klappy.dev Defaults)

--- a/canon/defaults/evidence-intake.md
+++ b/canon/defaults/evidence-intake.md
@@ -5,6 +5,7 @@ audience: canon
 stability: evolving
 exposure: nav
 tier: 2
+target_repo: "outcomes-driven-development"
 ---
 
 # Evidence Intake

--- a/canon/defaults/iteration-bias.md
+++ b/canon/defaults/iteration-bias.md
@@ -12,6 +12,7 @@ tags:
   - regeneration
   - bias
 epoch: 5
+target_repo: "outcomes-driven-development"
 ---
 
 # Iteration Bias (Klappy.dev Defaults)

--- a/canon/definitions/cognitive-saturation-threshold.md
+++ b/canon/definitions/cognitive-saturation-threshold.md
@@ -9,6 +9,7 @@ stability: stable
 tags: ["canon", "definition", "cst", "closure", "limits"]
 relevance: decision
 execution_posture: governing
+target_repo: "outcomes-driven-development"
 ---
 
 # Cognitive Saturation Threshold (CST)

--- a/canon/definitions/dolcheo-vocabulary.md
+++ b/canon/definitions/dolcheo-vocabulary.md
@@ -14,6 +14,7 @@ complements: "canon/meta/writing-canon.md, docs/oddkit/proactive/continuous-enco
 governs: "All session capture, project journals, and encode invocations in oddkit-powered projects"
 status: active
 supersedes: "docs/oddkit/proactive/dolche-vocabulary.md"
+target_repo: "outcomes-driven-development"
 ---
 
 # DOLCHEO — Seven Dimensions of Session Capture

--- a/canon/definitions/epistemic-modes.md
+++ b/canon/definitions/epistemic-modes.md
@@ -9,6 +9,7 @@ stability: semi_stable
 tags: ["epistemology", "decision-making", "governance"]
 epoch: E0009
 date: 2026-05-10
+target_repo: "outcomes-driven-development"
 ---
 
 # Epistemic Modes

--- a/canon/definitions/epistemic-obligation-and-document-tiers.md
+++ b/canon/definitions/epistemic-obligation-and-document-tiers.md
@@ -9,6 +9,7 @@ stability: stable
 tags: ["canon", "tiers", "epistemic-obligation", "architecture"]
 relevance: decision
 execution_posture: governing
+target_repo: "outcomes-driven-development"
 ---
 
 # Epistemic Obligation and Document Tiers

--- a/canon/definitions/execution-posture.md
+++ b/canon/definitions/execution-posture.md
@@ -9,6 +9,7 @@ voice: neutral
 stability: stable
 tags: ["documentation", "agents", "governance"]
 execution_posture: governing
+target_repo: "outcomes-driven-development"
 ---
 
 # Execution Posture

--- a/canon/definitions/software-virtues-vocabulary.md
+++ b/canon/definitions/software-virtues-vocabulary.md
@@ -13,6 +13,7 @@ derives_from: "https://medium.com/@klappy/what-are-software-virtues-and-how-to-p
 complements: "canon/principles/quality-attributes-are-in-tension.md, canon/observations/quality-attribute-tension-matrix.md, odd/maturity.md"
 governs: "Vocabulary used across canon when discussing tradeoffs between competing software properties. 'Virtues' is the rhetorical/historical name; 'quality attributes' or 'ilities' is the operational synonym. Both are first-class."
 status: active
+target_repo: "outcomes-driven-development"
 ---
 
 # Software Virtues Vocabulary — Ten Quality Attributes That Compete for Priority

--- a/canon/definitions/tier-vs-relevance.md
+++ b/canon/definitions/tier-vs-relevance.md
@@ -9,6 +9,7 @@ voice: neutral
 stability: stable
 tags: ["metadata", "documentation", "context-packs"]
 execution_posture: governing
+target_repo: "outcomes-driven-development"
 ---
 
 # Tier vs Relevance

--- a/canon/definitions/validation-as-epistemic-mode.md
+++ b/canon/definitions/validation-as-epistemic-mode.md
@@ -13,6 +13,7 @@ derives_from: "canon/definitions/epistemic-modes.md, canon/constraints/mode-disc
 complements: "docs/appendices/mode-separated-conversations.md, docs/oddkit/tools/oddkit_validate.md, canon/methods/revision-lens-sequence.md"
 governs: "Validation as a first-class epistemic mode — distinct from exploration, planning, and execution, with its own truth conditions, obligations, non-collapse requirements, and a structural separation requirement (context break between creator and validator). Applies to any review of produced artifacts against stated claims."
 status: active
+target_repo: "outcomes-driven-development"
 ---
 
 # Validation as Epistemic Mode

--- a/canon/diagnostics/camping-risk.md
+++ b/canon/diagnostics/camping-risk.md
@@ -15,6 +15,7 @@ tags:
   - escalation
   - plateau
 epoch: 5
+target_repo: "outcomes-driven-development"
 ---
 
 # Camping Risk

--- a/canon/diagnostics/epistemic-hygiene.md
+++ b/canon/diagnostics/epistemic-hygiene.md
@@ -8,6 +8,7 @@ tier: 2
 voice: neutral
 stability: stable
 tags: ["epistemics", "governance", "learning", "promotion"]
+target_repo: "outcomes-driven-development"
 ---
 
 # Epistemic Hygiene

--- a/canon/diagnostics/generative-arc-curve.md
+++ b/canon/diagnostics/generative-arc-curve.md
@@ -14,6 +14,7 @@ tags:
   - iteration
   - coherence
 epoch: 5
+target_repo: "outcomes-driven-development"
 ---
 
 # Generative Arc Curve

--- a/canon/diagnostics/ritual-detected.md
+++ b/canon/diagnostics/ritual-detected.md
@@ -7,6 +7,7 @@ tier: 3
 voice: system_first_person
 stability: evolving
 tags: ["diagnostic", "smell", "ritual", "lint"]
+target_repo: "outcomes-driven-development"
 ---
 
 # RITUAL_DETECTED

--- a/canon/meta/frontmatter-schema.md
+++ b/canon/meta/frontmatter-schema.md
@@ -225,6 +225,25 @@ Archived documents remain in the knowledge base for history but are excluded fro
 
 ---
 
+## Repo Routing — `target_repo`
+
+`target_repo` is an optional, cross-cutting field (it applies to documents of any audience) that declares which repository a file belongs to once the klappy.dev knowledge base bifurcates. It is the only routing signal extraction relies on: a later move is `git grep target_repo` plus copy, never a re-organization.
+
+| Field | Required? | Format | Notes |
+|-------|-----------|--------|-------|
+| `target_repo` | optional | `"outcomes-driven-development"` `"oddkit"` `"undecided"` | Destination repo for this file. Quoted string, one of the three enum values. **Absent = stays in klappy.dev** — the default home is the absence of a tag, so routing never depends on a file's path. |
+
+Values:
+
+- `"outcomes-driven-development"` — the portable core: universal governance and canon an outside adopter needs.
+- `"oddkit"` — the engine's own documentation and engine/release/telemetry governance.
+- `"undecided"` — contested; resolved deliberately before the file moves. Used for cross-cutting files and genuine judgment calls.
+- **Absent** — stays in klappy.dev (the personal overlay, the default home).
+
+Only files that leave klappy.dev carry the tag; the overlay's own files stay untagged. Non-markdown files cannot carry frontmatter, so their routing is recorded in `canon/meta/scope-map.json` instead. A malformed value is a merge-gate failure (the validator enum-checks this field), so a bad route never reaches the renderer. Governing document: `klappy://docs/repo-bifurcation-and-target-repo-routing`.
+
+---
+
 ## Smell Test — How to Detect a Frontmatter Violation
 
 - **Type mismatches.** If a boolean field like `public` is quoted as `"false"` (a truthy string) instead of `false` (a boolean), the renderer behaves incorrectly. If an integer field like `tier` is quoted as `"2"` instead of `2`, type comparisons fail.

--- a/canon/meta/scope-map.json
+++ b/canon/meta/scope-map.json
@@ -1,0 +1,10 @@
+{
+  "_comment": "Non-markdown movers for the klappy.dev bifurcation (Pass 1). Markdown files carry target_repo in frontmatter; these cannot, so their routing is recorded here. Absent from this map AND untagged in frontmatter = stays in klappy.dev. Governing doc: klappy://docs/repo-bifurcation-and-target-repo-routing. Handoff: klappy://odd/handoffs/2026-06-09-scope-audit-execution.",
+  "routes": {
+    "AGENTS.md": "undecided",
+    "canon/meta/pack.json": "oddkit",
+    "scripts/audit-retrieval-readiness.py": "oddkit",
+    "scripts/tests/test_validator.py": "oddkit",
+    "scripts/validate-frontmatter.py": "oddkit"
+  }
+}

--- a/canon/meta/triangle-of-yaps.md
+++ b/canon/meta/triangle-of-yaps.md
@@ -14,6 +14,7 @@ derives_from: "canon/values/axioms.md, canon/values/orientation.md, canon/meta/w
 complements: "canon/meta/writing-canon.md, canon/constraints/ai-voice-cliches.md, canon/methods/choosing-the-right-narrative-container.md, canon/constraints/dual-context-writing.md"
 governs: "The rhetorical shape of any single unit of spoken or written communication produced for klappy.dev — podcast script segments, published essays, and the standalone sections within them. Governs engagement structure; subordinate to writing-canon, which governs document structure."
 constraint: "This document cannot override the axioms or the Writing Canon. Where the Triangle and progressive disclosure conflict, progressive disclosure governs structure and the axioms govern truth."
+target_repo: "undecided"
 ---
 
 # The Triangle of Yaps — One Thought, One Illustration, One Next Step

--- a/canon/meta/writing-canon.md
+++ b/canon/meta/writing-canon.md
@@ -12,6 +12,7 @@ date: 2026-02-09
 complements: "canon/meta/TEMPLATE.md, docs/TEMPLATE.md, canon/meta/agent-executable-outline.md, canon/constraints/definition-of-done.md, canon/methods/self-audit.md, docs/oddkit/IMPL-writing-canon-gate.md"
 derives_from: "canon/values/axioms.md (Axiom 2 — A Claim Is a Debt)"
 governs: "All documents in canon/, odd/, and docs/ directories"
+target_repo: "undecided"
 ---
 
 # Writing Canon — Progressive Disclosure and Topographic Navigation

--- a/canon/methods/README.md
+++ b/canon/methods/README.md
@@ -9,6 +9,7 @@ stability: stable
 tags: ["canon", "methods", "practice", "application"]
 relevance: decision
 execution_posture: governing
+target_repo: "outcomes-driven-development"
 ---
 
 # Methods

--- a/canon/methods/borrow-bend-break-beget-build.md
+++ b/canon/methods/borrow-bend-break-beget-build.md
@@ -14,6 +14,7 @@ derives_from:
   - canon/values/trust-kernel.md
 complements: "canon/methods/self-audit.md, canon/methods/weighted-relevance-and-arbitration.md, canon/constraints/borrow-evaluation-before-implementation.md"
 supersedes_concept: "5B (Borrow, Bend, Break, Beget, Build) — Bide added as the sixth B per klappy://docs/promotions/P0002-borrow-evaluation-before-implementation; URI and filename retained for backward reference"
+target_repo: "outcomes-driven-development"
 ---
 
 # Method: Borrow, Bend, Break, Beget, Bide, Build

--- a/canon/methods/boundary-transition-review.md
+++ b/canon/methods/boundary-transition-review.md
@@ -9,6 +9,7 @@ stability: draft
 tags: ["canon", "methods", "boundaries", "review"]
 relevance: decision
 execution_posture: governing
+target_repo: "outcomes-driven-development"
 ---
 
 # Method: Boundary Transition Review

--- a/canon/methods/choosing-the-right-narrative-container.md
+++ b/canon/methods/choosing-the-right-narrative-container.md
@@ -9,6 +9,7 @@ stability: stable
 tags: ["canon", "methods", "writing", "structure"]
 relevance: decision
 execution_posture: governing
+target_repo: "undecided"
 ---
 
 # Method: Choosing the Right Narrative Container

--- a/canon/methods/community-checking.md
+++ b/canon/methods/community-checking.md
@@ -13,6 +13,7 @@ derives_from:
   - canon/values/axioms.md
   - canon/values/trust-kernel.md
 complements: "canon/methods/self-audit.md, odd/ledger/epistemic-ledger.md"
+target_repo: "outcomes-driven-development"
 ---
 
 # Community Checking — Outcome Validation Beyond Author Intent

--- a/canon/methods/dispatch-paths.md
+++ b/canon/methods/dispatch-paths.md
@@ -13,6 +13,7 @@ derives_from: "canon/methods/spawned-agent-session-runtime-contract.md, canon/me
 complements: "canon/methods/trigger-source-taxonomy.md, canon/methods/spawned-agent-session-substrate-options.md"
 governs: "How any consumer chooses between dispatching a runtime via an assistant in a chat session versus wiring an autonomous trigger that invokes the runtime with no assistant in the loop. Substrate-neutral. Pairs with trigger-source-taxonomy: this doc names the two dispatch classes; trigger-source-taxonomy names the input edges that wake the autonomous-trigger class."
 status: proposed
+target_repo: "outcomes-driven-development"
 ---
 
 # Dispatch Paths for Spawned Agent Sessions — Assistant-Orchestrated vs Autonomous-Trigger

--- a/canon/methods/epistemic-surface-extraction.md
+++ b/canon/methods/epistemic-surface-extraction.md
@@ -9,6 +9,7 @@ stability: evolving
 tags: ["evidence", "verification", "ese", "surface", "ocr", "asr", "video", "screenshots", "recordings"]
 relevance: decision
 execution_posture: governing
+target_repo: "outcomes-driven-development"
 ---
 
 # Epistemic Surface Extraction (ESE)

--- a/canon/methods/exploration-exhaust.md
+++ b/canon/methods/exploration-exhaust.md
@@ -9,6 +9,7 @@ stability: draft
 tags: ["canon", "methods", "exploration", "durability"]
 relevance: decision
 execution_posture: governing
+target_repo: "outcomes-driven-development"
 ---
 
 # Method: Exploration Exhaust

--- a/canon/methods/extreme-exploration-for-limit-discovery.md
+++ b/canon/methods/extreme-exploration-for-limit-discovery.md
@@ -9,6 +9,7 @@ stability: stable
 tags: ["canon", "methods", "exploration", "limits", "cst"]
 relevance: decision
 execution_posture: governing
+target_repo: "outcomes-driven-development"
 ---
 
 # Method: Extreme Exploration for Limit Discovery

--- a/canon/methods/fresh-session-over-context-carry.md
+++ b/canon/methods/fresh-session-over-context-carry.md
@@ -13,6 +13,7 @@ derives_from: "canon/principles/code-claims-require-code-observation.md, canon/p
 complements: "canon/constraints/release-validation-gate.md, canon/principles/contract-governs-handoff-drift.md, odd/ledger/2026-04-30-audit-cleanup-encode-artifacts-landed.md"
 governs: "Method for deciding whether a multi-phase workflow should continue in the current session or open a fresh one. Applies to any moment where the next phase's contract lives in canon (handoff, ledger, architecture doc) and the operator asks 'continue or fresh session?'"
 status: active
+target_repo: "outcomes-driven-development"
 ---
 
 # Method — Fresh Session Over Context Carry

--- a/canon/methods/governance-validation-via-agents.md
+++ b/canon/methods/governance-validation-via-agents.md
@@ -12,6 +12,7 @@ date: 2026-04-09
 derives_from: "canon/constraints/frontmatter-validation-before-merge.md, canon/constraints/ai-voice-cliches.md, canon/meta/writing-canon.md"
 complements: "docs/agents/validation/README.md, canon/constraints/definition-of-done.md"
 governs: "All PRs that add or modify canon, writings, or documentation"
+target_repo: "outcomes-driven-development"
 ---
 
 # Governance Validation via Managed Agents

--- a/canon/methods/pivot-on-inversion.md
+++ b/canon/methods/pivot-on-inversion.md
@@ -14,6 +14,7 @@ tags:
   - recovery
   - rebase
 epoch: 5
+target_repo: "outcomes-driven-development"
 ---
 
 # Pivot on Inversion

--- a/canon/methods/planning-queue.md
+++ b/canon/methods/planning-queue.md
@@ -12,6 +12,7 @@ date: 2026-02-18
 derives_from: "odd/constraint/use-only-what-hurts.md, odd/ledger/epistemic-ledger.md, canon/definitions/epistemic-modes.md"
 complements: "writings/the-drift-queue.md, docs/appendices/synthesis-ledger.md, docs/appendices/convention-requires-an-enforcer.md"
 governs: "docs/planning/ directory and all planning documents within it"
+target_repo: "outcomes-driven-development"
 ---
 
 # The Planning Queue — Implementation-Ready Specs That Wait Until They Hurt

--- a/canon/methods/reference-integrity-audit.md
+++ b/canon/methods/reference-integrity-audit.md
@@ -12,6 +12,7 @@ date: 2026-04-09
 derives_from: "odd/constraint/anti-cache-lying.md, canon/methods/governance-validation-via-agents.md, canon/values/axioms.md"
 complements: "canon/meta/frontmatter-schema.md, canon/methods/supersession.md, canon/methods/self-audit.md"
 governs: "All klappy:// URIs, frontmatter cross-references, and README index tables across the canon"
+target_repo: "outcomes-driven-development"
 ---
 
 # Reference Integrity Audit

--- a/canon/methods/reframe-before-trimming.md
+++ b/canon/methods/reframe-before-trimming.md
@@ -14,6 +14,7 @@ derives_from:
 complements:
   - klappy://canon/methods/pivot-on-inversion
 status: active
+target_repo: "outcomes-driven-development"
 ---
 
 # Reframe Before Trimming

--- a/canon/methods/revision-lens-sequence.md
+++ b/canon/methods/revision-lens-sequence.md
@@ -12,6 +12,7 @@ date: 2026-04-07
 derives_from: "canon/meta/writing-canon.md, canon/constraints/guide-posture.md, canon/constraints/relational-sensitivity.md, docs/book/governance-additions-2026-02-27.md"
 complements: "canon/methods/self-audit.md, canon/constraints/definition-of-done.md, docs/oddkit/IMPL-writing-canon-gate.md"
 governs: "All public essays (writings/) and book chapters — after draft-zero and after each major revision prior to publishing"
+target_repo: "undecided"
 ---
 
 # Method: Revision Lens Sequence — One Pass, One Lens, One Complete Read

--- a/canon/methods/self-audit.md
+++ b/canon/methods/self-audit.md
@@ -9,6 +9,7 @@ stability: evolving
 tags: ["self-audit", "verification"]
 relevance: supporting
 execution_posture: operational
+target_repo: "outcomes-driven-development"
 ---
 
 # Self-Audit Checklist

--- a/canon/methods/supersession.md
+++ b/canon/methods/supersession.md
@@ -17,6 +17,7 @@ derives_from:
 complements: "canon/methods/self-audit.md, canon/methods/planning-queue.md, writings/the-drift-queue.md, odd/ledger/epistemic-ledger.md, docs/appendices/compiled-memory.md"
 governs: "All documents in canon/, odd/, and docs/ directories when understanding evolves past what a document encodes"
 constraint: "Superseded documents must remain discoverable as historical evidence. Hiding evolution is a shortcut on truth — and shortcuts on truth always cost more than honest unknowns (Axiom 3)."
+target_repo: "outcomes-driven-development"
 ---
 
 # Method: Supersession — How Governance Evolves Without Erasing Its History

--- a/canon/methods/tool-specialization.md
+++ b/canon/methods/tool-specialization.md
@@ -9,6 +9,7 @@ stability: evolving
 tags: ["odd", "pattern", "tools", "decision-complexity"]
 relevance: supporting
 execution_posture: operational
+target_repo: "outcomes-driven-development"
 ---
 
 # Tool Specialization

--- a/canon/methods/triangle-pass.md
+++ b/canon/methods/triangle-pass.md
@@ -13,6 +13,7 @@ derives_from: "canon/meta/triangle-of-yaps.md, canon/constraints/guide-posture.m
 complements: "canon/methods/choosing-the-right-narrative-container.md, canon/constraints/ai-voice-cliches.md, docs/audits/guide-posture-audit.md"
 governs: "How any topic is introduced and presented at the entry layer for klappy.dev — the weekly audio overview, the opening of an essay or section, a talk intro, a tool or onboarding intro. Governs the entry and the handoff, not the proof the handoff points to."
 constraint: "Subordinate to canon/meta/triangle-of-yaps.md, canon/constraints/guide-posture.md, canon/meta/writing-canon.md, and the axioms. Where any of those conflict with this method, they govern."
+target_repo: "outcomes-driven-development"
 ---
 
 # The Triangle Pass — Introduce a Topic as a Door Into the Proof, Not a Replacement for It

--- a/canon/methods/using-ease-and-resistance-as-signals.md
+++ b/canon/methods/using-ease-and-resistance-as-signals.md
@@ -9,6 +9,7 @@ stability: stable
 tags: ["canon", "methods", "writing", "signals"]
 relevance: decision
 execution_posture: governing
+target_repo: "undecided"
 ---
 
 # Method: Using Ease and Resistance as Signals

--- a/canon/methods/weighted-relevance-and-arbitration.md
+++ b/canon/methods/weighted-relevance-and-arbitration.md
@@ -7,6 +7,7 @@ tier: 2
 voice: neutral
 stability: stable
 tags: ["arbitration", "relevance", "epistemic-hygiene", "promotion"]
+target_repo: "outcomes-driven-development"
 ---
 
 # Weighted Relevance & Arbitration

--- a/canon/methods/writing-apocrypha-fragments.md
+++ b/canon/methods/writing-apocrypha-fragments.md
@@ -9,6 +9,7 @@ stability: stable
 tags: ["canon", "methods", "apocrypha", "writing"]
 relevance: decision
 execution_posture: governing
+target_repo: "undecided"
 ---
 
 # Method: Writing Apocrypha Fragments

--- a/canon/methods/writing-predocumentaries.md
+++ b/canon/methods/writing-predocumentaries.md
@@ -12,6 +12,7 @@ execution_posture: governing
 depends_on:
   - canon/methods/writing-apocrypha-fragments.md
   - canon/methods/choosing-the-right-narrative-container.md
+target_repo: "undecided"
 ---
 
 # Method: Writing Predocumentaries

--- a/canon/principles/README.md
+++ b/canon/principles/README.md
@@ -9,6 +9,7 @@ stability: stable
 tags: ["principles", "index"]
 relevance: routing
 execution_posture: routing
+target_repo: "outcomes-driven-development"
 ---
 
 # Principles

--- a/canon/principles/agent-self-report-under-stress.md
+++ b/canon/principles/agent-self-report-under-stress.md
@@ -12,6 +12,7 @@ date: 2026-04-19
 derives_from: "canon/values/axioms.md, canon/principles/verification-requires-fresh-context.md, canon/methods/self-audit.md"
 complements: "canon/definitions/validation-as-epistemic-mode.md, canon/methods/governance-validation-via-agents.md, canon/meta/completion-report-template.md"
 governs: "How completion is verified when an agent reports what it did. Applies to any autonomous or semi-autonomous agent workflow where the agent's terminal self-report is used as evidence of work completed."
+target_repo: "outcomes-driven-development"
 ---
 
 # Agent Self-Report Under Stress — The Filesystem Is the Historian

--- a/canon/principles/agents-need-their-own-wire.md
+++ b/canon/principles/agents-need-their-own-wire.md
@@ -13,6 +13,7 @@ derives_from: "canon/values/axioms.md, canon/principles/discernment-layer.md, ca
 complements: "canon/principles/symmetric-participation.md, canon/architecture/substrate-stack.md, canon/principles/magical-first-run.md, canon/principles/creators-get-paid.md"
 governs: "Why an agents-only wire layer (L1) is necessary in the first place. Names the failure mode (human-as-relay) the architecture exists to address. Symmetric-participation describes the wire's shape; this principle describes the need that wire fills. Together they form the substrate's load-bearing rationale at L1."
 status: active
+target_repo: "outcomes-driven-development"
 ---
 
 # Agents Need Their Own Wire — The Human Cannot Be the Relay Between Agents

--- a/canon/principles/antifragile-failures-grow-canon.md
+++ b/canon/principles/antifragile-failures-grow-canon.md
@@ -13,6 +13,7 @@ derives_from: "canon/principles/vodka-architecture.md, canon/resonance/antifragi
 complements: "canon/principles/prompt-over-code.md, canon/principles/ritual-is-a-smell.md"
 governs: "All failure response decisions in this program"
 status: active
+target_repo: "undecided"
 ---
 
 # Antifragile — Every Failure Grows the Canon, Never the Server

--- a/canon/principles/async-by-default-for-long-running-tools.md
+++ b/canon/principles/async-by-default-for-long-running-tools.md
@@ -14,6 +14,7 @@ derives_from:
 complements:
   - klappy://canon/principles/partial-data-with-transparency-and-background-warm
 status: active
+target_repo: "oddkit"
 ---
 
 # Async by Default — Long-Running MCP Tools Return an Identifier, Never Block

--- a/canon/principles/bulldoze-but-keep-the-blueprint.md
+++ b/canon/principles/bulldoze-but-keep-the-blueprint.md
@@ -16,6 +16,7 @@ execution_posture: operational
   - evidence
   - cost-models
   - bt-tools
+target_repo: "outcomes-driven-development"
 ---
 
 # Bulldoze the App, Keep the Blueprint

--- a/canon/principles/cache-fetches-and-parses.md
+++ b/canon/principles/cache-fetches-and-parses.md
@@ -13,6 +13,7 @@ derives_from: "canon/principles/vodka-architecture.md, canon/principles/dry-cano
 complements: "canon/constraints/oddkit-prompt-pattern.md, canon/principles/ritual-is-a-smell.md"
 governs: "All caching decisions in oddkit and any oddkit-pattern MCP server — which derived values get cached, which get rebuilt per request"
 status: active
+target_repo: "oddkit"
 ---
 
 # Cache Fetches and Parses — Not Microsecond Derivations

--- a/canon/principles/capability-is-not-permission.md
+++ b/canon/principles/capability-is-not-permission.md
@@ -26,6 +26,7 @@ complements:
   - canon/apocrypha/fragments/fragment-12-the-terminal.md
   - writings/the-cost-of-code-dropped-to-zero.md
   - odd/constraint/use-only-what-hurts.md
+target_repo: "outcomes-driven-development"
 ---
 
 # Capability Is Not Permission — Frictionless Tools Require Intentional Constraint

--- a/canon/principles/code-claims-require-code-observation.md
+++ b/canon/principles/code-claims-require-code-observation.md
@@ -13,6 +13,7 @@ derives_from: "canon/principles/dry-canon-says-it-once.md, canon/principles/vodk
 complements: "canon/constraints/release-validation-gate.md, canon/principles/contract-governs-handoff-drift.md, canon/methods/supersession.md"
 governs: "Any claim that asserts what running code currently does. Architecture briefs, handoffs, ledgers, READMEs, essays, design docs, and prompt-side context all fall under this principle when they describe code behavior."
 status: active
+target_repo: "outcomes-driven-development"
 ---
 
 # Principle — Code Claims Require Code Observation

--- a/canon/principles/consistency-same-pattern-every-time.md
+++ b/canon/principles/consistency-same-pattern-every-time.md
@@ -13,6 +13,7 @@ derives_from: "canon/principles/vodka-architecture.md, canon/values/axioms.md"
 complements: "docs/architecture/epistemic-os-layers.md, canon/principles/kiss-simplicity-is-the-ceiling.md"
 governs: "All MCP server interfaces and knowledge base serving patterns in this program"
 status: active
+target_repo: "oddkit"
 ---
 
 # Consistency — Same Pattern, Every Knowledge Base, Every Time

--- a/canon/principles/contract-governs-handoff-drift.md
+++ b/canon/principles/contract-governs-handoff-drift.md
@@ -13,6 +13,7 @@ derives_from: "canon/principles/vodka-architecture.md, canon/principles/dry-cano
 complements: "canon/constraints/release-validation-gate.md, canon/constraints/oddkit-prompt-pattern.md, canon/bootstrap/model-operating-contract.md"
 governs: "All conflicts between session-scoped artifacts (handoffs, ledgers, PRDs, scratch notes) and tier-1 / tier-2 canon. Binding on every orchestrator: when a session artifact recommends a path that contradicts canon, canon wins, full stop."
 status: active
+target_repo: "outcomes-driven-development"
 ---
 
 # Contract Governs Handoff Drift — Canon Wins When Session Artifacts Disagree

--- a/canon/principles/creators-get-paid.md
+++ b/canon/principles/creators-get-paid.md
@@ -13,6 +13,7 @@ derives_from: "canon/values/axioms.md, canon/architecture/substrate-stack.md, ca
 complements: "canon/principles/magical-first-run.md, canon/principles/symmetric-participation.md"
 governs: "The economy layer (L6) of the substrate stack — payment, marketplace, reputation, discoverability, settlement. Constrains how every other layer monetizes. The principle the program defends against the App-Store / landlord failure mode of substrates that drift from infrastructure into rent-extraction."
 status: active
+target_repo: "outcomes-driven-development"
 ---
 
 # Creators Get Paid — The Substrate Is Paid for What It Provides and Never Extracts From Creators' Work

--- a/canon/principles/discernment-layer.md
+++ b/canon/principles/discernment-layer.md
@@ -13,6 +13,7 @@ derives_from: "canon/values/axioms.md, canon/principles/capability-is-not-permis
 complements: "canon/principles/dream-house-principle.md, canon/constraints/measure-before-you-object.md, canon/observations/performed-prudence-anti-pattern.md, writings/the-dream-house-and-pre-optimization.md"
 governs: "How operators should allocate their attention and expertise when collaborating with AI systems that produce code, drafts, designs, or benchmarks"
 status: active
+target_repo: "outcomes-driven-development"
 ---
 
 # The Discernment Layer — What Human Expertise Does When AI Executes

--- a/canon/principles/doing-less-enables-more.md
+++ b/canon/principles/doing-less-enables-more.md
@@ -13,6 +13,7 @@ derives_from: "canon/principles/vodka-architecture.md, canon/principles/kiss-sim
 complements: "canon/principles/prompt-over-code.md, canon/principles/maintainability-one-person-indefinitely.md"
 governs: "Substrate-design decisions across all programs in this canon: oddkit, AMS, future MCP servers, future protocol-grade work. The empirical principle behind why vodka architecture wins where opinionated stacks lose. Recommended frame for evaluating any substrate proposal."
 status: active
+target_repo: "undecided"
 ---
 
 # Doing Less Enables More — The Inversion Principle for Substrate Design

--- a/canon/principles/dream-house-principle.md
+++ b/canon/principles/dream-house-principle.md
@@ -13,6 +13,7 @@ derives_from: "canon/values/axioms.md, canon/principles/capability-is-not-permis
 complements: "canon/principles/discernment-layer.md, canon/constraints/mode-discipline-and-bottleneck-respect.md, writings/the-dream-house-and-pre-optimization.md"
 governs: "All work that involves deciding what to cut, defer, simplify, or pre-emptively constrain before the full version has been drawn"
 status: active
+target_repo: "outcomes-driven-development"
 ---
 
 # The Dream House Principle — Draw the Full Version Before Cutting from Contact with Reality

--- a/canon/principles/dry-canon-says-it-once.md
+++ b/canon/principles/dry-canon-says-it-once.md
@@ -13,6 +13,7 @@ derives_from: "canon/principles/vodka-architecture.md, canon/constraints/oddkit-
 complements: "canon/principles/prompt-over-code.md, canon/values/axioms.md"
 governs: "All governance rule placement decisions in this program"
 status: active
+target_repo: "oddkit"
 ---
 
 # DRY — The Canon Says It Once, the Server Never Repeats It

--- a/canon/principles/envelope-time-fields.md
+++ b/canon/principles/envelope-time-fields.md
@@ -13,6 +13,7 @@ derives_from: "odd/constraint/anti-cache-lying.md, canon/principles/cache-fetche
 complements: "docs/appendices/epoch-8-2.md, canon/constraints/core-governance-baseline.md"
 governs: "Semantics of time fields in the oddkit response envelope and any oddkit-pattern MCP server envelope — what each field means, which MUST be present, and which are forbidden"
 status: draft
+target_repo: "oddkit"
 ---
 
 # Envelope Time Fields — Request Time vs Content Provenance

--- a/canon/principles/focus-is-exclusion.md
+++ b/canon/principles/focus-is-exclusion.md
@@ -7,6 +7,7 @@ tier: 1
 voice: neutral
 stability: stable
 tags: ["principles", "capacity", "exclusion", "focus", "delivery"]
+target_repo: "outcomes-driven-development"
 ---
 
 # Focus Is Exclusion

--- a/canon/principles/identity-resolved-by-protocol.md
+++ b/canon/principles/identity-resolved-by-protocol.md
@@ -17,6 +17,7 @@ governs: "All cross-document identity references in canon and consumers of canon
 complements:
   - "canon/principles/anti-cache-lying.md"
   - "docs/oddkit/specs/oddkit-resolve.md"
+target_repo: "oddkit"
 ---
 
 # Identity Is Resolved By The Protocol — Hardcoded References Are A Cached Lie

--- a/canon/principles/irreversibility-is-the-real-cost.md
+++ b/canon/principles/irreversibility-is-the-real-cost.md
@@ -7,6 +7,7 @@ tier: 1
 voice: neutral
 stability: stable
 tags: ["principles", "irreversibility", "epistemic-cost", "commitment", "exploration"]
+target_repo: "outcomes-driven-development"
 ---
 
 # Irreversibility Is the Real Cost

--- a/canon/principles/kiss-simplicity-is-the-ceiling.md
+++ b/canon/principles/kiss-simplicity-is-the-ceiling.md
@@ -13,6 +13,7 @@ derives_from: "canon/principles/vodka-architecture.md, canon/values/axioms.md"
 complements: "canon/principles/ritual-is-a-smell.md, canon/principles/maintainability-one-person-indefinitely.md"
 governs: "All MCP servers, tools, and orchestration layers in this program"
 status: active
+target_repo: "undecided"
 ---
 
 # KISS — Simplicity Is the Ceiling, Not the Floor

--- a/canon/principles/magical-first-run.md
+++ b/canon/principles/magical-first-run.md
@@ -13,6 +13,7 @@ derives_from: "canon/values/axioms.md, canon/architecture/substrate-stack.md, ca
 complements: "canon/principles/symmetric-participation.md, canon/principles/creators-get-paid.md, canon/voice/oddie-the-river-guide.md, canon/principles/methodology-personification.md"
 governs: "Application-layer (L5) products in the klappy ecosystem. The success metric for any user-facing application built on the substrate. Does not govern substrate-layer (L1-L4) canon, which is graded on dial-tone correctness rather than consumer ergonomics."
 status: active
+target_repo: "outcomes-driven-development"
 ---
 
 # Magical First-Run — Non-Technical Operators Must Reach Useful Agent Collaboration in Under a Minute

--- a/canon/principles/maintainability-one-person-indefinitely.md
+++ b/canon/principles/maintainability-one-person-indefinitely.md
@@ -13,6 +13,7 @@ derives_from: "canon/principles/vodka-architecture.md, canon/values/axioms.md"
 complements: "canon/principles/ritual-is-a-smell.md, canon/principles/kiss-simplicity-is-the-ceiling.md"
 governs: "All infrastructure sizing and complexity decisions in this program"
 status: active
+target_repo: "undecided"
 ---
 
 # Maintainability — One Person, Indefinitely

--- a/canon/principles/methodology-personification.md
+++ b/canon/principles/methodology-personification.md
@@ -13,6 +13,7 @@ derives_from: "canon/constraints/guide-posture.md, canon/values/axioms.md"
 complements: "canon/voice/oddie-the-river-guide.md, canon/principles/voice-as-cognitive-load-shedding.md, canon/observations/clone-klappy-to-oddie-recognition.md"
 governs: "Design decisions about whether and how to personify operational methodologies"
 status: active
+target_repo: "outcomes-driven-development"
 ---
 
 # Methodology Personification — When a Named Practice Becomes More Accessible Through a Voice That Demonstrates It

--- a/canon/principles/odds-relationship-to-documentation.md
+++ b/canon/principles/odds-relationship-to-documentation.md
@@ -11,6 +11,7 @@ tags:
   - documentation
   - outcomes
   - epistemic-hygiene
+target_repo: "outcomes-driven-development"
 ---
 
 # Documentation Is the Lever, Not the Goal

--- a/canon/principles/partial-data-with-transparency-and-background-warm.md
+++ b/canon/principles/partial-data-with-transparency-and-background-warm.md
@@ -13,6 +13,7 @@ derives_from: "canon/values/axioms.md, canon/principles/vodka-architecture.md, c
 complements: "canon/principles/cache-fetches-and-parses.md, canon/principles/type-contract-plus-adversarial-review.md"
 governs: "Any tool handler, MCP server endpoint, or user-facing operation whose natural shape is 'scan a corpus to produce complete data.' Binding on all oddkit-pattern MCP servers in this program when deciding where expensive work runs relative to the user-blocking path."
 status: active
+target_repo: "oddkit"
 ---
 
 # Partial Data With Transparency And Background Warm — Never Block The User On A Corpus Scan

--- a/canon/principles/persistence-must-be-intentional.md
+++ b/canon/principles/persistence-must-be-intentional.md
@@ -15,6 +15,7 @@ tags:
   - epistemic-discipline
   - failure-modes
 epoch: 5
+target_repo: "outcomes-driven-development"
 ---
 
 # Persistence Must Be Intentional

--- a/canon/principles/prompt-over-code.md
+++ b/canon/principles/prompt-over-code.md
@@ -13,6 +13,7 @@ derives_from: "canon/principles/vodka-architecture.md, docs/appendices/conventio
 complements: "odd/prompt-architecture.md, canon/principles/ritual-is-a-smell.md, canon/principles/dry-canon-says-it-once.md"
 governs: "All governance rule implementation decisions in this program"
 status: active
+target_repo: "undecided"
 ---
 
 # Prompt Over Code — Fully Programmable Governance Without Changing the Server

--- a/canon/principles/quality-attributes-are-in-tension.md
+++ b/canon/principles/quality-attributes-are-in-tension.md
@@ -13,6 +13,7 @@ derives_from: "canon/definitions/software-virtues-vocabulary.md, canon/values/ax
 complements: "odd/maturity.md, canon/constraints/mode-discipline-and-bottleneck-respect.md"
 governs: "How tradeoffs between competing software properties are reasoned about across canon. Holds for any set of quality attributes, not only the canonical ten. Forbids reasoning that flattens the tradeoff space into a single objective function. Requires phase-aware weighting rather than universal rankings."
 status: active
+target_repo: "outcomes-driven-development"
 ---
 
 # Quality Attributes Are In Tension — The Tradeoff Space Cannot Be Flattened

--- a/canon/principles/ritual-is-a-smell.md
+++ b/canon/principles/ritual-is-a-smell.md
@@ -7,6 +7,7 @@ tier: 2
 voice: first_person
 stability: semi_stable
 tags: ["ritual", "design-smell", "automation", "stateless", "continuity", "ergonomics"]
+target_repo: "outcomes-driven-development"
 ---
 
 # Ritual Is a Smell

--- a/canon/principles/scope-over-folders.md
+++ b/canon/principles/scope-over-folders.md
@@ -7,6 +7,7 @@ tier: 2
 voice: first_person
 stability: draft
 tags: ["epistemic-scope", "portability", "ritual-smell", "oddkit"]
+target_repo: "outcomes-driven-development"
 ---
 
 # Scope Over Folders

--- a/canon/principles/scoped-truth.md
+++ b/canon/principles/scoped-truth.md
@@ -22,6 +22,7 @@ derives_from:
 complements:
   - canon/principles/capability-is-not-permission.md
   - docs/explorations/epoch-signal-operator-governance.md
+target_repo: "outcomes-driven-development"
 ---
 
 # Scoped Truth — Axioms Travel, Domain Doesn't

--- a/canon/principles/sessions-mirror-modes.md
+++ b/canon/principles/sessions-mirror-modes.md
@@ -13,6 +13,7 @@ derives_from: "canon/definitions/epistemic-modes.md, canon/principles/verificati
 complements: "canon/constraints/mode-transitions-require-encoded-handoff.md, canon/methods/persona-shaped-agent-runtime.md, docs/mode-separated-conversations.md"
 governs: "All multi-mode work — agent-driven and human-driven — where the same artifact passes through more than one epistemic mode"
 status: proposed
+target_repo: "outcomes-driven-development"
 ---
 
 # Sessions Mirror Modes — Each Epistemic Mode Earns Its Own Session

--- a/canon/principles/specs-lock-at-implementation.md
+++ b/canon/principles/specs-lock-at-implementation.md
@@ -13,6 +13,7 @@ derives_from: "canon/principles/contract-governs-handoff-drift.md, canon/princip
 complements: "canon/methods/planning-queue.md, canon/principles/maintainability-one-person-indefinitely.md"
 governs: "All spec-document edits after implementation has begun — applies to API specs, protocol specs, schema specs, version specs, and any document an implementer (human or agent) is building against"
 status: active
+target_repo: "outcomes-driven-development"
 ---
 
 # Specs Lock at Implementation — A Spec Is a Contract; Don't Change It Mid-Build

--- a/canon/principles/symmetric-participation.md
+++ b/canon/principles/symmetric-participation.md
@@ -13,6 +13,7 @@ derives_from: "canon/values/axioms.md, canon/architecture/substrate-stack.md, ca
 complements: "canon/principles/magical-first-run.md, canon/principles/creators-get-paid.md, canon/principles/dream-house-principle.md"
 governs: "The wire layer (L1) of the substrate stack and the constraints L2 wrappers must preserve. Forbids any feature that would special-case the substrate by peer type. Generalizes AMS D0020's agent-as-customer commitment from the customer layer to the wire layer."
 status: active
+target_repo: "outcomes-driven-development"
 ---
 
 # Symmetric Participation — Every Peer on the Substrate Interacts Through Identical Wire Primitives

--- a/canon/principles/type-contract-plus-adversarial-review.md
+++ b/canon/principles/type-contract-plus-adversarial-review.md
@@ -13,6 +13,7 @@ derives_from: "canon/values/axioms.md, canon/principles/verification-requires-fr
 complements: "canon/constraints/release-validation-gate.md, canon/principles/cache-fetches-and-parses.md"
 governs: "Any code change whose correctness depends on accurately reporting its own incompleteness, partiality, or failure. Binding on every orchestrator shipping type-carrying interfaces across trust boundaries in oddkit-pattern MCP servers and their consumers."
 status: active
+target_repo: "outcomes-driven-development"
 ---
 
 # Type Contract Plus Adversarial Review — Boundary Types Are Necessary, Not Sufficient

--- a/canon/principles/verification-requires-fresh-context.md
+++ b/canon/principles/verification-requires-fresh-context.md
@@ -12,6 +12,7 @@ date: 2026-04-07
 derives_from: "canon/values/axioms.md, canon/principles/capability-is-not-permission.md, odd/appendices/quantum-development.md"
 complements: "writings/the-same-rules-fresh-eyes.md, canon/methods/revision-lens-sequence.md, canon/constraints/relational-sensitivity.md"
 governs: "All verification and review processes for public essays, canon documents, and code"
+target_repo: "outcomes-driven-development"
 ---
 
 # Verification Requires Fresh Context — A Creator Cannot Be Their Own Critic

--- a/canon/principles/vodka-architecture.md
+++ b/canon/principles/vodka-architecture.md
@@ -13,6 +13,7 @@ derives_from: "canon/values/axioms.md, canon/principles/ritual-is-a-smell.md, ca
 complements: "docs/architecture/epistemic-os-layers.md, odd/prompt-architecture.md, canon/constraints/oddkit-prompt-pattern.md"
 governs: "All MCP servers, knowledge base serving infrastructure, and orchestration layers in this program"
 status: active
+target_repo: "undecided"
 ---
 
 # Vodka Architecture — The Design Pattern for Epistemic Infrastructure

--- a/canon/principles/voice-as-cognitive-load-shedding.md
+++ b/canon/principles/voice-as-cognitive-load-shedding.md
@@ -13,6 +13,7 @@ derives_from: "canon/values/axioms.md, canon/constraints/guide-posture.md"
 complements: "canon/voice/oddie-the-river-guide.md, canon/constraints/ai-voice-cliches.md"
 governs: "Voice design decisions for surfaces operating under high information density"
 status: active
+target_repo: "outcomes-driven-development"
 ---
 
 # Voice as Cognitive Load Shedding — Why Dryness, Calm, and Brevity Are Structural Under Pressure

--- a/canon/values/axioms.md
+++ b/canon/values/axioms.md
@@ -13,6 +13,7 @@ governs: "All epistemic constraints, validators, and definitions of done derive 
 start_here: true
 start_here_order: 11
 start_here_label: Foundational Axioms
+target_repo: "outcomes-driven-development"
 ---
 
 # Foundational Axioms

--- a/canon/values/drift.md
+++ b/canon/values/drift.md
@@ -12,6 +12,7 @@ date: 2026-02-15
 derives_from: "canon/values/axioms.md"
 complements: "canon/methods/weighted-relevance-and-arbitration.md, canon/methods/self-audit.md, odd/ledger/epistemic-ledger.md"
 constraint: "Drift is expected in any living system. Its presence must never be treated as failure."
+target_repo: "outcomes-driven-development"
 ---
 
 # Drift — Evidence of a System That's Still Learning

--- a/canon/values/orientation.md
+++ b/canon/values/orientation.md
@@ -11,6 +11,7 @@ epoch: E0005
 date: 2026-02-09
 derives_from: "canon/values/axioms.md"
 constraint: "This document cannot override the axioms. If tension arises, the axioms govern."
+target_repo: "outcomes-driven-development"
 ---
 
 # Orientation

--- a/canon/values/shared-values-as-trust-proxy.md
+++ b/canon/values/shared-values-as-trust-proxy.md
@@ -16,6 +16,7 @@ status: final
 start_here: true
 start_here_order: 3
 start_here_label: "Shared Values as a Trust Proxy"
+target_repo: "outcomes-driven-development"
 ---
 
 # Shared Values as a Trust Proxy

--- a/canon/values/trust-kernel.md
+++ b/canon/values/trust-kernel.md
@@ -16,6 +16,7 @@ constraint: "This is a principle (why), not a process (how). The axioms, constra
 start_here: true
 start_here_order: 10
 start_here_label: "Trust Is Built by Managing Expectations — The Kernel"
+target_repo: "outcomes-driven-development"
 ---
 
 # Trust Is Built by Managing Expectations

--- a/docs/oddkit/ABOUT.md
+++ b/docs/oddkit/ABOUT.md
@@ -7,6 +7,7 @@ tier: 1
 voice: neutral
 stability: stable
 tags: ["oddkit", "odd", "definition", "outcomes-driven-development", "what-is-odd", "about", "orientation"]
+target_repo: "oddkit"
 ---
 
 # About oddkit

--- a/docs/oddkit/IMPL-A-explain-mode-annotation.md
+++ b/docs/oddkit/IMPL-A-explain-mode-annotation.md
@@ -8,6 +8,7 @@ voice: neutral
 stability: evolving
 status: superseded
 tags: ["oddkit", "implementation", "epistemic-modes"]
+target_repo: "oddkit"
 ---
 
 # Implementation Instruction Set A

--- a/docs/oddkit/IMPL-B-mode-headers.md
+++ b/docs/oddkit/IMPL-B-mode-headers.md
@@ -8,6 +8,7 @@ voice: neutral
 stability: evolving
 status: superseded
 tags: ["oddkit", "implementation", "epistemic-modes"]
+target_repo: "oddkit"
 ---
 
 # Implementation Instruction Set B

--- a/docs/oddkit/IMPL-catalog-recent.md
+++ b/docs/oddkit/IMPL-catalog-recent.md
@@ -9,6 +9,7 @@ stability: evolving
 tags: ["oddkit", "catalog", "discovery", "metadata", "recent", "temporal", "implementation", "epoch-7"]
 epoch: E0007
 date: 2026-04-03
+target_repo: "oddkit"
 ---
 
 # Implementation: Catalog Metadata Exposure — Articles List with Full Frontmatter

--- a/docs/oddkit/IMPL-content-addressed-caching.md
+++ b/docs/oddkit/IMPL-content-addressed-caching.md
@@ -9,6 +9,7 @@ stability: evolving
 status: implemented
 tags: ["oddkit", "implementation", "caching", "content-addressed", "anti-cache-lying"]
 derives_from: "odd/constraint/anti-cache-lying.md"
+target_repo: "oddkit"
 ---
 
 # Implementation: Replace TTL Caching with Content-Addressed Storage in OddKit

--- a/docs/oddkit/IMPL-guide-posture-gate.md
+++ b/docs/oddkit/IMPL-guide-posture-gate.md
@@ -11,6 +11,7 @@ epoch: E0005
 date: 2026-02-17
 derives_from: "canon/constraints/guide-posture.md"
 complements: "docs/oddkit/IMPL-writing-canon-gate.md"
+target_repo: "oddkit"
 ---
 
 # Implementation: Surface Guide Posture for Public-Facing Deliverables

--- a/docs/oddkit/IMPL-oddkit-diff.md
+++ b/docs/oddkit/IMPL-oddkit-diff.md
@@ -13,6 +13,7 @@ date: 2026-02-18
 derives_from: "docs/planning/automated-changelog.md, docs/planning/oddkit-write-access.md, odd/ledger/epistemic-ledger.md, canon/principles/ritual-is-a-smell.md, odd/constraint/anti-cache-lying.md"
 complements: "docs/oddkit/IMPL-content-addressed-caching.md, canon/CHANGELOG.md, canon/methods/planning-queue.md"
 governs: "oddkit MCP server diff action, changelog generation pipeline"
+target_repo: "oddkit"
 ---
 
 # Implementation: oddkit_diff — The Universal "What Moved" Primitive

--- a/docs/oddkit/IMPL-oddkit-write.md
+++ b/docs/oddkit/IMPL-oddkit-write.md
@@ -12,6 +12,7 @@ date: 2026-02-25
 derives_from: "docs/decisions/D0017-oddkit-write-path.md, docs/planning/oddkit-write-access.md, canon/principles/ritual-is-a-smell.md, odd/constraint/use-only-what-hurts.md"
 complements: "docs/oddkit/IMPL-content-addressed-caching.md, docs/oddkit/IMPL-oddkit-diff.md"
 governs: "oddkit MCP server write action implementation"
+target_repo: "oddkit"
 ---
 
 # Implementation: oddkit_write — One Action, Content to Repo

--- a/docs/oddkit/IMPL-writing-canon-gate.md
+++ b/docs/oddkit/IMPL-writing-canon-gate.md
@@ -8,6 +8,7 @@ voice: neutral
 stability: stable
 tags: ["oddkit", "implementation", "writing-canon", "progressive-disclosure", "gate"]
 derives_from: "canon/meta/writing-canon.md"
+target_repo: "oddkit"
 ---
 
 # Implementation: Surface Writing Canon as a Gate for Document Deliverables

--- a/docs/oddkit/SYSTEM-MAP.md
+++ b/docs/oddkit/SYSTEM-MAP.md
@@ -7,6 +7,7 @@ tier: 2
 voice: neutral
 stability: stable
 tags: ["oddkit", "odd", "outcomes-driven-development", "orchestrator", "librarian", "validation", "arbitration"]
+target_repo: "oddkit"
 ---
 
 # Oddkit System Map

--- a/docs/oddkit/WHY.md
+++ b/docs/oddkit/WHY.md
@@ -7,6 +7,7 @@ tier: 1
 voice: neutral
 stability: stable
 tags: ["orientation", "oddkit", "agents", "epistemic-hygiene"]
+target_repo: "oddkit"
 ---
 
 # Why oddkit Exists

--- a/docs/oddkit/architecture/non-diff-review-surfaces.md
+++ b/docs/oddkit/architecture/non-diff-review-surfaces.md
@@ -12,6 +12,7 @@ date: 2026-04-20
 derives_from: "odd/ledger/2026-04-20-post-4-7-proactive-loop-experience.md, odd/ledger/2026-04-19-validator-closeout-and-0.17.0.md, odd/ledger/journal/2026-04-17-pr100-rage-quit-handoff.md"
 complements: "canon/methods/self-audit.md, canon/constraints/release-validation-gate.md"
 governs: "Review-surface architecture for oddkit and klappy.dev releases"
+target_repo: "oddkit"
 ---
 
 # Non-Diff Review Surfaces — Catching System-Level Issues Diff-Scoped Validators Miss

--- a/docs/oddkit/encode-persistence-gap.md
+++ b/docs/oddkit/encode-persistence-gap.md
@@ -12,6 +12,7 @@ date: 2026-04-03
 derives_from: "odd/constraint/use-only-what-hurts.md, canon/values/axioms.md, canon/principles/ritual-is-a-smell.md"
 complements: "odd/ledger/epistemic-ledger.md, docs/oddkit/tools/oddkit_encode.md, writings/the-project-journal.md, canon/diagnostics/ritual-detected.md, writings/learning-in-the-open.md, canon/values/drift.md"
 governs: "oddkit_encode tool description, oddkit_orient behavior, and all consumers of the encode action"
+target_repo: "oddkit"
 ---
 
 # Encode Does Not Persist, Nobody Knows OLDC+H, and the Fix Is Continuous Encoding

--- a/docs/oddkit/epistemic-instructions.md
+++ b/docs/oddkit/epistemic-instructions.md
@@ -5,6 +5,7 @@ exposure: nav
 tier: 2
 audience: docs
 stability: stable
+target_repo: "oddkit"
 ---
 
 # oddkit Epistemic Instructions

--- a/docs/oddkit/evidence/challenge-governance-articles-commit.md
+++ b/docs/oddkit/evidence/challenge-governance-articles-commit.md
@@ -7,6 +7,7 @@ tier: 3
 voice: neutral
 stability: stable
 tags: ["docs", "oddkit", "evidence", "gauntlet"]
+target_repo: "oddkit"
 ---
 
 # Gauntlet Evidence — Challenge Governance Articles Commit

--- a/docs/oddkit/modes.md
+++ b/docs/oddkit/modes.md
@@ -8,6 +8,7 @@ voice: neutral
 stability: evolving
 epoch: E0005
 tags: ["oddkit", "agents", "epistemic-modes"]
+target_repo: "oddkit"
 ---
 
 # Epistemic Mode Guidance for oddkit

--- a/docs/oddkit/positioning.md
+++ b/docs/oddkit/positioning.md
@@ -13,6 +13,7 @@ complements: "odd/ledger/epistemic-ledger.md, canon/values/trust-kernel.md, cano
 start_here: true
 start_here_order: 8
 start_here_label: "oddkit — A Protocol, Not a Platform"
+target_repo: "oddkit"
 ---
 
 # oddkit — A Protocol, Not a Platform

--- a/docs/oddkit/proactive/continuous-encoding.md
+++ b/docs/oddkit/proactive/continuous-encoding.md
@@ -9,6 +9,7 @@ stability: stable
 tags: ["odd", "oddkit", "encode", "dolcheo", "oldc-h", "proactive", "continuous", "journal", "epoch-7"]
 epoch: E0007
 date: 2026-04-03
+target_repo: "oddkit"
 ---
 
 # Continuous DOLCHEO Encoding — Track at Every Turn, Not Just Session End

--- a/docs/oddkit/proactive/dolche-vocabulary.md
+++ b/docs/oddkit/proactive/dolche-vocabulary.md
@@ -15,6 +15,7 @@ complements: "docs/oddkit/proactive/posture-lapse.md, docs/oddkit/proactive/proa
 governs: "All session capture, project journal entries, and encode invocations"
 status: superseded
 superseded_by: "canon/definitions/dolcheo-vocabulary.md"
+target_repo: "oddkit"
 ---
 
 # DOLCHE — Six Dimensions of Session Capture

--- a/docs/oddkit/proactive/e0007-validation.md
+++ b/docs/oddkit/proactive/e0007-validation.md
@@ -9,6 +9,7 @@ stability: stable
 tags: ["odd", "oddkit", "epoch-7", "proactive", "validation", "ab-test", "evidence", "bm25"]
 epoch: E0007
 date: 2026-04-03
+target_repo: "oddkit"
 ---
 
 # E0007 Validation — A/B Test Results for Proactive Posture

--- a/docs/oddkit/proactive/encode-does-not-persist.md
+++ b/docs/oddkit/proactive/encode-does-not-persist.md
@@ -9,6 +9,7 @@ stability: stable
 tags: ["odd", "oddkit", "encode", "persistence", "proactive", "epoch-7"]
 epoch: E0007
 date: 2026-04-03
+target_repo: "oddkit"
 ---
 
 # Encode Does Not Persist — The Caller Must Save

--- a/docs/oddkit/proactive/handoff-to-new-conversation.md
+++ b/docs/oddkit/proactive/handoff-to-new-conversation.md
@@ -9,6 +9,7 @@ stability: stable
 tags: ["odd", "oddkit", "handoff", "proactive", "context-window", "saturation", "bootstrap", "epoch-7"]
 epoch: E0007
 date: 2026-04-03
+target_repo: "oddkit"
 ---
 
 # Proactive Handoff — Detect Saturation, Bootstrap the Next Conversation

--- a/docs/oddkit/proactive/oldc-h-vocabulary.md
+++ b/docs/oddkit/proactive/oldc-h-vocabulary.md
@@ -11,6 +11,7 @@ epoch: E0007
 date: 2026-04-03
 superseded_by: "docs/oddkit/proactive/dolche-vocabulary.md"
 supersession_reason: "Superseded by DOLCHE (six dimensions, adds Encode as meta-action) and then by DOLCHEO (seven dimensions, adds Open as forward-pointing thread). Walk superseded_by transitively for current canonical: klappy://canon/definitions/dolcheo-vocabulary."
+target_repo: "oddkit"
 ---
 
 # OLDC+H — The Five Standard Artifact Types for Session Capture

--- a/docs/oddkit/proactive/posture-lapse.md
+++ b/docs/oddkit/proactive/posture-lapse.md
@@ -13,6 +13,7 @@ derives_from: "docs/appendices/epoch-7.md, canon/principles/ritual-is-a-smell.md
 complements: "docs/oddkit/proactive/proactive-orient.md, docs/oddkit/proactive/proactive-gate.md, docs/oddkit/proactive/proactive-search.md, docs/oddkit/proactive/proactive-challenge.md, docs/oddkit/proactive/proactive-validate.md, docs/oddkit/proactive/proactive-preflight.md, docs/oddkit/proactive/continuous-encoding.md, docs/oddkit/proactive/proactive-identity-of-integrity.md"
 governs: "All agent behavior in oddkit-powered sessions"
 status: active
+target_repo: "oddkit"
 ---
 
 # Proactive Posture Lapse — Detecting When the Cognitive Rhythm Breaks Down

--- a/docs/oddkit/proactive/proactive-bootstrap.md
+++ b/docs/oddkit/proactive/proactive-bootstrap.md
@@ -9,6 +9,7 @@ stability: stable
 tags: ["odd", "oddkit", "proactive", "bootstrap", "system-prompt", "project-instructions", "epoch-7"]
 epoch: E0007
 date: 2026-04-03
+target_repo: "oddkit"
 ---
 
 # Proactive Bootstrap — System Prompt for E0007 Agents

--- a/docs/oddkit/proactive/proactive-challenge.md
+++ b/docs/oddkit/proactive/proactive-challenge.md
@@ -9,6 +9,7 @@ stability: stable
 tags: ["odd", "oddkit", "challenge", "proactive", "pressure-test", "epoch-7"]
 epoch: E0007
 date: 2026-04-03
+target_repo: "oddkit"
 ---
 
 # Proactive Challenge — Challenge Before Encoding, Not When Asked

--- a/docs/oddkit/proactive/proactive-gate.md
+++ b/docs/oddkit/proactive/proactive-gate.md
@@ -9,6 +9,7 @@ stability: stable
 tags: ["odd", "oddkit", "gate", "proactive", "mode-transition", "epoch-7"]
 epoch: E0007
 date: 2026-04-03
+target_repo: "oddkit"
 ---
 
 # Proactive Gate — Gate at Every Mode Transition, Not Just Formal Ones

--- a/docs/oddkit/proactive/proactive-identity-of-integrity.md
+++ b/docs/oddkit/proactive/proactive-identity-of-integrity.md
@@ -9,6 +9,7 @@ stability: stable
 tags: ["odd", "oddkit", "creed", "axioms", "proactive", "drift", "hallucination", "epoch-7"]
 epoch: E0007
 date: 2026-04-03
+target_repo: "oddkit"
 ---
 
 # Proactive Identity of Integrity — Surface the Creed to Prevent Drift

--- a/docs/oddkit/proactive/proactive-orient.md
+++ b/docs/oddkit/proactive/proactive-orient.md
@@ -9,6 +9,7 @@ stability: stable
 tags: ["odd", "oddkit", "orient", "proactive", "context-shift", "epoch-7"]
 epoch: E0007
 date: 2026-04-03
+target_repo: "oddkit"
 ---
 
 # Proactive Orient — Reorient at Every Context Shift

--- a/docs/oddkit/proactive/proactive-preflight.md
+++ b/docs/oddkit/proactive/proactive-preflight.md
@@ -9,6 +9,7 @@ stability: stable
 tags: ["odd", "oddkit", "preflight", "proactive", "execution", "epoch-7"]
 epoch: E0007
 date: 2026-04-03
+target_repo: "oddkit"
 ---
 
 # Proactive Preflight — Preflight Before Every Execution Task

--- a/docs/oddkit/proactive/proactive-search.md
+++ b/docs/oddkit/proactive/proactive-search.md
@@ -9,6 +9,7 @@ stability: stable
 tags: ["odd", "oddkit", "search", "proactive", "canon", "epoch-7"]
 epoch: E0007
 date: 2026-04-03
+target_repo: "oddkit"
 ---
 
 # Proactive Search — Search Before Claiming, Not After Failing

--- a/docs/oddkit/proactive/proactive-session-close.md
+++ b/docs/oddkit/proactive/proactive-session-close.md
@@ -9,6 +9,7 @@ stability: stable
 tags: ["odd", "oddkit", "proactive", "provenance", "journal", "changelog", "version", "ritual", "epoch-7"]
 epoch: E0007
 date: 2026-04-03
+target_repo: "oddkit"
 ---
 
 # Proactive Artifact Provenance — Capture What Happened Before Finalizing

--- a/docs/oddkit/proactive/proactive-validate.md
+++ b/docs/oddkit/proactive/proactive-validate.md
@@ -9,6 +9,7 @@ stability: stable
 tags: ["odd", "oddkit", "validate", "proactive", "completion", "epoch-7"]
 epoch: E0007
 date: 2026-04-03
+target_repo: "oddkit"
 ---
 
 # Proactive Validate — Validate Before Claiming Done

--- a/docs/oddkit/proactive/terminology-project-journal.md
+++ b/docs/oddkit/proactive/terminology-project-journal.md
@@ -9,6 +9,7 @@ stability: stable
 tags: ["odd", "oddkit", "terminology", "project-journal", "epistemic-ledger", "naming", "epoch-7"]
 epoch: E0007
 date: 2026-04-03
+target_repo: "oddkit"
 ---
 
 # Terminology — Project Journal Over Epistemic Ledger

--- a/docs/oddkit/prompts/epistemic-guide.md
+++ b/docs/oddkit/prompts/epistemic-guide.md
@@ -7,6 +7,7 @@ tier: 2
 voice: neutral
 stability: evolving
 tags: ["oddkit", "prompt", "mcp", "epistemics", "guide", "orchestration"]
+target_repo: "oddkit"
 ---
 
 # Epistemic Guide

--- a/docs/oddkit/release-notes/2026-04-20-post-4-7-adaptation.md
+++ b/docs/oddkit/release-notes/2026-04-20-post-4-7-adaptation.md
@@ -12,6 +12,7 @@ date: 2026-04-20
 derives_from: "canon/principles/ritual-is-a-smell.md, writings/copy-paste.md, odd/ledger/2026-04-20-post-4-7-proactive-loop-experience.md"
 governs: "Operator and agent behavior after PR #133 merges"
 related_pr: "https://github.com/klappy/klappy.dev/pull/133"
+target_repo: "oddkit"
 ---
 
 # Release Notes — Post-4.7 Adaptation Suite (2026-04-20)

--- a/docs/oddkit/release-notes/2026-05-12-epoch-9-substrate-becomes-the-wire.md
+++ b/docs/oddkit/release-notes/2026-05-12-epoch-9-substrate-becomes-the-wire.md
@@ -11,6 +11,7 @@ epoch: E0009
 date: 2026-05-12
 derives_from: "canon/constraints/governance-change-discipline.md, docs/appendices/epoch-9.md, writings/we-were-the-wire.md, canon/principles/agents-need-their-own-wire.md, canon/architecture/substrate-stack.md, canon/methods/dispatch-paths.md"
 governs: "Operator and agent behavior after this release lands — the substrate stack is the default integration pattern, operator-as-wire is named as a design smell, autonomous-trigger is the canonical path for everything except synchronous user-facing assistance."
+target_repo: "oddkit"
 ---
 
 # Release Notes — Epoch 9: Substrate Becomes the Wire (2026-05-12)

--- a/docs/oddkit/responses/envelope-reference.md
+++ b/docs/oddkit/responses/envelope-reference.md
@@ -11,6 +11,7 @@ epoch: E0008
 date: 2026-04-26
 derives_from: "canon/constraints/telemetry-governance.md, canon/principles/vodka-architecture.md"
 complements: "docs/oddkit/tools/telemetry_public.md"
+target_repo: "oddkit"
 ---
 
 # Response Envelope Reference — debug.trace and the Per-Request Story

--- a/docs/oddkit/sales/unified-account-launch-plan.md
+++ b/docs/oddkit/sales/unified-account-launch-plan.md
@@ -13,6 +13,7 @@ derives_from: "canon/constraints/borrow-evaluation-before-implementation.md, can
 complements: "odd/handoffs/2026-05-16-mcp-bearer-token-middleware.md, https://oddkit.dev/ (authoritative tier copy + pricing + design), workers/src/sales-page.ts (klappy/oddkit)"
 governs: "Every artifact produced by the customer-surface build session — Supabase schema, Stripe products + prices, Lovable React app routes, application forms, admin queue, referral system, BYO Anthropic key field, ToS + privacy pages. Defines what ships, what does not, and what the build session is forbidden to invent."
 status: active
+target_repo: "oddkit"
 ---
 
 # Unified Account Launch Plan — Customer Surface, All Tiers, One Lovable Build

--- a/docs/oddkit/specs/oddkit-audit.md
+++ b/docs/oddkit/specs/oddkit-audit.md
@@ -16,6 +16,7 @@ derives_from:
   - "docs/oddkit/specs/oddkit-resolve.md"
 governs: "Mechanical detection of dead klappy:// references at PR time"
 supersedes: "DRAFT v2.1 (2026-04-26, default-scope narrowed); DRAFT v1 (2026-04-26, four-check version)"
+target_repo: "oddkit"
 ---
 
 # oddkit_audit — Action Specification (DRAFT v2.2 — KISS)

--- a/docs/oddkit/specs/oddkit-resolve.md
+++ b/docs/oddkit/specs/oddkit-resolve.md
@@ -16,6 +16,7 @@ derives_from:
   - "docs/oddkit/IMPL-catalog-recent.md"
 governs: "Resolution of klappy:// URIs by every consumer of canon"
 supersedes: "DRAFT v3 (2026-04-24, pre-Vodka-cut)"
+target_repo: "oddkit"
 ---
 
 # oddkit_resolve — Action Specification (DRAFT v4 — KISS)

--- a/docs/oddkit/tools/oddkit_catalog.md
+++ b/docs/oddkit/tools/oddkit_catalog.md
@@ -7,6 +7,7 @@ tier: 2
 voice: neutral
 stability: evolving
 tags: ["oddkit", "tool", "epistemics", "catalog", "discovery", "navigation"]
+target_repo: "oddkit"
 ---
 
 # oddkit_catalog

--- a/docs/oddkit/tools/oddkit_challenge.md
+++ b/docs/oddkit/tools/oddkit_challenge.md
@@ -7,6 +7,7 @@ tier: 2
 voice: neutral
 stability: evolving
 tags: ["oddkit", "tool", "epistemics", "challenge", "validation"]
+target_repo: "oddkit"
 ---
 
 # oddkit_challenge

--- a/docs/oddkit/tools/oddkit_cleanup_storage.md
+++ b/docs/oddkit/tools/oddkit_cleanup_storage.md
@@ -7,6 +7,7 @@ tier: 2
 voice: neutral
 stability: evolving
 tags: ["oddkit", "tool", "maintenance", "storage", "cleanup", "cache"]
+target_repo: "oddkit"
 ---
 
 # oddkit_cleanup_storage

--- a/docs/oddkit/tools/oddkit_encode.md
+++ b/docs/oddkit/tools/oddkit_encode.md
@@ -7,6 +7,7 @@ tier: 2
 voice: neutral
 stability: evolving
 tags: ["oddkit", "tool", "epistemics", "encoding", "decisions", "durability"]
+target_repo: "oddkit"
 ---
 
 # oddkit_encode

--- a/docs/oddkit/tools/oddkit_gate.md
+++ b/docs/oddkit/tools/oddkit_gate.md
@@ -7,6 +7,7 @@ tier: 2
 voice: neutral
 stability: evolving
 tags: ["oddkit", "tool", "epistemics", "gating", "transitions", "deceleration"]
+target_repo: "oddkit"
 ---
 
 # oddkit_gate

--- a/docs/oddkit/tools/oddkit_get.md
+++ b/docs/oddkit/tools/oddkit_get.md
@@ -7,6 +7,7 @@ tier: 2
 voice: neutral
 stability: evolving
 tags: ["oddkit", "tool", "epistemics", "retrieval", "get", "lookup"]
+target_repo: "oddkit"
 ---
 
 # oddkit_get

--- a/docs/oddkit/tools/oddkit_orient.md
+++ b/docs/oddkit/tools/oddkit_orient.md
@@ -7,6 +7,7 @@ tier: 2
 voice: neutral
 stability: evolving
 tags: ["oddkit", "tool", "epistemics", "orientation", "modes"]
+target_repo: "oddkit"
 ---
 
 # oddkit_orient

--- a/docs/oddkit/tools/oddkit_preflight.md
+++ b/docs/oddkit/tools/oddkit_preflight.md
@@ -7,6 +7,7 @@ tier: 2
 voice: neutral
 stability: evolving
 tags: ["oddkit", "tool", "epistemics", "preflight", "implementation", "constraints"]
+target_repo: "oddkit"
 ---
 
 # oddkit_preflight

--- a/docs/oddkit/tools/oddkit_search.md
+++ b/docs/oddkit/tools/oddkit_search.md
@@ -7,6 +7,7 @@ tier: 2
 voice: neutral
 stability: evolving
 tags: ["oddkit", "tool", "epistemics", "search", "retrieval", "discovery"]
+target_repo: "oddkit"
 ---
 
 # oddkit_search

--- a/docs/oddkit/tools/oddkit_validate.md
+++ b/docs/oddkit/tools/oddkit_validate.md
@@ -7,6 +7,7 @@ tier: 2
 voice: neutral
 stability: evolving
 tags: ["oddkit", "tool", "epistemics", "validation", "completion", "evidence"]
+target_repo: "oddkit"
 ---
 
 # oddkit_validate

--- a/docs/oddkit/tools/oddkit_version.md
+++ b/docs/oddkit/tools/oddkit_version.md
@@ -7,6 +7,7 @@ tier: 2
 voice: neutral
 stability: evolving
 tags: ["oddkit", "tool", "epistemics", "version", "maintenance"]
+target_repo: "oddkit"
 ---
 
 # oddkit_version

--- a/docs/oddkit/tools/telemetry_policy.md
+++ b/docs/oddkit/tools/telemetry_policy.md
@@ -11,6 +11,7 @@ epoch: E0008
 date: 2026-04-09
 derives_from: "canon/constraints/telemetry-governance.md"
 complements: "docs/oddkit/tools/telemetry_public.md"
+target_repo: "oddkit"
 ---
 
 # telemetry_policy

--- a/docs/oddkit/tools/telemetry_public.md
+++ b/docs/oddkit/tools/telemetry_public.md
@@ -11,6 +11,7 @@ epoch: E0008
 date: 2026-04-26
 derives_from: "canon/constraints/telemetry-governance.md, canon/principles/vodka-architecture.md, canon/principles/prompt-over-code.md"
 complements: "docs/oddkit/tools/telemetry_policy.md, docs/oddkit/responses/envelope-reference.md"
+target_repo: "oddkit"
 ---
 
 # telemetry_public — Raw SQL Against the Public Telemetry Dataset

--- a/interfaces/canon-frontmatter/CONTRACT.md
+++ b/interfaces/canon-frontmatter/CONTRACT.md
@@ -7,6 +7,7 @@ tier: 2
 voice: neutral
 stability: stable
 tags: ["interfaces", "canon", "frontmatter", "schema", "verification"]
+target_repo: "oddkit"
 ---
 
 # Canon Frontmatter Contract

--- a/interfaces/manifest/CONTRACT.md
+++ b/interfaces/manifest/CONTRACT.md
@@ -2,6 +2,7 @@
 contract: manifest
 version: 2.0.0
 status: active
+target_repo: "oddkit"
 ---
 
 # Manifest Contract (manifest@2.0.0)

--- a/interfaces/mcp/CONTRACT.md
+++ b/interfaces/mcp/CONTRACT.md
@@ -2,6 +2,7 @@
 contract: mcp
 version: 0.1.0
 status: draft
+target_repo: "oddkit"
 ---
 
 # MCP Contract (mcp@0.1.0)

--- a/odd/README.md
+++ b/odd/README.md
@@ -13,6 +13,7 @@ assets: {"practice_video":"/assets/odd/odd-in-practice.mp4","misconception_image
 start_here: true
 start_here_order: 10
 start_here_label: What is ODD?
+target_repo: "outcomes-driven-development"
 ---
 
 # Outcomes-Driven Development (ODD)

--- a/odd/TEMPLATE.md
+++ b/odd/TEMPLATE.md
@@ -9,6 +9,7 @@ stability: stable
 tags: ["odd", "template"]
 relevance: routing
 execution_posture: routing
+target_repo: "outcomes-driven-development"
 ---
 
 # ODD Article Template

--- a/odd/appendices/README.md
+++ b/odd/appendices/README.md
@@ -9,6 +9,7 @@ stability: evolving
 tags: ["odd", "appendices", "index", "portable"]
 relevance: routing
 execution_posture: routing
+target_repo: "outcomes-driven-development"
 ---
 
 # ODD Appendices (Portable)

--- a/odd/appendices/TEMPLATE.md
+++ b/odd/appendices/TEMPLATE.md
@@ -9,6 +9,7 @@ stability: stable
 tags: ["odd", "appendices", "template"]
 relevance: routing
 execution_posture: routing
+target_repo: "outcomes-driven-development"
 ---
 
 # ODD Appendix Template

--- a/odd/appendices/alignment-reviews.md
+++ b/odd/appendices/alignment-reviews.md
@@ -9,6 +9,7 @@ stability: stable
 tags: ["odd", "alignment", "drift", "hygiene", "selection-pressure"]
 relevance: supporting
 execution_posture: operational
+target_repo: "outcomes-driven-development"
 ---
 
 # Alignment Reviews

--- a/odd/appendices/cognitive-saturation-threshold.md
+++ b/odd/appendices/cognitive-saturation-threshold.md
@@ -15,6 +15,7 @@ status: final
 start_here: true
 start_here_order: 5
 start_here_label: "Cognitive Saturation Threshold"
+target_repo: "outcomes-driven-development"
 ---
 
 # Cognitive Saturation Threshold — When Words Stop Transferring Knowledge

--- a/odd/appendices/evolution-not-automation.md
+++ b/odd/appendices/evolution-not-automation.md
@@ -9,6 +9,7 @@ stability: semi_stable
 tags: ["odd", "evolution", "automation", "orientation"]
 relevance: supporting
 execution_posture: operational
+target_repo: "outcomes-driven-development"
 ---
 
 # Evolution, Not Automation

--- a/odd/appendices/failure-driven-modularity.md
+++ b/odd/appendices/failure-driven-modularity.md
@@ -9,6 +9,7 @@ stability: stable
 tags: ["canon", "evolution", "modularity", "regenerability"]
 relevance: supporting
 execution_posture: operational
+target_repo: "outcomes-driven-development"
 ---
 
 # Failure-Driven Modularity

--- a/odd/appendices/media-as-learning-layer.md
+++ b/odd/appendices/media-as-learning-layer.md
@@ -9,6 +9,7 @@ stability: stable
 tags: ["odd", "media", "learning", "progressive-disclosure", "website"]
 relevance: supporting
 execution_posture: operational
+target_repo: "outcomes-driven-development"
 ---
 
 # Media as a Learning Layer

--- a/odd/appendices/progressive-elevation.md
+++ b/odd/appendices/progressive-elevation.md
@@ -12,6 +12,7 @@ execution_posture: operational
 status: canonical
 category: odd-appendix
 version: 1.0
+target_repo: "outcomes-driven-development"
 ---
 
 # Progressive Elevation & Decay

--- a/odd/appendices/quantum-development.md
+++ b/odd/appendices/quantum-development.md
@@ -9,6 +9,7 @@ stability: semi_stable
 tags: ["odd", "quantum", "attempts", "uncertainty", "orientation"]
 relevance: supporting
 execution_posture: operational
+target_repo: "outcomes-driven-development"
 ---
 
 # Quantum Development

--- a/odd/appendices/visual-evolution.md
+++ b/odd/appendices/visual-evolution.md
@@ -9,6 +9,7 @@ stability: semi_stable
 tags: ["odd", "visual", "evolution", "interfaces"]
 relevance: supporting
 execution_posture: operational
+target_repo: "outcomes-driven-development"
 ---
 
 # Visual Evolution

--- a/odd/challenge-types/assumption.md
+++ b/odd/challenge-types/assumption.md
@@ -12,6 +12,7 @@ date: 2026-04-16
 derives_from: "canon/constraints/epistemic-challenge.md, odd/challenge-types/how-to-write-challenge-types.md"
 governs: "oddkit_challenge behavior for assumption type"
 status: active
+target_repo: "outcomes-driven-development"
 ---
 
 # Challenge Type: Assumption

--- a/odd/challenge-types/comparative-positioning.md
+++ b/odd/challenge-types/comparative-positioning.md
@@ -12,6 +12,7 @@ date: 2026-04-16
 derives_from: "canon/constraints/epistemic-challenge.md, odd/challenge-types/how-to-write-challenge-types.md"
 governs: "oddkit_challenge behavior for comparative-positioning claims — positioning work against a landscape of other work"
 status: active
+target_repo: "outcomes-driven-development"
 ---
 
 # Challenge Type: Comparative Positioning

--- a/odd/challenge-types/how-to-write-challenge-types.md
+++ b/odd/challenge-types/how-to-write-challenge-types.md
@@ -13,6 +13,7 @@ derives_from: "canon/principles/prompt-over-code.md, canon/principles/vodka-arch
 complements: "odd/challenge-types/strong-claim.md, odd/challenge-types/proposal.md, odd/challenge-types/assumption.md, odd/challenge-types/observation.md, odd/challenge/base-prerequisites.md, odd/challenge/normative-vocabulary.md, odd/challenge/stakes-calibration.md"
 governs: "All challenge-type governance articles, server parsing of challenge-type docs, custom challenge type creation, multi-type matching semantics, base-plus-overlay prerequisite resolution"
 status: active
+target_repo: "outcomes-driven-development"
 ---
 
 # How to Write a Challenge Type Governance Article

--- a/odd/challenge-types/observation.md
+++ b/odd/challenge-types/observation.md
@@ -13,6 +13,7 @@ derives_from: "canon/constraints/epistemic-challenge.md, odd/challenge-types/how
 governs: "oddkit_challenge behavior for observation type and fallback routing"
 fallback: true
 status: active
+target_repo: "outcomes-driven-development"
 ---
 
 # Challenge Type: Observation

--- a/odd/challenge-types/pattern-coinage.md
+++ b/odd/challenge-types/pattern-coinage.md
@@ -12,6 +12,7 @@ date: 2026-04-16
 derives_from: "canon/constraints/epistemic-challenge.md, odd/challenge-types/how-to-write-challenge-types.md"
 governs: "oddkit_challenge behavior for pattern-coinage claims — naming novel patterns or concepts"
 status: active
+target_repo: "outcomes-driven-development"
 ---
 
 # Challenge Type: Pattern Coinage

--- a/odd/challenge-types/principle-extraction.md
+++ b/odd/challenge-types/principle-extraction.md
@@ -12,6 +12,7 @@ date: 2026-04-16
 derives_from: "canon/constraints/epistemic-challenge.md, odd/challenge-types/how-to-write-challenge-types.md"
 governs: "oddkit_challenge behavior for principle-extraction claims — elevating a heuristic from experience into canon"
 status: active
+target_repo: "outcomes-driven-development"
 ---
 
 # Principle Extraction

--- a/odd/challenge-types/proposal.md
+++ b/odd/challenge-types/proposal.md
@@ -12,6 +12,7 @@ date: 2026-04-16
 derives_from: "canon/constraints/epistemic-challenge.md, canon/principles/irreversibility-is-the-real-cost.md, odd/challenge-types/how-to-write-challenge-types.md"
 governs: "oddkit_challenge behavior for proposal type"
 status: active
+target_repo: "outcomes-driven-development"
 ---
 
 # Challenge Type: Proposal

--- a/odd/challenge-types/strong-claim.md
+++ b/odd/challenge-types/strong-claim.md
@@ -12,6 +12,7 @@ date: 2026-04-16
 derives_from: "canon/constraints/epistemic-challenge.md, odd/challenge-types/how-to-write-challenge-types.md"
 governs: "oddkit_challenge behavior for strong-claim type"
 status: active
+target_repo: "outcomes-driven-development"
 ---
 
 # Challenge Type: Strong Claim

--- a/odd/challenge/base-prerequisites.md
+++ b/odd/challenge/base-prerequisites.md
@@ -12,6 +12,7 @@ date: 2026-04-16
 derives_from: "canon/constraints/epistemic-challenge.md, odd/challenge-types/how-to-write-challenge-types.md"
 governs: "oddkit_challenge universal prerequisite checks applied regardless of matched type"
 status: active
+target_repo: "outcomes-driven-development"
 ---
 
 # Challenge Base Prerequisites

--- a/odd/challenge/normative-vocabulary.md
+++ b/odd/challenge/normative-vocabulary.md
@@ -12,6 +12,7 @@ date: 2026-04-17
 derives_from: "canon/constraints/epistemic-challenge.md, odd/challenge-types/how-to-write-challenge-types.md"
 governs: "oddkit_challenge detection vocabulary on two surfaces — signal in retrieved canon quotes (tension detection) and noise in user input (BM25 stop-word filter)"
 status: active
+target_repo: "outcomes-driven-development"
 ---
 
 # Challenge Normative Vocabulary

--- a/odd/challenge/stakes-calibration.md
+++ b/odd/challenge/stakes-calibration.md
@@ -12,6 +12,7 @@ date: 2026-04-16
 derives_from: "canon/definitions/epistemic-modes.md, canon/constraints/epistemic-challenge.md, canon/principles/irreversibility-is-the-real-cost.md, odd/challenge-types/how-to-write-challenge-types.md"
 governs: "oddkit_challenge mode-to-depth mapping — which question tiers, prerequisite strictness, and reframings surface for a given caller mode"
 status: active
+target_repo: "outcomes-driven-development"
 ---
 
 # Challenge Stakes Calibration

--- a/odd/cognitive-partitioning.md
+++ b/odd/cognitive-partitioning.md
@@ -9,6 +9,7 @@ stability: evolving
 tags: ["odd", "cognition", "scaling", "decision-load"]
 relevance: supporting
 execution_posture: operational
+target_repo: "outcomes-driven-development"
 ---
 
 # Cognitive Partitioning

--- a/odd/constraint/README.md
+++ b/odd/constraint/README.md
@@ -7,6 +7,7 @@ tier: 1
 voice: neutral
 stability: evolving
 tags: ["odd", "constraints", "index"]
+target_repo: "outcomes-driven-development"
 ---
 
 # ODD Constraints

--- a/odd/constraint/anti-cache-lying.md
+++ b/odd/constraint/anti-cache-lying.md
@@ -12,6 +12,7 @@ epoch: E0005
 date: 2026-02-12
 governs: "All caching decisions for derived or mutable content in ODD-aligned systems"
 complements: "odd/constraint/anti-metric-laundering.md, canon/constraints/decision-rules.md"
+target_repo: "outcomes-driven-development"
 ---
 
 # Constraint: Anti-Cache Lying

--- a/odd/constraint/anti-metric-laundering.md
+++ b/odd/constraint/anti-metric-laundering.md
@@ -7,6 +7,7 @@ tier: 1
 voice: neutral
 stability: stable
 tags: ["constraints", "metrics", "trust", "governance", "agents"]
+target_repo: "outcomes-driven-development"
 ---
 
 # Constraint: Anti-Metric Laundering

--- a/odd/constraint/use-only-what-hurts.md
+++ b/odd/constraint/use-only-what-hurts.md
@@ -12,6 +12,7 @@ context:
 tags: ["odd", "constraint", "tension-wire", "non-framework"]
 relevance: decision
 execution_posture: governing
+target_repo: "outcomes-driven-development"
 ---
 
 # Use Only What Hurts

--- a/odd/contract.md
+++ b/odd/contract.md
@@ -11,6 +11,7 @@ relevance: decision
 execution_posture: governing
 epoch: E0005
 derives_from: "canon/values/axioms.md (Axiom 1 — Reality Is Sovereign)"
+target_repo: "outcomes-driven-development"
 ---
 
 # ODD System Contract

--- a/odd/contract/epistemic-contract.md
+++ b/odd/contract/epistemic-contract.md
@@ -5,6 +5,7 @@ audience: odd
 stability: long_lived
 exposure: nav
 tier: 2
+target_repo: "outcomes-driven-development"
 ---
 
 # Epistemic Contract

--- a/odd/encoding-types/constraint.md
+++ b/odd/encoding-types/constraint.md
@@ -13,6 +13,7 @@ derives_from: "canon/definitions/dolcheo-vocabulary.md, docs/architecture/encode
 complements: "odd/encoding-types/decision.md, odd/encoding-types/observation.md, odd/encoding-types/learning.md, odd/encoding-types/handoff.md, odd/encoding-types/open.md, odd/encoding-types/encode.md, odd/encoding-types/how-to-write-encoding-types.md, odd/encoding-types/serialization-format.md"
 governs: "oddkit_encode parsing and quality scoring for type C"
 status: active
+target_repo: "outcomes-driven-development"
 ---
 
 

--- a/odd/encoding-types/decision.md
+++ b/odd/encoding-types/decision.md
@@ -13,6 +13,7 @@ derives_from: "canon/definitions/dolcheo-vocabulary.md, docs/architecture/encode
 complements: "odd/encoding-types/observation.md, odd/encoding-types/learning.md, odd/encoding-types/constraint.md, odd/encoding-types/handoff.md, odd/encoding-types/open.md, odd/encoding-types/encode.md, odd/encoding-types/how-to-write-encoding-types.md, odd/encoding-types/serialization-format.md"
 governs: "oddkit_encode parsing and quality scoring for type D"
 status: active
+target_repo: "outcomes-driven-development"
 ---
 
 

--- a/odd/encoding-types/encode.md
+++ b/odd/encoding-types/encode.md
@@ -13,6 +13,7 @@ derives_from: "canon/definitions/dolcheo-vocabulary.md, docs/oddkit/proactive/do
 complements: "odd/encoding-types/decision.md, odd/encoding-types/observation.md, odd/encoding-types/learning.md, odd/encoding-types/constraint.md, odd/encoding-types/handoff.md, odd/encoding-types/open.md"
 governs: "oddkit_encode parsing and quality scoring for type E"
 status: active
+target_repo: "outcomes-driven-development"
 ---
 
 # Encoding Type: Encode (E)

--- a/odd/encoding-types/handoff.md
+++ b/odd/encoding-types/handoff.md
@@ -13,6 +13,7 @@ derives_from: "canon/definitions/dolcheo-vocabulary.md, docs/architecture/encode
 complements: "odd/encoding-types/decision.md, odd/encoding-types/observation.md, odd/encoding-types/learning.md, odd/encoding-types/constraint.md, odd/encoding-types/open.md, odd/encoding-types/encode.md, odd/encoding-types/how-to-write-encoding-types.md, odd/encoding-types/serialization-format.md"
 governs: "oddkit_encode parsing and quality scoring for type H"
 status: active
+target_repo: "outcomes-driven-development"
 ---
 
 

--- a/odd/encoding-types/how-to-write-encoding-types.md
+++ b/odd/encoding-types/how-to-write-encoding-types.md
@@ -13,6 +13,7 @@ derives_from: "canon/principles/prompt-over-code.md, canon/principles/vodka-arch
 complements: "odd/encoding-types/decision.md, odd/encoding-types/observation.md, odd/encoding-types/learning.md, odd/encoding-types/constraint.md, odd/encoding-types/handoff.md"
 governs: "All encoding-type governance articles, server parsing of encoding-type docs, custom type creation"
 status: active
+target_repo: "outcomes-driven-development"
 ---
 
 # How to Write an Encoding Type Governance Article

--- a/odd/encoding-types/learning.md
+++ b/odd/encoding-types/learning.md
@@ -13,6 +13,7 @@ derives_from: "canon/definitions/dolcheo-vocabulary.md, docs/architecture/encode
 complements: "odd/encoding-types/decision.md, odd/encoding-types/observation.md, odd/encoding-types/constraint.md, odd/encoding-types/handoff.md, odd/encoding-types/open.md, odd/encoding-types/encode.md, odd/encoding-types/how-to-write-encoding-types.md, odd/encoding-types/serialization-format.md"
 governs: "oddkit_encode parsing and quality scoring for type L"
 status: active
+target_repo: "outcomes-driven-development"
 ---
 
 

--- a/odd/encoding-types/observation.md
+++ b/odd/encoding-types/observation.md
@@ -14,6 +14,7 @@ complements: "odd/encoding-types/decision.md, odd/encoding-types/learning.md, od
 governs: "oddkit_encode parsing and quality scoring for type O"
 fallback: true
 status: active
+target_repo: "outcomes-driven-development"
 ---
 
 

--- a/odd/encoding-types/open.md
+++ b/odd/encoding-types/open.md
@@ -13,6 +13,7 @@ derives_from: "canon/definitions/dolcheo-vocabulary.md, docs/architecture/encode
 complements: "odd/encoding-types/observation.md, odd/encoding-types/handoff.md, odd/encoding-types/decision.md, odd/encoding-types/learning.md, odd/encoding-types/constraint.md, odd/encoding-types/encode.md, odd/encoding-types/how-to-write-encoding-types.md, odd/encoding-types/serialization-format.md"
 governs: "oddkit_encode parsing and quality scoring for type O, facet=open"
 status: active
+target_repo: "outcomes-driven-development"
 ---
 
 # Encoding Type: Open (O, forward-pointing)

--- a/odd/encoding-types/serialization-format.md
+++ b/odd/encoding-types/serialization-format.md
@@ -13,6 +13,7 @@ derives_from: "docs/oddkit/proactive/dolche-vocabulary.md, odd/encoding-types/ho
 complements: "odd/encoding-types/decision.md, odd/encoding-types/observation.md, odd/encoding-types/learning.md, odd/encoding-types/constraint.md, odd/encoding-types/handoff.md, odd/encoding-types/question.md"
 governs: "How encoding type fields are serialized for input, output, and storage"
 status: active
+target_repo: "outcomes-driven-development"
 ---
 
 # Encoding Serialization Format — TSV as Default Wire and Storage Format

--- a/odd/gate/prerequisites.md
+++ b/odd/gate/prerequisites.md
@@ -13,6 +13,7 @@ derives_from: "canon/constraints/mode-discipline-and-bottleneck-respect.md, cano
 complements: "odd/gate/transitions.md"
 governs: "oddkit_gate prerequisite id definitions — each prereq's description, the vocabulary used to check whether the input satisfies it, and the gap message surfaced when it does not"
 status: active
+target_repo: "outcomes-driven-development"
 ---
 
 # Gate Prerequisites — Prerequisite IDs, Check Vocabularies, and Gap Messages

--- a/odd/gate/transitions.md
+++ b/odd/gate/transitions.md
@@ -13,6 +13,7 @@ derives_from: "canon/constraints/mode-discipline-and-bottleneck-respect.md, cano
 complements: "odd/gate/prerequisites.md"
 governs: "oddkit_gate transition keys, their from/to endpoints, the prerequisite ids required at each transition, and the detection terms used to identify a transition in user input"
 status: active
+target_repo: "outcomes-driven-development"
 ---
 
 # Gate Transitions — Mode Transition Keys and Detection Terms

--- a/odd/getting-started/README.md
+++ b/odd/getting-started/README.md
@@ -7,6 +7,7 @@ tier: 2
 voice: neutral
 stability: stable
 tags: ["odd", "getting-started", "onboarding", "oddkit"]
+target_repo: "outcomes-driven-development"
 ---
 
 # Getting Started

--- a/odd/getting-started/odd-agents-and-mcp.md
+++ b/odd/getting-started/odd-agents-and-mcp.md
@@ -7,6 +7,7 @@ tier: 3
 voice: neutral
 stability: evolving
 tags: ["agents", "mcp", "oddkit", "getting-started"]
+target_repo: "outcomes-driven-development"
 ---
 
 # ODD Agents & MCP: Getting Started

--- a/odd/index.md
+++ b/odd/index.md
@@ -10,6 +10,7 @@ stability: stable
 tags: ["odd", "index", "definition", "outcomes-driven-development", "what-is-odd", "methodology"]
 relevance: routing
 execution_posture: routing
+target_repo: "outcomes-driven-development"
 ---
 
 # 🎯 Outcomes-Driven Development (ODD)

--- a/odd/manifesto.md
+++ b/odd/manifesto.md
@@ -15,6 +15,7 @@ start_here_label: The Manifesto
 epoch: E0005
 derives_from: "canon/values/axioms.md"
 complements: "canon/values/orientation.md, canon/constraints/definition-of-done.md, odd/maturity.md"
+target_repo: "outcomes-driven-development"
 ---
 
 # ODD Manifesto v1.2 (Extended)

--- a/odd/maturity.md
+++ b/odd/maturity.md
@@ -9,6 +9,7 @@ stability: semi_stable
 tags: ["maturity", "governance"]
 relevance: supporting
 execution_posture: operational
+target_repo: "outcomes-driven-development"
 ---
 
 # Project Maturity & Progressive Governance

--- a/odd/misuse-patterns.md
+++ b/odd/misuse-patterns.md
@@ -9,6 +9,7 @@ stability: evolving
 tags: ["odd", "misuse", "failure-modes"]
 relevance: supporting
 execution_posture: operational
+target_repo: "outcomes-driven-development"
 ---
 
 # ODD Misuse Patterns

--- a/odd/odd-compared.md
+++ b/odd/odd-compared.md
@@ -7,6 +7,7 @@ tier: 2
 voice: neutral
 stability: stable
 tags: ["odd", "comparison", "methodology", "overview"]
+target_repo: "outcomes-driven-development"
 ---
 
 # ODD Compared: What It Is, What It Isn't, and How It Relates to Everything Else

--- a/odd/orientation-map.md
+++ b/odd/orientation-map.md
@@ -9,6 +9,7 @@ stability: semi_stable
 tags: ["odd", "orientation", "mental-model", "outcomes-driven-development", "hierarchy"]
 relevance: supporting
 execution_posture: operational
+target_repo: "outcomes-driven-development"
 ---
 
 # ODD + Canon + Evidence — Orientation Map

--- a/odd/prompt-architecture.md
+++ b/odd/prompt-architecture.md
@@ -9,6 +9,7 @@ stability: semi_stable
 tags: ["odd", "prompt-architecture", "orchestration"]
 relevance: supporting
 execution_posture: operational
+target_repo: "outcomes-driven-development"
 ---
 
 # Prompt Architecture (Orientation)

--- a/odd/terminology.md
+++ b/odd/terminology.md
@@ -12,6 +12,7 @@ stability: evolving
 tags: ["odd", "terminology", "disambiguation", "boundary", "definition", "outcomes-driven-development", "glossary"]
 relevance: supporting
 execution_posture: operational
+target_repo: "outcomes-driven-development"
 ---
 
 # 📖 ODD Terminology & Disambiguation

--- a/scripts/tests/fixtures/broken-invalid-target-repo.md
+++ b/scripts/tests/fixtures/broken-invalid-target-repo.md
@@ -1,0 +1,12 @@
+---
+uri: klappy://canon/principles/example-misrouted
+title: "A document with an out-of-enum target_repo"
+audience: canon
+exposure: nav
+tier: 2
+voice: neutral
+stability: stable
+tags: ["test", "target_repo"]
+target_repo: "truthkit"
+---
+body

--- a/scripts/tests/fixtures/valid-target-repo.md
+++ b/scripts/tests/fixtures/valid-target-repo.md
@@ -1,0 +1,12 @@
+---
+uri: klappy://canon/principles/example-routed
+title: "A valid document routed to a target repo"
+audience: canon
+exposure: nav
+tier: 2
+voice: neutral
+stability: stable
+tags: ["test", "target_repo"]
+target_repo: "oddkit"
+---
+body

--- a/scripts/tests/test_validator.py
+++ b/scripts/tests/test_validator.py
@@ -88,6 +88,26 @@ def main() -> None:
         "broken-nav-missing-discovery: nav essay missing public/type/slug fails",
     )
 
+    # 4c. target_repo allowlist (repo bifurcation). A valid enum value passes
+    #     clean; an out-of-enum value fires frontmatter-invalid-enum. The field
+    #     is optional, so its absence is never itself a finding (covered by the
+    #     other fixtures, none of which carry target_repo).
+    d, rc = run(str(FIXTURES / "valid-target-repo.md"))
+    assert rc == 0 and not d["findings"], f"valid target_repo failed: {d}"
+    print("  OK: valid target_repo → 0 findings, exit 0")
+
+    d, rc = run(str(FIXTURES / "broken-invalid-target-repo.md"))
+    assert rc == 1, f"expected exit 1 for invalid target_repo, got {rc}"
+    occurrences = {f["occurrence"] for f in d["findings"]}
+    assert any(o.startswith("target_repo:") for o in occurrences), (
+        f"invalid target_repo should flag the field; got {occurrences}"
+    )
+    expect(
+        {"frontmatter-invalid-enum"},
+        d["findings"],
+        "broken-invalid-target-repo: out-of-enum value fails",
+    )
+
     # 5. Real writings/ directory must be clean (this enforces that we never
     #    ship the validator with existing breakage)
     d, rc = run("writings/")

--- a/scripts/validate-frontmatter.py
+++ b/scripts/validate-frontmatter.py
@@ -67,6 +67,12 @@ ENUMS: dict[str, set] = {
                  "conversational", "authoritative"},
     "tier":     {1, 2, 3, 4},
     "audience": {"canon", "docs", "public", "odd", "operators", "apocrypha"},
+    # Repo-routing field for the klappy.dev bifurcation. Optional: absence means
+    # the file stays in klappy.dev. When present it must be one of these three
+    # destinations — a malformed value would silently mis-route a file at
+    # extraction time, so the gate rejects it. Source of truth:
+    # canon/meta/frontmatter-schema.md §"Repo Routing — target_repo".
+    "target_repo": {"outcomes-driven-development", "oddkit", "undecided"},
 }
 
 # The eight universal fields. Every document, regardless of audience, must


### PR DESCRIPTION
## Pass 1 — tag movers with `target_repo` (bifurcation)

Executes Pass 1 of the repo bifurcation per the handoff
`klappy://odd/handoffs/2026-06-09-scope-audit-execution` and its governing article
`klappy://docs/repo-bifurcation-and-target-repo-routing`. Classification was reproduced
from the live git tree (not the oddkit catalog). **No files moved or copied. `main` untouched.
Not for merge as-is** — this is a reviewable tagging pass.

### What changed
- **232 markdown movers** tagged with a single `target_repo` frontmatter line (inserted as the last key in each existing block; no bodies touched, zero deletions).
- **`canon/meta/scope-map.json`** — new sidecar routing the **non-markdown movers** (and `AGENTS.md`, which has no frontmatter block — not fabricated one).
- **`canon/meta/frontmatter-schema.md`** — new "Repo Routing — target_repo" section documenting the optional quoted-string enum and the *absent = stays in klappy.dev* rule. (This file is itself a "stays" file, so it carries no tag.)
- **`scripts/validate-frontmatter.py`** — `target_repo` allowlisted via the ENUMS guard: absence is never flagged; an out-of-enum value raises `frontmatter-invalid-enum`.
- **`scripts/tests/`** — two fixtures (`valid-target-repo.md`, `broken-invalid-target-repo.md`) + matching cases. Full validator suite passes; repo validator run is clean (44 files, 0 findings).

### Counts achieved (frontmatter-anchored)
| target_repo | md files |
|---|---|
| `outcomes-driven-development` | **140** |
| `oddkit` | **73** |
| `undecided` | **19** (md) + `AGENTS.md` via sidecar = **20** |
| **Total md tagged** | **232** |

Non-md movers in sidecar: 4 (`canon/meta/pack.json`, `scripts/audit-retrieval-readiness.py`, `scripts/validate-frontmatter.py`, `scripts/tests/test_validator.py`) → all `oddkit`; plus `AGENTS.md` → `undecided`.

### Honest deltas against the handoff's stated targets — read before merge
1. **oddkit is 73, not ~94 (~21-file gap).** The handoff's *explicit* oddkit enumeration (docs/oddkit 54 + interfaces 3 + 9 named constraints + 7 named principles) sums to exactly 73. The ~94 target comes from the prior session's **file-level** split inside `canon/constraints|methods|principles`, whose per-file manifest ("29 judgment-calls plus three forks", per the journal) did **not** survive into the repo. The handoff deliberately simplified to folder-level "most → core" rules for reviewability, which sweeps the ~21 oddkit-leaning engine files into core. I did **not** invent assignments to hit 94 (that would violate "do not guess / contested → undecided"). Refining those ~21 + the ~29 judgment-calls is the **Pass 1 follow-up**.
2. **Non-md sidecar is 4, not ~11.** The ~6 unaccounted are repo-infra the handoff never explicitly routed (`package.json`, `.github/workflows/canon-quality.yml`, `.husky/pre-commit`, `.mcp.json`). Left for maintainer review rather than guessed in.
3. **3 forks → `undecided`** as specified (writing-vertical, vodka/architecture principles, AGENTS.md).

### Verification note
A raw `git grep target_repo '*.md'` reports inflated counts (142/74/238 + "1 outside enum"). That is expected: the DR article and this handoff each contain 3 prose `target_repo: "…"` examples in their **bodies**. Frontmatter-anchored counting (above) is the source of truth — all real tags are enum-valid.

### Definition-of-done status
Met: branch `scope-audit` (not main), 232 md tagged, schema documented, validator + fixtures, sidecar written, PR opened unmerged, contested → undecided, classified from live tree, no files moved, `docs/archive` + apocrypha PDF untouched. **Not met: oddkit count does not reach ~94** (reason above) — flagged here rather than papered over; the wrong-tag cost is a one-line edit and this PR is not merged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical frontmatter and validation-only changes; no file moves or runtime behavior shifts beyond rejecting bad enum values at merge time.
> 
> **Overview**
> **Pass 1 of klappy.dev repo bifurcation** — declares where each artifact should land after a future split, without moving or copying anything yet.
> 
> Adds optional frontmatter **`target_repo`** (`outcomes-driven-development`, `oddkit`, or `undecided`) to **232 markdown** movers so extraction can route via `git grep` instead of path heuristics. **Absent field = stays on klappy.dev.**
> 
> Introduces **`canon/meta/scope-map.json`** for non-markdown routes (e.g. `AGENTS.md`, validator scripts, `pack.json`). Documents the field in **`canon/meta/frontmatter-schema.md`** and extends **`scripts/validate-frontmatter.py`** with an enum check plus test fixtures so invalid values fail the merge gate.
> 
> The PR author notes **~21 fewer `oddkit` tags than an earlier ~94 target** (folder-level pass vs per-file manifest) and a **smaller sidecar** than ~11 infra files — follow-up refinement, not blockers for this tagging-only pass.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02c7df5db72cf837ebc7d4c1d027db57c913d536. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->