### PR TITLE
declare kind: odd in frontmatter across odd/

### DIFF
--- a/odd/README.md
+++ b/odd/README.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://public/odd
+kind: odd
 title: "What is ODD? — Outcomes-Driven Development"
 audience: public
 exposure: nav

--- a/odd/README.md
+++ b/odd/README.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://public/odd
-kind: odd
+kind: canon
 title: "What is ODD? — Outcomes-Driven Development"
 audience: public
 exposure: nav

--- a/odd/TEMPLATE.md
+++ b/odd/TEMPLATE.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/template
+kind: odd
 title: "ODD Article Template"
 audience: canon
 exposure: hidden

--- a/odd/TEMPLATE.md
+++ b/odd/TEMPLATE.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/template
-kind: odd
+kind: docs
 title: "ODD Article Template"
 audience: canon
 exposure: hidden

--- a/odd/appendices/README.md
+++ b/odd/appendices/README.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/appendices
+kind: odd
 title: "ODD Appendices (Portable)"
 audience: canon
 exposure: nav

--- a/odd/appendices/README.md
+++ b/odd/appendices/README.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/appendices
-kind: odd
+kind: canon
 title: "ODD Appendices (Portable)"
 audience: canon
 exposure: nav

--- a/odd/appendices/TEMPLATE.md
+++ b/odd/appendices/TEMPLATE.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/appendices/template
-kind: odd
+kind: canon
 title: "ODD Appendix Template"
 audience: canon
 exposure: hidden

--- a/odd/appendices/TEMPLATE.md
+++ b/odd/appendices/TEMPLATE.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/appendices/template
+kind: odd
 title: "ODD Appendix Template"
 audience: canon
 exposure: hidden

--- a/odd/appendices/alignment-reviews.md
+++ b/odd/appendices/alignment-reviews.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/alignment-reviews
-kind: odd
+kind: canon
 title: "Alignment Reviews"
 audience: canon
 exposure: nav

--- a/odd/appendices/alignment-reviews.md
+++ b/odd/appendices/alignment-reviews.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/alignment-reviews
+kind: odd
 title: "Alignment Reviews"
 audience: canon
 exposure: nav

--- a/odd/appendices/cognitive-saturation-threshold.md
+++ b/odd/appendices/cognitive-saturation-threshold.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/appendices/cognitive-saturation-threshold
-kind: odd
+kind: canon
 title: "Cognitive Saturation Threshold — When Words Stop Transferring Knowledge"
 audience: odd
 exposure: nav

--- a/odd/appendices/cognitive-saturation-threshold.md
+++ b/odd/appendices/cognitive-saturation-threshold.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/appendices/cognitive-saturation-threshold
+kind: odd
 title: "Cognitive Saturation Threshold — When Words Stop Transferring Knowledge"
 audience: odd
 exposure: nav

--- a/odd/appendices/evolution-not-automation.md
+++ b/odd/appendices/evolution-not-automation.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/evolution-not-automation
-kind: odd
+kind: canon
 title: "Evolution, Not Automation"
 audience: canon
 exposure: hidden

--- a/odd/appendices/evolution-not-automation.md
+++ b/odd/appendices/evolution-not-automation.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/evolution-not-automation
+kind: odd
 title: "Evolution, Not Automation"
 audience: canon
 exposure: hidden

--- a/odd/appendices/failure-driven-modularity.md
+++ b/odd/appendices/failure-driven-modularity.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/appendices/failure-driven-modularity
-kind: odd
+kind: canon
 title: "Failure-Driven Modularity"
 audience: canon
 exposure: nav

--- a/odd/appendices/failure-driven-modularity.md
+++ b/odd/appendices/failure-driven-modularity.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/appendices/failure-driven-modularity
+kind: odd
 title: "Failure-Driven Modularity"
 audience: canon
 exposure: nav

--- a/odd/appendices/media-as-learning-layer.md
+++ b/odd/appendices/media-as-learning-layer.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/media-as-learning-layer
+kind: odd
 title: "Media as a Learning Layer"
 audience: canon
 exposure: nav

--- a/odd/appendices/media-as-learning-layer.md
+++ b/odd/appendices/media-as-learning-layer.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/media-as-learning-layer
-kind: odd
+kind: canon
 title: "Media as a Learning Layer"
 audience: canon
 exposure: nav

--- a/odd/appendices/progressive-elevation.md
+++ b/odd/appendices/progressive-elevation.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/appendices/progressive-elevation
-kind: odd
+kind: canon
 title: Progressive Elevation & Decay
 audience: odd
 exposure: nav

--- a/odd/appendices/progressive-elevation.md
+++ b/odd/appendices/progressive-elevation.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/appendices/progressive-elevation
+kind: odd
 title: Progressive Elevation & Decay
 audience: odd
 exposure: nav

--- a/odd/appendices/quantum-development.md
+++ b/odd/appendices/quantum-development.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/quantum-development
-kind: odd
+kind: canon
 title: "Quantum Development"
 audience: canon
 exposure: nav

--- a/odd/appendices/quantum-development.md
+++ b/odd/appendices/quantum-development.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/quantum-development
+kind: odd
 title: "Quantum Development"
 audience: canon
 exposure: nav

--- a/odd/appendices/visual-evolution.md
+++ b/odd/appendices/visual-evolution.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/visual-evolution
+kind: odd
 title: "Visual Evolution"
 audience: canon
 exposure: nav

--- a/odd/appendices/visual-evolution.md
+++ b/odd/appendices/visual-evolution.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/visual-evolution
-kind: odd
+kind: canon
 title: "Visual Evolution"
 audience: canon
 exposure: nav

--- a/odd/backlog/wish-came-true-essay-stub.md
+++ b/odd/backlog/wish-came-true-essay-stub.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/backlog/wish-came-true-essay-stub
+kind: odd
 title: "Backlog — The Wish Came True (Celebration Essay Stub)"
 audience: odd
 exposure: nav

--- a/odd/backlog/wish-came-true-essay-stub.md
+++ b/odd/backlog/wish-came-true-essay-stub.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/backlog/wish-came-true-essay-stub
-kind: odd
+kind: docs
 title: "Backlog — The Wish Came True (Celebration Essay Stub)"
 audience: odd
 exposure: nav

--- a/odd/challenge-types/assumption.md
+++ b/odd/challenge-types/assumption.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/challenge-types/assumption
+kind: odd
 title: "Challenge Type: Assumption"
 audience: docs
 exposure: nav

--- a/odd/challenge-types/assumption.md
+++ b/odd/challenge-types/assumption.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/challenge-types/assumption
-kind: odd
+kind: canon
 title: "Challenge Type: Assumption"
 audience: docs
 exposure: nav

--- a/odd/challenge-types/comparative-positioning.md
+++ b/odd/challenge-types/comparative-positioning.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/challenge-types/comparative-positioning
-kind: odd
+kind: canon
 title: "Challenge Type: Comparative Positioning"
 audience: docs
 exposure: nav

--- a/odd/challenge-types/comparative-positioning.md
+++ b/odd/challenge-types/comparative-positioning.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/challenge-types/comparative-positioning
+kind: odd
 title: "Challenge Type: Comparative Positioning"
 audience: docs
 exposure: nav

--- a/odd/challenge-types/how-to-write-challenge-types.md
+++ b/odd/challenge-types/how-to-write-challenge-types.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/challenge-types/how-to-write-challenge-types
+kind: odd
 title: "How to Write a Challenge Type Governance Article"
 audience: docs
 exposure: nav

--- a/odd/challenge-types/how-to-write-challenge-types.md
+++ b/odd/challenge-types/how-to-write-challenge-types.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/challenge-types/how-to-write-challenge-types
-kind: odd
+kind: canon
 title: "How to Write a Challenge Type Governance Article"
 audience: docs
 exposure: nav

--- a/odd/challenge-types/observation.md
+++ b/odd/challenge-types/observation.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/challenge-types/observation
+kind: odd
 title: "Challenge Type: Observation"
 audience: docs
 exposure: nav

--- a/odd/challenge-types/observation.md
+++ b/odd/challenge-types/observation.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/challenge-types/observation
-kind: odd
+kind: canon
 title: "Challenge Type: Observation"
 audience: docs
 exposure: nav

--- a/odd/challenge-types/pattern-coinage.md
+++ b/odd/challenge-types/pattern-coinage.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/challenge-types/pattern-coinage
+kind: odd
 title: "Challenge Type: Pattern Coinage"
 audience: docs
 exposure: nav

--- a/odd/challenge-types/pattern-coinage.md
+++ b/odd/challenge-types/pattern-coinage.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/challenge-types/pattern-coinage
-kind: odd
+kind: canon
 title: "Challenge Type: Pattern Coinage"
 audience: docs
 exposure: nav

--- a/odd/challenge-types/principle-extraction.md
+++ b/odd/challenge-types/principle-extraction.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/challenge-types/principle-extraction
-kind: odd
+kind: canon
 title: "Challenge Type: Principle Extraction"
 audience: docs
 exposure: nav

--- a/odd/challenge-types/principle-extraction.md
+++ b/odd/challenge-types/principle-extraction.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/challenge-types/principle-extraction
+kind: odd
 title: "Challenge Type: Principle Extraction"
 audience: docs
 exposure: nav

--- a/odd/challenge-types/proposal.md
+++ b/odd/challenge-types/proposal.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/challenge-types/proposal
+kind: odd
 title: "Challenge Type: Proposal"
 audience: docs
 exposure: nav

--- a/odd/challenge-types/proposal.md
+++ b/odd/challenge-types/proposal.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/challenge-types/proposal
-kind: odd
+kind: canon
 title: "Challenge Type: Proposal"
 audience: docs
 exposure: nav

--- a/odd/challenge-types/strong-claim.md
+++ b/odd/challenge-types/strong-claim.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/challenge-types/strong-claim
+kind: odd
 title: "Challenge Type: Strong Claim"
 audience: docs
 exposure: nav

--- a/odd/challenge-types/strong-claim.md
+++ b/odd/challenge-types/strong-claim.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/challenge-types/strong-claim
-kind: odd
+kind: canon
 title: "Challenge Type: Strong Claim"
 audience: docs
 exposure: nav

--- a/odd/challenge/base-prerequisites.md
+++ b/odd/challenge/base-prerequisites.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/challenge/base-prerequisites
-kind: odd
+kind: canon
 title: "Challenge Base Prerequisites"
 audience: docs
 exposure: nav

--- a/odd/challenge/base-prerequisites.md
+++ b/odd/challenge/base-prerequisites.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/challenge/base-prerequisites
+kind: odd
 title: "Challenge Base Prerequisites"
 audience: docs
 exposure: nav

--- a/odd/challenge/normative-vocabulary.md
+++ b/odd/challenge/normative-vocabulary.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/challenge/normative-vocabulary
+kind: odd
 title: "Challenge Normative Vocabulary"
 audience: docs
 exposure: nav

--- a/odd/challenge/normative-vocabulary.md
+++ b/odd/challenge/normative-vocabulary.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/challenge/normative-vocabulary
-kind: odd
+kind: canon
 title: "Challenge Normative Vocabulary"
 audience: docs
 exposure: nav

--- a/odd/challenge/stakes-calibration.md
+++ b/odd/challenge/stakes-calibration.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/challenge/stakes-calibration
+kind: odd
 title: "Challenge Stakes Calibration"
 audience: docs
 exposure: nav

--- a/odd/challenge/stakes-calibration.md
+++ b/odd/challenge/stakes-calibration.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/challenge/stakes-calibration
-kind: odd
+kind: canon
 title: "Challenge Stakes Calibration"
 audience: docs
 exposure: nav

--- a/odd/cognitive-partitioning.md
+++ b/odd/cognitive-partitioning.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/cognitive-partitioning
-kind: odd
+kind: canon
 title: "Cognitive Partitioning"
 audience: docs
 exposure: nav

--- a/odd/cognitive-partitioning.md
+++ b/odd/cognitive-partitioning.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/cognitive-partitioning
+kind: odd
 title: "Cognitive Partitioning"
 audience: docs
 exposure: nav

--- a/odd/constraint/README.md
+++ b/odd/constraint/README.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/constraint
+kind: odd
 title: "ODD Constraints"
 audience: odd
 exposure: nav

--- a/odd/constraint/README.md
+++ b/odd/constraint/README.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/constraint
-kind: odd
+kind: canon
 title: "ODD Constraints"
 audience: odd
 exposure: nav

--- a/odd/constraint/anti-cache-lying.md
+++ b/odd/constraint/anti-cache-lying.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/constraints/anti-cache-lying
+kind: odd
 title: "Constraint: Anti-Cache Lying"
 audience: odd
 exposure: nav

--- a/odd/constraint/anti-cache-lying.md
+++ b/odd/constraint/anti-cache-lying.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/constraints/anti-cache-lying
-kind: odd
+kind: canon
 title: "Constraint: Anti-Cache Lying"
 audience: odd
 exposure: nav

--- a/odd/constraint/anti-metric-laundering.md
+++ b/odd/constraint/anti-metric-laundering.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/constraints/anti-metric-laundering
+kind: odd
 title: "Constraint: Anti-Metric Laundering"
 audience: odd
 exposure: nav

--- a/odd/constraint/anti-metric-laundering.md
+++ b/odd/constraint/anti-metric-laundering.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/constraints/anti-metric-laundering
-kind: odd
+kind: canon
 title: "Constraint: Anti-Metric Laundering"
 audience: odd
 exposure: nav

--- a/odd/constraint/use-only-what-hurts.md
+++ b/odd/constraint/use-only-what-hurts.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/constraint/use-only-what-hurts
+kind: odd
 title: "Use Only What Hurts"
 audience: odd
 exposure: nav

--- a/odd/constraint/use-only-what-hurts.md
+++ b/odd/constraint/use-only-what-hurts.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/constraint/use-only-what-hurts
-kind: odd
+kind: canon
 title: "Use Only What Hurts"
 audience: odd
 exposure: nav

--- a/odd/contract.md
+++ b/odd/contract.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/contract
-kind: odd
+kind: canon
 title: "ODD System Contract"
 audience: canon
 exposure: nav

--- a/odd/contract.md
+++ b/odd/contract.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/contract
+kind: odd
 title: "ODD System Contract"
 audience: canon
 exposure: nav

--- a/odd/contract/epistemic-contract.md
+++ b/odd/contract/epistemic-contract.md
@@ -1,5 +1,6 @@
 ---
 uri: odd://contract/epistemic-contract
+kind: odd
 title: "Epistemic Contract"
 audience: odd
 stability: long_lived

--- a/odd/contract/epistemic-contract.md
+++ b/odd/contract/epistemic-contract.md
@@ -1,6 +1,6 @@
 ---
 uri: odd://contract/epistemic-contract
-kind: odd
+kind: canon
 title: "Epistemic Contract"
 audience: odd
 stability: long_lived

--- a/odd/decisions/D0001-three-tier-conceptual-hierarchy.md
+++ b/odd/decisions/D0001-three-tier-conceptual-hierarchy.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/decisions/D0001
-kind: odd
+kind: canon
 title: "Three-Tier Conceptual Hierarchy"
 audience: canon
 exposure: nav

--- a/odd/decisions/D0001-three-tier-conceptual-hierarchy.md
+++ b/odd/decisions/D0001-three-tier-conceptual-hierarchy.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/decisions/D0001
+kind: odd
 title: "Three-Tier Conceptual Hierarchy"
 audience: canon
 exposure: nav

--- a/odd/decisions/D0002-canon-storage-model.md
+++ b/odd/decisions/D0002-canon-storage-model.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/decisions/D0002
+kind: odd
 title: "The Canon Storage Model: Files Write, the Index Reads, the URI Keys"
 audience: canon
 exposure: nav

--- a/odd/decisions/D0002-canon-storage-model.md
+++ b/odd/decisions/D0002-canon-storage-model.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/decisions/D0002
-kind: odd
+kind: canon
 title: "The Canon Storage Model: Files Write, the Index Reads, the URI Keys"
 audience: canon
 exposure: nav

--- a/odd/decisions/README.md
+++ b/odd/decisions/README.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/decisions
+kind: odd
 title: "ODD Conceptual Decisions"
 audience: canon
 exposure: nav

--- a/odd/decisions/README.md
+++ b/odd/decisions/README.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/decisions
-kind: odd
+kind: canon
 title: "ODD Conceptual Decisions"
 audience: canon
 exposure: nav

--- a/odd/encoding-types/constraint.md
+++ b/odd/encoding-types/constraint.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/encoding-types/constraint
-kind: odd
+kind: canon
 title: "Encoding Type: Constraint (C)"
 audience: docs
 exposure: nav

--- a/odd/encoding-types/constraint.md
+++ b/odd/encoding-types/constraint.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/encoding-types/constraint
+kind: odd
 title: "Encoding Type: Constraint (C)"
 audience: docs
 exposure: nav

--- a/odd/encoding-types/decision.md
+++ b/odd/encoding-types/decision.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/encoding-types/decision
+kind: odd
 title: "Encoding Type: Decision (D)"
 audience: docs
 exposure: nav

--- a/odd/encoding-types/decision.md
+++ b/odd/encoding-types/decision.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/encoding-types/decision
-kind: odd
+kind: canon
 title: "Encoding Type: Decision (D)"
 audience: docs
 exposure: nav

--- a/odd/encoding-types/encode.md
+++ b/odd/encoding-types/encode.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/encoding-types/encode
-kind: odd
+kind: canon
 title: "Encoding Type: Encode (E)"
 audience: docs
 exposure: nav

--- a/odd/encoding-types/encode.md
+++ b/odd/encoding-types/encode.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/encoding-types/encode
+kind: odd
 title: "Encoding Type: Encode (E)"
 audience: docs
 exposure: nav

--- a/odd/encoding-types/handoff.md
+++ b/odd/encoding-types/handoff.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/encoding-types/handoff
-kind: odd
+kind: canon
 title: "Encoding Type: Handoff (H)"
 audience: docs
 exposure: nav

--- a/odd/encoding-types/handoff.md
+++ b/odd/encoding-types/handoff.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/encoding-types/handoff
+kind: odd
 title: "Encoding Type: Handoff (H)"
 audience: docs
 exposure: nav

--- a/odd/encoding-types/how-to-write-encoding-types.md
+++ b/odd/encoding-types/how-to-write-encoding-types.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/encoding-types/how-to-write-encoding-types
-kind: odd
+kind: canon
 title: "How to Write an Encoding Type Governance Article"
 audience: docs
 exposure: nav

--- a/odd/encoding-types/how-to-write-encoding-types.md
+++ b/odd/encoding-types/how-to-write-encoding-types.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/encoding-types/how-to-write-encoding-types
+kind: odd
 title: "How to Write an Encoding Type Governance Article"
 audience: docs
 exposure: nav

--- a/odd/encoding-types/learning.md
+++ b/odd/encoding-types/learning.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/encoding-types/learning
+kind: odd
 title: "Encoding Type: Learning (L)"
 audience: docs
 exposure: nav

--- a/odd/encoding-types/learning.md
+++ b/odd/encoding-types/learning.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/encoding-types/learning
-kind: odd
+kind: canon
 title: "Encoding Type: Learning (L)"
 audience: docs
 exposure: nav

--- a/odd/encoding-types/observation.md
+++ b/odd/encoding-types/observation.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/encoding-types/observation
-kind: odd
+kind: canon
 title: "Encoding Type: Observation (O)"
 audience: docs
 exposure: nav

--- a/odd/encoding-types/observation.md
+++ b/odd/encoding-types/observation.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/encoding-types/observation
+kind: odd
 title: "Encoding Type: Observation (O)"
 audience: docs
 exposure: nav

--- a/odd/encoding-types/open.md
+++ b/odd/encoding-types/open.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/encoding-types/open
+kind: odd
 title: "Encoding Type: Open (O, forward-pointing)"
 audience: docs
 exposure: nav

--- a/odd/encoding-types/open.md
+++ b/odd/encoding-types/open.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/encoding-types/open
-kind: odd
+kind: canon
 title: "Encoding Type: Open (O, forward-pointing)"
 audience: docs
 exposure: nav

--- a/odd/encoding-types/serialization-format.md
+++ b/odd/encoding-types/serialization-format.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/encoding-types/serialization-format
-kind: odd
+kind: canon
 title: "Encoding Serialization Format — TSV as Default Wire and Storage Format"
 audience: docs
 exposure: nav

--- a/odd/encoding-types/serialization-format.md
+++ b/odd/encoding-types/serialization-format.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/encoding-types/serialization-format
+kind: odd
 title: "Encoding Serialization Format — TSV as Default Wire and Storage Format"
 audience: docs
 exposure: nav

--- a/odd/gate/prerequisites.md
+++ b/odd/gate/prerequisites.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/gate/prerequisites
-kind: odd
+kind: canon
 title: "Gate Prerequisites — Prerequisite IDs, Check Vocabularies, and Gap Messages"
 audience: docs
 exposure: nav

--- a/odd/gate/prerequisites.md
+++ b/odd/gate/prerequisites.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/gate/prerequisites
+kind: odd
 title: "Gate Prerequisites — Prerequisite IDs, Check Vocabularies, and Gap Messages"
 audience: docs
 exposure: nav

--- a/odd/gate/transitions.md
+++ b/odd/gate/transitions.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/gate/transitions
-kind: odd
+kind: canon
 title: "Gate Transitions — Mode Transition Keys and Detection Terms"
 audience: docs
 exposure: nav

--- a/odd/gate/transitions.md
+++ b/odd/gate/transitions.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/gate/transitions
+kind: odd
 title: "Gate Transitions — Mode Transition Keys and Detection Terms"
 audience: docs
 exposure: nav

--- a/odd/getting-started/README.md
+++ b/odd/getting-started/README.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/getting-started
-kind: odd
+kind: docs
 title: Getting Started
 audience: odd
 exposure: nav

--- a/odd/getting-started/README.md
+++ b/odd/getting-started/README.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/getting-started
+kind: odd
 title: Getting Started
 audience: odd
 exposure: nav

--- a/odd/getting-started/odd-agents-and-mcp.md
+++ b/odd/getting-started/odd-agents-and-mcp.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/getting-started/agents-and-mcp
-kind: odd
+kind: docs
 title: "Agents & MCP"
 audience: odd
 exposure: nav

--- a/odd/getting-started/odd-agents-and-mcp.md
+++ b/odd/getting-started/odd-agents-and-mcp.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/getting-started/agents-and-mcp
+kind: odd
 title: "Agents & MCP"
 audience: odd
 exposure: nav

--- a/odd/handoffs/2026-04-19-fresh-session-continuation.md
+++ b/odd/handoffs/2026-04-19-fresh-session-continuation.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/handoffs/2026-04-19-fresh-session-continuation
+kind: odd
 title: "Handoff — Fresh Session Continuation from 2026-04-19 CST"
 audience: odd
 exposure: nav

--- a/odd/handoffs/2026-04-19-fresh-session-continuation.md
+++ b/odd/handoffs/2026-04-19-fresh-session-continuation.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/handoffs/2026-04-19-fresh-session-continuation
-kind: odd
+kind: docs
 title: "Handoff — Fresh Session Continuation from 2026-04-19 CST"
 audience: odd
 exposure: nav

--- a/odd/handoffs/2026-04-19-fresh-session-continuation.md
+++ b/odd/handoffs/2026-04-19-fresh-session-continuation.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/handoffs/2026-04-19-fresh-session-continuation
-kind: docs
+kind: journals
 title: "Handoff — Fresh Session Continuation from 2026-04-19 CST"
 audience: odd
 exposure: nav

--- a/odd/handoffs/2026-04-20-fresh-session-continuation.md
+++ b/odd/handoffs/2026-04-20-fresh-session-continuation.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/handoffs/2026-04-20-fresh-session-continuation
-kind: docs
+kind: journals
 title: "Handoff — Fresh Session Continuation from 2026-04-19 (post agent-team pilot)"
 audience: odd
 exposure: nav

--- a/odd/handoffs/2026-04-20-fresh-session-continuation.md
+++ b/odd/handoffs/2026-04-20-fresh-session-continuation.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/handoffs/2026-04-20-fresh-session-continuation
+kind: odd
 title: "Handoff — Fresh Session Continuation from 2026-04-19 (post agent-team pilot)"
 audience: odd
 exposure: nav

--- a/odd/handoffs/2026-04-20-fresh-session-continuation.md
+++ b/odd/handoffs/2026-04-20-fresh-session-continuation.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/handoffs/2026-04-20-fresh-session-continuation
-kind: odd
+kind: docs
 title: "Handoff — Fresh Session Continuation from 2026-04-19 (post agent-team pilot)"
 audience: odd
 exposure: nav

--- a/odd/handoffs/2026-04-20-p1-2-encode-canary.md
+++ b/odd/handoffs/2026-04-20-p1-2-encode-canary.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/handoffs/2026-04-20-p1-2-encode-canary
-kind: docs
+kind: journals
 title: "Handoff — P1.2 oddkit_encode Batch Mode + Prompt-Over-Code Canary"
 audience: odd
 exposure: nav

--- a/odd/handoffs/2026-04-20-p1-2-encode-canary.md
+++ b/odd/handoffs/2026-04-20-p1-2-encode-canary.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/handoffs/2026-04-20-p1-2-encode-canary
-kind: odd
+kind: docs
 title: "Handoff — P1.2 oddkit_encode Batch Mode + Prompt-Over-Code Canary"
 audience: odd
 exposure: nav

--- a/odd/handoffs/2026-04-20-p1-2-encode-canary.md
+++ b/odd/handoffs/2026-04-20-p1-2-encode-canary.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/handoffs/2026-04-20-p1-2-encode-canary
+kind: odd
 title: "Handoff — P1.2 oddkit_encode Batch Mode + Prompt-Over-Code Canary"
 audience: odd
 exposure: nav

--- a/odd/handoffs/2026-04-20-p1-3-2-phase-2-gate-code-refactor.md
+++ b/odd/handoffs/2026-04-20-p1-3-2-phase-2-gate-code-refactor.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/handoffs/2026-04-20-p1-3-2-phase-2-gate-code-refactor
+kind: odd
 title: "Handoff — P1.3.2 Phase 2: oddkit_gate Code Refactor (0.20.0)"
 audience: odd
 exposure: nav

--- a/odd/handoffs/2026-04-20-p1-3-2-phase-2-gate-code-refactor.md
+++ b/odd/handoffs/2026-04-20-p1-3-2-phase-2-gate-code-refactor.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/handoffs/2026-04-20-p1-3-2-phase-2-gate-code-refactor
-kind: odd
+kind: docs
 title: "Handoff — P1.3.2 Phase 2: oddkit_gate Code Refactor (0.20.0)"
 audience: odd
 exposure: nav

--- a/odd/handoffs/2026-04-20-p1-3-2-phase-2-gate-code-refactor.md
+++ b/odd/handoffs/2026-04-20-p1-3-2-phase-2-gate-code-refactor.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/handoffs/2026-04-20-p1-3-2-phase-2-gate-code-refactor
-kind: docs
+kind: journals
 title: "Handoff — P1.3.2 Phase 2: oddkit_gate Code Refactor (0.20.0)"
 audience: odd
 exposure: nav

--- a/odd/handoffs/2026-04-20-p1-3-3-challenge-revisit.md
+++ b/odd/handoffs/2026-04-20-p1-3-3-challenge-revisit.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/handoffs/2026-04-20-p1-3-3-challenge-revisit
-kind: odd
+kind: docs
 title: "Handoff — P1.3.3 Challenge Canon-Parity Refactor + Cache Principle Graduation (0.21.0)"
 audience: odd
 exposure: nav

--- a/odd/handoffs/2026-04-20-p1-3-3-challenge-revisit.md
+++ b/odd/handoffs/2026-04-20-p1-3-3-challenge-revisit.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/handoffs/2026-04-20-p1-3-3-challenge-revisit
+kind: odd
 title: "Handoff — P1.3.3 Challenge Canon-Parity Refactor + Cache Principle Graduation (0.21.0)"
 audience: odd
 exposure: nav

--- a/odd/handoffs/2026-04-20-p1-3-3-challenge-revisit.md
+++ b/odd/handoffs/2026-04-20-p1-3-3-challenge-revisit.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/handoffs/2026-04-20-p1-3-3-challenge-revisit
-kind: docs
+kind: journals
 title: "Handoff — P1.3.3 Challenge Canon-Parity Refactor + Cache Principle Graduation (0.21.0)"
 audience: odd
 exposure: nav

--- a/odd/handoffs/2026-04-20-p1-3-4-encode-canon-parity.md
+++ b/odd/handoffs/2026-04-20-p1-3-4-encode-canon-parity.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/handoffs/2026-04-20-p1-3-4-encode-canon-parity
-kind: docs
+kind: journals
 title: "Handoff — P1.3.4 Encode Canon-Parity Refactor (D5 Stemmed Matcher + D9 Cache Removal for triggerRegex) (0.22.0)"
 audience: odd
 exposure: nav

--- a/odd/handoffs/2026-04-20-p1-3-4-encode-canon-parity.md
+++ b/odd/handoffs/2026-04-20-p1-3-4-encode-canon-parity.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/handoffs/2026-04-20-p1-3-4-encode-canon-parity
-kind: odd
+kind: docs
 title: "Handoff — P1.3.4 Encode Canon-Parity Refactor (D5 Stemmed Matcher + D9 Cache Removal for triggerRegex) (0.22.0)"
 audience: odd
 exposure: nav

--- a/odd/handoffs/2026-04-20-p1-3-4-encode-canon-parity.md
+++ b/odd/handoffs/2026-04-20-p1-3-4-encode-canon-parity.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/handoffs/2026-04-20-p1-3-4-encode-canon-parity
+kind: odd
 title: "Handoff — P1.3.4 Encode Canon-Parity Refactor (D5 Stemmed Matcher + D9 Cache Removal for triggerRegex) (0.22.0)"
 audience: odd
 exposure: nav

--- a/odd/handoffs/2026-04-20-p1-3-challenge-canary.md
+++ b/odd/handoffs/2026-04-20-p1-3-challenge-canary.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/handoffs/2026-04-20-p1-3-challenge-canary
-kind: docs
+kind: journals
 title: "Handoff — P1.3.1 oddkit_challenge governance_source Retrofit"
 audience: odd
 exposure: nav

--- a/odd/handoffs/2026-04-20-p1-3-challenge-canary.md
+++ b/odd/handoffs/2026-04-20-p1-3-challenge-canary.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/handoffs/2026-04-20-p1-3-challenge-canary
+kind: odd
 title: "Handoff — P1.3.1 oddkit_challenge governance_source Retrofit"
 audience: odd
 exposure: nav

--- a/odd/handoffs/2026-04-20-p1-3-challenge-canary.md
+++ b/odd/handoffs/2026-04-20-p1-3-challenge-canary.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/handoffs/2026-04-20-p1-3-challenge-canary
-kind: odd
+kind: docs
 title: "Handoff — P1.3.1 oddkit_challenge governance_source Retrofit"
 audience: odd
 exposure: nav

--- a/odd/handoffs/2026-04-20-post-closeout.md
+++ b/odd/handoffs/2026-04-20-post-closeout.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/handoffs/2026-04-20-post-closeout
+kind: odd
 title: "Handoff — Post-Closeout State (validator VERIFIED, schema extended, 0.17.0 shipped)"
 audience: odd
 exposure: nav

--- a/odd/handoffs/2026-04-20-post-closeout.md
+++ b/odd/handoffs/2026-04-20-post-closeout.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/handoffs/2026-04-20-post-closeout
-kind: docs
+kind: journals
 title: "Handoff — Post-Closeout State (validator VERIFIED, schema extended, 0.17.0 shipped)"
 audience: odd
 exposure: nav

--- a/odd/handoffs/2026-04-20-post-closeout.md
+++ b/odd/handoffs/2026-04-20-post-closeout.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/handoffs/2026-04-20-post-closeout
-kind: odd
+kind: docs
 title: "Handoff — Post-Closeout State (validator VERIFIED, schema extended, 0.17.0 shipped)"
 audience: odd
 exposure: nav

--- a/odd/handoffs/2026-04-21-p1-3-2-gate-canary.md
+++ b/odd/handoffs/2026-04-21-p1-3-2-gate-canary.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/handoffs/2026-04-21-p1-3-2-gate-canary
+kind: odd
 title: "Handoff — P1.3.2 oddkit_gate Vodka Refactor + governance_source Envelope"
 audience: odd
 exposure: nav

--- a/odd/handoffs/2026-04-21-p1-3-2-gate-canary.md
+++ b/odd/handoffs/2026-04-21-p1-3-2-gate-canary.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/handoffs/2026-04-21-p1-3-2-gate-canary
-kind: docs
+kind: journals
 title: "Handoff — P1.3.2 oddkit_gate Vodka Refactor + governance_source Envelope"
 audience: odd
 exposure: nav

--- a/odd/handoffs/2026-04-21-p1-3-2-gate-canary.md
+++ b/odd/handoffs/2026-04-21-p1-3-2-gate-canary.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/handoffs/2026-04-21-p1-3-2-gate-canary
-kind: odd
+kind: docs
 title: "Handoff — P1.3.2 oddkit_gate Vodka Refactor + governance_source Envelope"
 audience: odd
 exposure: nav

--- a/odd/handoffs/2026-04-27-link-rot-phase-2-promote-resume.md
+++ b/odd/handoffs/2026-04-27-link-rot-phase-2-promote-resume.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/handoffs/2026-04-27-link-rot-phase-2-promote-resume
-kind: docs
+kind: journals
 title: "Handoff — Link-Rot Phase 2 Promote Resume (RV-Gate Cleared, Awaiting Final Merge)"
 audience: odd
 exposure: nav

--- a/odd/handoffs/2026-04-27-link-rot-phase-2-promote-resume.md
+++ b/odd/handoffs/2026-04-27-link-rot-phase-2-promote-resume.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/handoffs/2026-04-27-link-rot-phase-2-promote-resume
-kind: odd
+kind: docs
 title: "Handoff — Link-Rot Phase 2 Promote Resume (RV-Gate Cleared, Awaiting Final Merge)"
 audience: odd
 exposure: nav

--- a/odd/handoffs/2026-04-27-link-rot-phase-2-promote-resume.md
+++ b/odd/handoffs/2026-04-27-link-rot-phase-2-promote-resume.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/handoffs/2026-04-27-link-rot-phase-2-promote-resume
+kind: odd
 title: "Handoff — Link-Rot Phase 2 Promote Resume (RV-Gate Cleared, Awaiting Final Merge)"
 audience: odd
 exposure: nav

--- a/odd/handoffs/2026-04-30-cli-encode-deprecation.md
+++ b/odd/handoffs/2026-04-30-cli-encode-deprecation.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/handoffs/2026-04-30-cli-encode-deprecation
+kind: odd
 title: "Handoff — Deprecate Node CLI Encode Path (src/tasks/encode.js Consumers, Worker Is Source of Truth)"
 audience: docs
 exposure: nav

--- a/odd/handoffs/2026-04-30-cli-encode-deprecation.md
+++ b/odd/handoffs/2026-04-30-cli-encode-deprecation.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/handoffs/2026-04-30-cli-encode-deprecation
-kind: docs
+kind: journals
 title: "Handoff — Deprecate Node CLI Encode Path (src/tasks/encode.js Consumers, Worker Is Source of Truth)"
 audience: docs
 exposure: nav

--- a/odd/handoffs/2026-04-30-cli-encode-deprecation.md
+++ b/odd/handoffs/2026-04-30-cli-encode-deprecation.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/handoffs/2026-04-30-cli-encode-deprecation
-kind: odd
+kind: docs
 title: "Handoff — Deprecate Node CLI Encode Path (src/tasks/encode.js Consumers, Worker Is Source of Truth)"
 audience: docs
 exposure: nav

--- a/odd/handoffs/2026-04-30-encode-vodka-refactor-alternative-d-revised.md
+++ b/odd/handoffs/2026-04-30-encode-vodka-refactor-alternative-d-revised.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/handoffs/2026-04-30-encode-vodka-refactor-alternative-d-revised
+kind: odd
 title: "Handoff (Revised) — oddkit_encode Phase 2 (Five Worker Items + Open Dedup Bug, Scoped Against Real Code State)"
 audience: docs
 exposure: nav

--- a/odd/handoffs/2026-04-30-encode-vodka-refactor-alternative-d-revised.md
+++ b/odd/handoffs/2026-04-30-encode-vodka-refactor-alternative-d-revised.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/handoffs/2026-04-30-encode-vodka-refactor-alternative-d-revised
-kind: odd
+kind: docs
 title: "Handoff (Revised) — oddkit_encode Phase 2 (Five Worker Items + Open Dedup Bug, Scoped Against Real Code State)"
 audience: docs
 exposure: nav

--- a/odd/handoffs/2026-04-30-encode-vodka-refactor-alternative-d-revised.md
+++ b/odd/handoffs/2026-04-30-encode-vodka-refactor-alternative-d-revised.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/handoffs/2026-04-30-encode-vodka-refactor-alternative-d-revised
-kind: docs
+kind: journals
 title: "Handoff (Revised) — oddkit_encode Phase 2 (Five Worker Items + Open Dedup Bug, Scoped Against Real Code State)"
 audience: docs
 exposure: nav

--- a/odd/handoffs/2026-04-30-encode-vodka-refactor-alternative-d.md
+++ b/odd/handoffs/2026-04-30-encode-vodka-refactor-alternative-d.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/handoffs/2026-04-30-encode-vodka-refactor-alternative-d
-kind: docs
+kind: journals
 title: "Handoff — oddkit_encode Vodka Refactor (Alternative D, Governance-Driven Parser, E0008.4 Phase 2)"
 audience: docs
 exposure: nav

--- a/odd/handoffs/2026-04-30-encode-vodka-refactor-alternative-d.md
+++ b/odd/handoffs/2026-04-30-encode-vodka-refactor-alternative-d.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/handoffs/2026-04-30-encode-vodka-refactor-alternative-d
-kind: odd
+kind: docs
 title: "Handoff — oddkit_encode Vodka Refactor (Alternative D, Governance-Driven Parser, E0008.4 Phase 2)"
 audience: docs
 exposure: nav

--- a/odd/handoffs/2026-04-30-encode-vodka-refactor-alternative-d.md
+++ b/odd/handoffs/2026-04-30-encode-vodka-refactor-alternative-d.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/handoffs/2026-04-30-encode-vodka-refactor-alternative-d
+kind: odd
 title: "Handoff — oddkit_encode Vodka Refactor (Alternative D, Governance-Driven Parser, E0008.4 Phase 2)"
 audience: docs
 exposure: nav

--- a/odd/handoffs/2026-05-10-survey-governance-wiring.md
+++ b/odd/handoffs/2026-05-10-survey-governance-wiring.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/handoffs/2026-05-10-survey-governance-wiring
-kind: docs
+kind: journals
 title: "Handoff — Survey Method Governance Wiring (PR #192 continuation)"
 audience: docs
 exposure: nav

--- a/odd/handoffs/2026-05-10-survey-governance-wiring.md
+++ b/odd/handoffs/2026-05-10-survey-governance-wiring.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/handoffs/2026-05-10-survey-governance-wiring
-kind: odd
+kind: docs
 title: "Handoff — Survey Method Governance Wiring (PR #192 continuation)"
 audience: docs
 exposure: nav

--- a/odd/handoffs/2026-05-10-survey-governance-wiring.md
+++ b/odd/handoffs/2026-05-10-survey-governance-wiring.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/handoffs/2026-05-10-survey-governance-wiring
+kind: odd
 title: "Handoff — Survey Method Governance Wiring (PR #192 continuation)"
 audience: docs
 exposure: nav

--- a/odd/handoffs/2026-05-12-epoch-9-trio.md
+++ b/odd/handoffs/2026-05-12-epoch-9-trio.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/handoffs/2026-05-12-epoch-9-trio
-kind: odd
+kind: docs
 title: "Handoff — Epoch 9 Declaration Trio (Two-PR Sequence Against klappy/klappy.dev)"
 audience: docs
 exposure: nav

--- a/odd/handoffs/2026-05-12-epoch-9-trio.md
+++ b/odd/handoffs/2026-05-12-epoch-9-trio.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/handoffs/2026-05-12-epoch-9-trio
+kind: odd
 title: "Handoff — Epoch 9 Declaration Trio (Two-PR Sequence Against klappy/klappy.dev)"
 audience: docs
 exposure: nav

--- a/odd/handoffs/2026-05-12-epoch-9-trio.md
+++ b/odd/handoffs/2026-05-12-epoch-9-trio.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/handoffs/2026-05-12-epoch-9-trio
-kind: docs
+kind: journals
 title: "Handoff — Epoch 9 Declaration Trio (Two-PR Sequence Against klappy/klappy.dev)"
 audience: docs
 exposure: nav

--- a/odd/handoffs/2026-05-14-telemetry-coverage-completeness.md
+++ b/odd/handoffs/2026-05-14-telemetry-coverage-completeness.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/handoffs/2026-05-14-telemetry-coverage-completeness
-kind: docs
+kind: journals
 title: "Handoff — Telemetry Coverage Completeness (Phase 1)"
 audience: odd
 exposure: nav

--- a/odd/handoffs/2026-05-14-telemetry-coverage-completeness.md
+++ b/odd/handoffs/2026-05-14-telemetry-coverage-completeness.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/handoffs/2026-05-14-telemetry-coverage-completeness
-kind: odd
+kind: docs
 title: "Handoff — Telemetry Coverage Completeness (Phase 1)"
 audience: odd
 exposure: nav

--- a/odd/handoffs/2026-05-14-telemetry-coverage-completeness.md
+++ b/odd/handoffs/2026-05-14-telemetry-coverage-completeness.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/handoffs/2026-05-14-telemetry-coverage-completeness
+kind: odd
 title: "Handoff — Telemetry Coverage Completeness (Phase 1)"
 audience: odd
 exposure: nav

--- a/odd/handoffs/2026-05-16-mcp-bearer-token-middleware.md
+++ b/odd/handoffs/2026-05-16-mcp-bearer-token-middleware.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/handoffs/2026-05-16-mcp-bearer-token-middleware
+kind: odd
 title: "Handoff — MCP Server Bearer-Token Middleware (Supabase JWT + PAT Validation)"
 audience: odd
 exposure: nav

--- a/odd/handoffs/2026-05-16-mcp-bearer-token-middleware.md
+++ b/odd/handoffs/2026-05-16-mcp-bearer-token-middleware.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/handoffs/2026-05-16-mcp-bearer-token-middleware
-kind: odd
+kind: docs
 title: "Handoff — MCP Server Bearer-Token Middleware (Supabase JWT + PAT Validation)"
 audience: odd
 exposure: nav

--- a/odd/handoffs/2026-05-16-mcp-bearer-token-middleware.md
+++ b/odd/handoffs/2026-05-16-mcp-bearer-token-middleware.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/handoffs/2026-05-16-mcp-bearer-token-middleware
-kind: docs
+kind: journals
 title: "Handoff — MCP Server Bearer-Token Middleware (Supabase JWT + PAT Validation)"
 audience: odd
 exposure: nav

--- a/odd/handoffs/2026-06-09-scope-audit-execution.md
+++ b/odd/handoffs/2026-06-09-scope-audit-execution.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/handoffs/2026-06-09-scope-audit-execution
+kind: odd
 title: "Handoff — scope-audit PR: Tag Movers with target_repo (klappy.dev Bifurcation, Pass 1)"
 audience: odd
 exposure: nav

--- a/odd/handoffs/2026-06-09-scope-audit-execution.md
+++ b/odd/handoffs/2026-06-09-scope-audit-execution.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/handoffs/2026-06-09-scope-audit-execution
-kind: docs
+kind: journals
 title: "Handoff — scope-audit PR: Tag Movers with target_repo (klappy.dev Bifurcation, Pass 1)"
 audience: odd
 exposure: nav

--- a/odd/handoffs/2026-06-09-scope-audit-execution.md
+++ b/odd/handoffs/2026-06-09-scope-audit-execution.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/handoffs/2026-06-09-scope-audit-execution
-kind: odd
+kind: docs
 title: "Handoff — scope-audit PR: Tag Movers with target_repo (klappy.dev Bifurcation, Pass 1)"
 audience: odd
 exposure: nav

--- a/odd/handoffs/2026-06-09-storage-model-execution.md
+++ b/odd/handoffs/2026-06-09-storage-model-execution.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/handoffs/2026-06-09-storage-model-execution
-kind: odd
+kind: docs
 title: "Handoff — Execute the Canon Storage Model (D0002 v2), Verify oddkit, Then Bifurcate"
 audience: canon
 exposure: hidden

--- a/odd/handoffs/2026-06-09-storage-model-execution.md
+++ b/odd/handoffs/2026-06-09-storage-model-execution.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/handoffs/2026-06-09-storage-model-execution
-kind: docs
+kind: journals
 title: "Handoff — Execute the Canon Storage Model (D0002 v2), Verify oddkit, Then Bifurcate"
 audience: canon
 exposure: hidden

--- a/odd/handoffs/2026-06-09-storage-model-execution.md
+++ b/odd/handoffs/2026-06-09-storage-model-execution.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/handoffs/2026-06-09-storage-model-execution
+kind: odd
 title: "Handoff — Execute the Canon Storage Model (D0002 v2), Verify oddkit, Then Bifurcate"
 audience: canon
 exposure: hidden

--- a/odd/index.md
+++ b/odd/index.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd
-kind: odd
+kind: canon
 title: "Outcomes-Driven Development (ODD)"
 subtitle: "ODD = Outcomes-Driven Development — the philosophical and operational foundation for this repository."
 audience: canon

--- a/odd/index.md
+++ b/odd/index.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd
+kind: odd
 title: "Outcomes-Driven Development (ODD)"
 subtitle: "ODD = Outcomes-Driven Development — the philosophical and operational foundation for this repository."
 audience: canon

--- a/odd/ledger/2026-03-21-drift-audit-session.md
+++ b/odd/ledger/2026-03-21-drift-audit-session.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/ledger/2026-03-21-drift-audit-session
-kind: odd
+kind: journals
 title: "Session Ledger — Drift Audit, Supersession Method, and Learning in Public"
 tier: 3
 type: ledger

--- a/odd/ledger/2026-03-21-drift-audit-session.md
+++ b/odd/ledger/2026-03-21-drift-audit-session.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/ledger/2026-03-21-drift-audit-session
+kind: odd
 title: "Session Ledger — Drift Audit, Supersession Method, and Learning in Public"
 tier: 3
 type: ledger

--- a/odd/ledger/2026-04-03-e0007-session-2.md
+++ b/odd/ledger/2026-04-03-e0007-session-2.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/ledger/2026-04-03-e0007-session-2
-kind: odd
+kind: journals
 title: "E0007 Session 2 — Governance Articles, Catalog Feature, oddkit Implementation"
 audience: docs
 exposure: internal

--- a/odd/ledger/2026-04-03-e0007-session-2.md
+++ b/odd/ledger/2026-04-03-e0007-session-2.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/ledger/2026-04-03-e0007-session-2
+kind: odd
 title: "E0007 Session 2 — Governance Articles, Catalog Feature, oddkit Implementation"
 audience: docs
 exposure: internal

--- a/odd/ledger/2026-04-03-e0007-session-3.md
+++ b/odd/ledger/2026-04-03-e0007-session-3.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/ledger/2026-04-03-e0007-session-3
-kind: odd
+kind: journals
 title: "E0007 Session 3 — Implementation, Testing, Validation, Bootstrap"
 audience: docs
 exposure: internal

--- a/odd/ledger/2026-04-03-e0007-session-3.md
+++ b/odd/ledger/2026-04-03-e0007-session-3.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/ledger/2026-04-03-e0007-session-3
+kind: odd
 title: "E0007 Session 3 — Implementation, Testing, Validation, Bootstrap"
 audience: docs
 exposure: internal

--- a/odd/ledger/2026-04-03-e0007-session-4.md
+++ b/odd/ledger/2026-04-03-e0007-session-4.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/ledger/2026-04-03-e0007-session-4
+kind: odd
 title: "E0007 Session 4 — Phase 5 Public Articles and README Overhauls"
 audience: docs
 exposure: internal

--- a/odd/ledger/2026-04-03-e0007-session-4.md
+++ b/odd/ledger/2026-04-03-e0007-session-4.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/ledger/2026-04-03-e0007-session-4
-kind: odd
+kind: journals
 title: "E0007 Session 4 — Phase 5 Public Articles and README Overhauls"
 audience: docs
 exposure: internal

--- a/odd/ledger/2026-04-03-e0007-the-gauntlet-should-run-itself.md
+++ b/odd/ledger/2026-04-03-e0007-the-gauntlet-should-run-itself.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/ledger/2026-04-03-e0007-the-gauntlet-should-run-itself
-kind: odd
+kind: journals
 title: "2026 04 03 E0007 The Gauntlet Should Run Itself"
 audience: odd
 exposure: nav

--- a/odd/ledger/2026-04-03-e0007-the-gauntlet-should-run-itself.md
+++ b/odd/ledger/2026-04-03-e0007-the-gauntlet-should-run-itself.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/ledger/2026-04-03-e0007-the-gauntlet-should-run-itself
+kind: odd
 title: "2026 04 03 E0007 The Gauntlet Should Run Itself"
 audience: odd
 exposure: nav

--- a/odd/ledger/2026-04-09-managed-agents-session.md
+++ b/odd/ledger/2026-04-09-managed-agents-session.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/ledger/2026-04-09-managed-agents-session
+kind: odd
 title: "2026 04 09 Managed Agents Session"
 audience: odd
 exposure: nav

--- a/odd/ledger/2026-04-09-managed-agents-session.md
+++ b/odd/ledger/2026-04-09-managed-agents-session.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/ledger/2026-04-09-managed-agents-session
-kind: odd
+kind: journals
 title: "2026 04 09 Managed Agents Session"
 audience: odd
 exposure: nav

--- a/odd/ledger/2026-04-13-swarm-spike.md
+++ b/odd/ledger/2026-04-13-swarm-spike.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/ledger/2026-04-13-swarm-spike
-kind: odd
+kind: journals
 title: "2026 04 13 Swarm Spike"
 audience: odd
 exposure: nav

--- a/odd/ledger/2026-04-13-swarm-spike.md
+++ b/odd/ledger/2026-04-13-swarm-spike.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/ledger/2026-04-13-swarm-spike
+kind: odd
 title: "2026 04 13 Swarm Spike"
 audience: odd
 exposure: nav

--- a/odd/ledger/2026-04-18-e0008-3-validation-and-teams-over-swarms.md
+++ b/odd/ledger/2026-04-18-e0008-3-validation-and-teams-over-swarms.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/ledger/2026-04-18-e0008-3-validation-and-teams-over-swarms
-kind: odd
+kind: journals
 title: "E0008.3 Session — Validation Mode, Context Break, and Teams Over Swarms"
 audience: odd
 exposure: nav

--- a/odd/ledger/2026-04-18-e0008-3-validation-and-teams-over-swarms.md
+++ b/odd/ledger/2026-04-18-e0008-3-validation-and-teams-over-swarms.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/ledger/2026-04-18-e0008-3-validation-and-teams-over-swarms
+kind: odd
 title: "E0008.3 Session — Validation Mode, Context Break, and Teams Over Swarms"
 audience: odd
 exposure: nav

--- a/odd/ledger/2026-04-19-agent-team-pilot.md
+++ b/odd/ledger/2026-04-19-agent-team-pilot.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/ledger/2026-04-19-agent-team-pilot
+kind: odd
 title: "Session Ledger — Agent-Team Pilot (Execution + Validation, Cross-Model)"
 audience: odd
 exposure: nav

--- a/odd/ledger/2026-04-19-agent-team-pilot.md
+++ b/odd/ledger/2026-04-19-agent-team-pilot.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/ledger/2026-04-19-agent-team-pilot
-kind: odd
+kind: journals
 title: "Session Ledger — Agent-Team Pilot (Execution + Validation, Cross-Model)"
 audience: odd
 exposure: nav

--- a/odd/ledger/2026-04-19-p1-2-encode-dolcheo-landed.md
+++ b/odd/ledger/2026-04-19-p1-2-encode-dolcheo-landed.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/ledger/2026-04-19-p1-2-encode-dolcheo-landed
+kind: odd
 title: "Session Ledger — P1.2 Encode DOLCHEO + Canary Landed (0.18.0)"
 audience: odd
 exposure: nav

--- a/odd/ledger/2026-04-19-p1-2-encode-dolcheo-landed.md
+++ b/odd/ledger/2026-04-19-p1-2-encode-dolcheo-landed.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/ledger/2026-04-19-p1-2-encode-dolcheo-landed
-kind: odd
+kind: journals
 title: "Session Ledger — P1.2 Encode DOLCHEO + Canary Landed (0.18.0)"
 audience: odd
 exposure: nav

--- a/odd/ledger/2026-04-19-validator-closeout-and-0.17.0.md
+++ b/odd/ledger/2026-04-19-validator-closeout-and-0.17.0.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/ledger/2026-04-19-validator-closeout-and-0.17.0
+kind: odd
 title: "Session Ledger — Validator Closeout and 0.17.0 Release"
 audience: odd
 exposure: nav

--- a/odd/ledger/2026-04-19-validator-closeout-and-0.17.0.md
+++ b/odd/ledger/2026-04-19-validator-closeout-and-0.17.0.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/ledger/2026-04-19-validator-closeout-and-0.17.0
-kind: odd
+kind: journals
 title: "Session Ledger — Validator Closeout and 0.17.0 Release"
 audience: odd
 exposure: nav

--- a/odd/ledger/2026-04-20-0-22-0-envelope-fixes-and-retroactive-closure.md
+++ b/odd/ledger/2026-04-20-0-22-0-envelope-fixes-and-retroactive-closure.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/ledger/2026-04-20-0-22-0-envelope-fixes-and-retroactive-closure
-kind: odd
+kind: journals
 title: "Session Ledger — 0.22.0 Ship Cycle (Envelope Fixes) and the First Retroactive-Closure Pattern Under release-validation-gate Canon"
 audience: odd
 exposure: nav

--- a/odd/ledger/2026-04-20-0-22-0-envelope-fixes-and-retroactive-closure.md
+++ b/odd/ledger/2026-04-20-0-22-0-envelope-fixes-and-retroactive-closure.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/ledger/2026-04-20-0-22-0-envelope-fixes-and-retroactive-closure
+kind: odd
 title: "Session Ledger — 0.22.0 Ship Cycle (Envelope Fixes) and the First Retroactive-Closure Pattern Under release-validation-gate Canon"
 audience: odd
 exposure: nav

--- a/odd/ledger/2026-04-20-p1-3-1-challenge-canary-landed.md
+++ b/odd/ledger/2026-04-20-p1-3-1-challenge-canary-landed.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/ledger/2026-04-20-p1-3-1-challenge-canary-landed
-kind: odd
+kind: journals
 title: "Session Ledger — P1.3.1 Challenge governance_source Canary Landed (0.19.0)"
 audience: odd
 exposure: nav

--- a/odd/ledger/2026-04-20-p1-3-1-challenge-canary-landed.md
+++ b/odd/ledger/2026-04-20-p1-3-1-challenge-canary-landed.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/ledger/2026-04-20-p1-3-1-challenge-canary-landed
+kind: odd
 title: "Session Ledger — P1.3.1 Challenge governance_source Canary Landed (0.19.0)"
 audience: odd
 exposure: nav

--- a/odd/ledger/2026-04-20-p1-3-2-gate-canary-landed.md
+++ b/odd/ledger/2026-04-20-p1-3-2-gate-canary-landed.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/ledger/2026-04-20-p1-3-2-gate-canary-landed
+kind: odd
 title: "Session Ledger — P1.3.2 Gate governance_source Canary Landed (0.20.0)"
 audience: odd
 exposure: nav

--- a/odd/ledger/2026-04-20-p1-3-2-gate-canary-landed.md
+++ b/odd/ledger/2026-04-20-p1-3-2-gate-canary-landed.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/ledger/2026-04-20-p1-3-2-gate-canary-landed
-kind: odd
+kind: journals
 title: "Session Ledger — P1.3.2 Gate governance_source Canary Landed (0.20.0)"
 audience: odd
 exposure: nav

--- a/odd/ledger/2026-04-20-p1-3-3-challenge-canon-parity-landed.md
+++ b/odd/ledger/2026-04-20-p1-3-3-challenge-canon-parity-landed.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/ledger/2026-04-20-p1-3-3-challenge-canon-parity-landed
+kind: odd
 title: "P1.3.3 Closeout — Challenge Canon-Parity (D5 + D9 + Cache-Fetches-and-Parses), Plus the Process Failure That Made the Release-Validation-Gate Canon Necessary"
 audience: odd
 exposure: nav

--- a/odd/ledger/2026-04-20-p1-3-3-challenge-canon-parity-landed.md
+++ b/odd/ledger/2026-04-20-p1-3-3-challenge-canon-parity-landed.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/ledger/2026-04-20-p1-3-3-challenge-canon-parity-landed
-kind: odd
+kind: journals
 title: "P1.3.3 Closeout — Challenge Canon-Parity (D5 + D9 + Cache-Fetches-and-Parses), Plus the Process Failure That Made the Release-Validation-Gate Canon Necessary"
 audience: odd
 exposure: nav

--- a/odd/ledger/2026-04-20-p1-3-4-encode-canon-parity-landed.md
+++ b/odd/ledger/2026-04-20-p1-3-4-encode-canon-parity-landed.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/ledger/2026-04-20-p1-3-4-encode-canon-parity-landed
-kind: odd
+kind: journals
 title: "P1.3.4 Closeout — Encode Canon-Parity (D5 Phrase-Subset Matcher + D9 cachedEncodingTypes Removal), Plus Second Application of Release-Validation-Gate Canon, Plus the 0.22.0-Parallel-Release Version Collision"
 audience: odd
 exposure: nav

--- a/odd/ledger/2026-04-20-p1-3-4-encode-canon-parity-landed.md
+++ b/odd/ledger/2026-04-20-p1-3-4-encode-canon-parity-landed.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/ledger/2026-04-20-p1-3-4-encode-canon-parity-landed
+kind: odd
 title: "P1.3.4 Closeout — Encode Canon-Parity (D5 Phrase-Subset Matcher + D9 cachedEncodingTypes Removal), Plus Second Application of Release-Validation-Gate Canon, Plus the 0.22.0-Parallel-Release Version Collision"
 audience: odd
 exposure: nav

--- a/odd/ledger/2026-04-20-post-4-7-proactive-loop-experience.md
+++ b/odd/ledger/2026-04-20-post-4-7-proactive-loop-experience.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/ledger/2026-04-20-post-4-7-proactive-loop-experience
+kind: odd
 title: "Observation — Six Sessions of Proactive Loop Since Opus 4.7: Trust Gained, Verbosity Cost, Checkpoint Shape Revealed"
 audience: odd
 exposure: nav

--- a/odd/ledger/2026-04-20-post-4-7-proactive-loop-experience.md
+++ b/odd/ledger/2026-04-20-post-4-7-proactive-loop-experience.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/ledger/2026-04-20-post-4-7-proactive-loop-experience
-kind: odd
+kind: journals
 title: "Observation — Six Sessions of Proactive Loop Since Opus 4.7: Trust Gained, Verbosity Cost, Checkpoint Shape Revealed"
 audience: odd
 exposure: nav

--- a/odd/ledger/2026-04-24-aquifer-session-principles-graduated.md
+++ b/odd/ledger/2026-04-24-aquifer-session-principles-graduated.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/ledger/2026-04-24-aquifer-session-principles-graduated
+kind: odd
 title: "Ledger — Two Canon Principles Graduated From The aquifer-mcp J-002 → H11b Session"
 audience: odd
 exposure: nav

--- a/odd/ledger/2026-04-24-aquifer-session-principles-graduated.md
+++ b/odd/ledger/2026-04-24-aquifer-session-principles-graduated.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/ledger/2026-04-24-aquifer-session-principles-graduated
-kind: odd
+kind: journals
 title: "Ledger — Two Canon Principles Graduated From The aquifer-mcp J-002 → H11b Session"
 audience: odd
 exposure: nav

--- a/odd/ledger/2026-04-26-pr139-and-deploy-propagation-correction.md
+++ b/odd/ledger/2026-04-26-pr139-and-deploy-propagation-correction.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/ledger/2026-04-26-pr139-and-deploy-propagation-correction
+kind: odd
 title: "Ledger Correction — PR #139 Closed The File-Tier Open Item, And A New Deploy-Propagation Open Item Surfaced"
 audience: odd
 exposure: nav

--- a/odd/ledger/2026-04-26-pr139-and-deploy-propagation-correction.md
+++ b/odd/ledger/2026-04-26-pr139-and-deploy-propagation-correction.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/ledger/2026-04-26-pr139-and-deploy-propagation-correction
-kind: odd
+kind: journals
 title: "Ledger Correction — PR #139 Closed The File-Tier Open Item, And A New Deploy-Propagation Open Item Surfaced"
 audience: odd
 exposure: nav

--- a/odd/ledger/2026-04-26-telemetry-and-canon-integration-session.md
+++ b/odd/ledger/2026-04-26-telemetry-and-canon-integration-session.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/ledger/2026-04-26-telemetry-and-canon-integration-session
-kind: odd
+kind: journals
 title: "Ledger — Telemetry Semantic Names, cache_tier Streaming-Race, And Canon-Integration-Audit (Four PRs Shipped)"
 audience: odd
 exposure: nav

--- a/odd/ledger/2026-04-26-telemetry-and-canon-integration-session.md
+++ b/odd/ledger/2026-04-26-telemetry-and-canon-integration-session.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/ledger/2026-04-26-telemetry-and-canon-integration-session
+kind: odd
 title: "Ledger — Telemetry Semantic Names, cache_tier Streaming-Race, And Canon-Integration-Audit (Four PRs Shipped)"
 audience: odd
 exposure: nav

--- a/odd/ledger/2026-04-27-link-rot-phase-2-shipped.md
+++ b/odd/ledger/2026-04-27-link-rot-phase-2-shipped.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/ledger/2026-04-27-link-rot-phase-2-shipped
+kind: odd
 title: "Session Ledger — Link-Rot Phase 2 Shipped (oddkit v0.26.0 in prod)"
 audience: odd
 exposure: nav

--- a/odd/ledger/2026-04-27-link-rot-phase-2-shipped.md
+++ b/odd/ledger/2026-04-27-link-rot-phase-2-shipped.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/ledger/2026-04-27-link-rot-phase-2-shipped
-kind: odd
+kind: journals
 title: "Session Ledger — Link-Rot Phase 2 Shipped (oddkit v0.26.0 in prod)"
 audience: odd
 exposure: nav

--- a/odd/ledger/2026-04-30-audit-cleanup-encode-artifacts-landed.md
+++ b/odd/ledger/2026-04-30-audit-cleanup-encode-artifacts-landed.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/ledger/2026-04-30-audit-cleanup-encode-artifacts-landed
+kind: odd
 title: "Audit 2026-04-30 Cleanup Closeout — Three Stale Artifacts Superseded, Code-Observation Principle Earned, CLI Deprecation Queued"
 audience: docs
 exposure: nav

--- a/odd/ledger/2026-04-30-audit-cleanup-encode-artifacts-landed.md
+++ b/odd/ledger/2026-04-30-audit-cleanup-encode-artifacts-landed.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/ledger/2026-04-30-audit-cleanup-encode-artifacts-landed
-kind: odd
+kind: journals
 title: "Audit 2026-04-30 Cleanup Closeout — Three Stale Artifacts Superseded, Code-Observation Principle Earned, CLI Deprecation Queued"
 audience: docs
 exposure: nav

--- a/odd/ledger/2026-04-30-e0008-4-phase-1-encode-governance-migration-landed.md
+++ b/odd/ledger/2026-04-30-e0008-4-phase-1-encode-governance-migration-landed.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/ledger/2026-04-30-e0008-4-phase-1-encode-governance-migration-landed
-kind: odd
+kind: journals
 title: "E0008.4 Phase 1 Closeout — Encode Governance Migration from TruthKit-KB (Canon-Only Ship, Phase 2 Handoff Laid)"
 audience: docs
 exposure: nav

--- a/odd/ledger/2026-04-30-e0008-4-phase-1-encode-governance-migration-landed.md
+++ b/odd/ledger/2026-04-30-e0008-4-phase-1-encode-governance-migration-landed.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/ledger/2026-04-30-e0008-4-phase-1-encode-governance-migration-landed
+kind: odd
 title: "E0008.4 Phase 1 Closeout — Encode Governance Migration from TruthKit-KB (Canon-Only Ship, Phase 2 Handoff Laid)"
 audience: docs
 exposure: nav

--- a/odd/ledger/2026-04-30-encode-vodka-refactor-phase-2-landed.md
+++ b/odd/ledger/2026-04-30-encode-vodka-refactor-phase-2-landed.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/ledger/2026-04-30-encode-vodka-refactor-phase-2-landed
-kind: odd
+kind: journals
 title: "E0008.4 Phase 2 Closeout — Encode Items 1–4 (governance_uris Plural, (letter,facet) Dedup, Open in Fallback, governance_extended Self-Teaching), Item 5 Deferred to 0.29.0, Two Bugbot Findings Autofix-Forwarded, Validator PASS, Prod Promotion Outstanding"
 audience: odd
 exposure: nav

--- a/odd/ledger/2026-04-30-encode-vodka-refactor-phase-2-landed.md
+++ b/odd/ledger/2026-04-30-encode-vodka-refactor-phase-2-landed.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/ledger/2026-04-30-encode-vodka-refactor-phase-2-landed
+kind: odd
 title: "E0008.4 Phase 2 Closeout — Encode Items 1–4 (governance_uris Plural, (letter,facet) Dedup, Open in Fallback, governance_extended Self-Teaching), Item 5 Deferred to 0.29.0, Two Bugbot Findings Autofix-Forwarded, Validator PASS, Prod Promotion Outstanding"
 audience: odd
 exposure: nav

--- a/odd/ledger/2026-05-05-biblical-roots-appendix-slug-alignment.md
+++ b/odd/ledger/2026-05-05-biblical-roots-appendix-slug-alignment.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/ledger/2026-05-05-biblical-roots-appendix-slug-alignment
-kind: odd
+kind: journals
 title: "Biblical Roots Appendix Slug Alignment — Closing One Audit-Job-#36 Finding by Aligning the Forward-Ref to the Draft's Declared URI"
 audience: docs
 exposure: nav

--- a/odd/ledger/2026-05-05-biblical-roots-appendix-slug-alignment.md
+++ b/odd/ledger/2026-05-05-biblical-roots-appendix-slug-alignment.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/ledger/2026-05-05-biblical-roots-appendix-slug-alignment
+kind: odd
 title: "Biblical Roots Appendix Slug Alignment — Closing One Audit-Job-#36 Finding by Aligning the Forward-Ref to the Draft's Declared URI"
 audience: docs
 exposure: nav

--- a/odd/ledger/2026-05-07-pr177-validation-review.md
+++ b/odd/ledger/2026-05-07-pr177-validation-review.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/ledger/2026-05-07-pr177-validation-review
-kind: odd
+kind: journals
 title: "PR #177 Validation Review — Audit Gates Are Managed Agents (klappy.dev)"
 tier: 3
 audience: odd

--- a/odd/ledger/2026-05-07-pr177-validation-review.md
+++ b/odd/ledger/2026-05-07-pr177-validation-review.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/ledger/2026-05-07-pr177-validation-review
+kind: odd
 title: "PR #177 Validation Review — Audit Gates Are Managed Agents (klappy.dev)"
 tier: 3
 audience: odd

--- a/odd/ledger/2026-05-10-software-virtues-canon-package.md
+++ b/odd/ledger/2026-05-10-software-virtues-canon-package.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/ledger/2026-05-10-software-virtues-canon-package
-kind: odd
+kind: journals
 title: "Ledger — Software Virtues Canon Package + Essay (Session 2026-05-10)"
 audience: odd
 exposure: nav

--- a/odd/ledger/2026-05-10-software-virtues-canon-package.md
+++ b/odd/ledger/2026-05-10-software-virtues-canon-package.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/ledger/2026-05-10-software-virtues-canon-package
+kind: odd
 title: "Ledger — Software Virtues Canon Package + Essay (Session 2026-05-10)"
 audience: odd
 exposure: nav

--- a/odd/ledger/2026-05-11-agent-runtime-exploration.md
+++ b/odd/ledger/2026-05-11-agent-runtime-exploration.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/ledger/2026-05-11-agent-runtime-exploration
-kind: odd
+kind: journals
 title: "Journal — 2026-05-11 Exploration: agent-runtime, Project Think, and Canon Alignment"
 audience: odd
 exposure: nav

--- a/odd/ledger/2026-05-11-agent-runtime-exploration.md
+++ b/odd/ledger/2026-05-11-agent-runtime-exploration.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/ledger/2026-05-11-agent-runtime-exploration
+kind: odd
 title: "Journal — 2026-05-11 Exploration: agent-runtime, Project Think, and Canon Alignment"
 audience: odd
 exposure: nav

--- a/odd/ledger/2026-05-11-trigger-taxonomy-drafting.md
+++ b/odd/ledger/2026-05-11-trigger-taxonomy-drafting.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/ledger/2026-05-11-trigger-taxonomy-drafting
+kind: odd
 title: "Session Ledger — 2026-05-11 Drafting trigger-source-taxonomy"
 audience: odd
 exposure: nav

--- a/odd/ledger/2026-05-11-trigger-taxonomy-drafting.md
+++ b/odd/ledger/2026-05-11-trigger-taxonomy-drafting.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/ledger/2026-05-11-trigger-taxonomy-drafting
-kind: odd
+kind: journals
 title: "Session Ledger — 2026-05-11 Drafting trigger-source-taxonomy"
 audience: odd
 exposure: nav

--- a/odd/ledger/2026-05-12-epoch-9-planning.md
+++ b/odd/ledger/2026-05-12-epoch-9-planning.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/ledger/2026-05-12-epoch-9-planning
+kind: odd
 title: "Session Ledger — Epoch 9 Planning + Gauntlet + Handoff (2026-05-12)"
 audience: odd
 exposure: nav

--- a/odd/ledger/2026-05-12-epoch-9-planning.md
+++ b/odd/ledger/2026-05-12-epoch-9-planning.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/ledger/2026-05-12-epoch-9-planning
-kind: odd
+kind: journals
 title: "Session Ledger — Epoch 9 Planning + Gauntlet + Handoff (2026-05-12)"
 audience: odd
 exposure: nav

--- a/odd/ledger/2026-05-12-epoch-9-trio-execution.md
+++ b/odd/ledger/2026-05-12-epoch-9-trio-execution.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/ledger/2026-05-12-epoch-9-trio-execution
+kind: odd
 title: "Session Ledger — Epoch 9 Trio Execution (2026-05-12)"
 audience: odd
 exposure: nav

--- a/odd/ledger/2026-05-12-epoch-9-trio-execution.md
+++ b/odd/ledger/2026-05-12-epoch-9-trio-execution.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/ledger/2026-05-12-epoch-9-trio-execution
-kind: odd
+kind: journals
 title: "Session Ledger — Epoch 9 Trio Execution (2026-05-12)"
 audience: odd
 exposure: nav

--- a/odd/ledger/2026-05-12-ritual-was-the-smell.md
+++ b/odd/ledger/2026-05-12-ritual-was-the-smell.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/ledger/2026-05-12-ritual-was-the-smell
-kind: odd
+kind: journals
 title: "Session Ledger — Ritual Was the Smell (we-were-the-wire revision, 2026-05-12)"
 audience: odd
 exposure: nav

--- a/odd/ledger/2026-05-12-ritual-was-the-smell.md
+++ b/odd/ledger/2026-05-12-ritual-was-the-smell.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/ledger/2026-05-12-ritual-was-the-smell
+kind: odd
 title: "Session Ledger — Ritual Was the Smell (we-were-the-wire revision, 2026-05-12)"
 audience: odd
 exposure: nav

--- a/odd/ledger/2026-05-14-telemetry-coverage-planning-session.md
+++ b/odd/ledger/2026-05-14-telemetry-coverage-planning-session.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/ledger/2026-05-14-telemetry-coverage-planning-session
+kind: odd
 title: "Session Journal — Telemetry Coverage Completeness Planning"
 audience: odd
 exposure: nav

--- a/odd/ledger/2026-05-14-telemetry-coverage-planning-session.md
+++ b/odd/ledger/2026-05-14-telemetry-coverage-planning-session.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/ledger/2026-05-14-telemetry-coverage-planning-session
-kind: odd
+kind: journals
 title: "Session Journal — Telemetry Coverage Completeness Planning"
 audience: odd
 exposure: nav

--- a/odd/ledger/2026-05-15-cutover-validation-session.md
+++ b/odd/ledger/2026-05-15-cutover-validation-session.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/ledger/2026-05-15-cutover-validation-session
-kind: odd
+kind: journals
 title: "Session Ledger — Cutover Validation, Canon Authoring, Wrapper Smoke (2026-05-15 to 2026-05-16)"
 audience: odd
 exposure: nav

--- a/odd/ledger/2026-05-15-cutover-validation-session.md
+++ b/odd/ledger/2026-05-15-cutover-validation-session.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/ledger/2026-05-15-cutover-validation-session
+kind: odd
 title: "Session Ledger — Cutover Validation, Canon Authoring, Wrapper Smoke (2026-05-15 to 2026-05-16)"
 audience: odd
 exposure: nav

--- a/odd/ledger/2026-05-23-p0010-retrieval-disclosure-contract-proposal-drafted.md
+++ b/odd/ledger/2026-05-23-p0010-retrieval-disclosure-contract-proposal-drafted.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/ledger/2026-05-23-p0010-retrieval-disclosure-contract-proposal-drafted
-kind: odd
+kind: journals
 title: "Session Ledger — P0010 Retrieval Disclosure Contract Proposal Drafted"
 audience: odd
 exposure: nav

--- a/odd/ledger/2026-05-23-p0010-retrieval-disclosure-contract-proposal-drafted.md
+++ b/odd/ledger/2026-05-23-p0010-retrieval-disclosure-contract-proposal-drafted.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/ledger/2026-05-23-p0010-retrieval-disclosure-contract-proposal-drafted
+kind: odd
 title: "Session Ledger — P0010 Retrieval Disclosure Contract Proposal Drafted"
 audience: odd
 exposure: nav

--- a/odd/ledger/e0007-handoff-bootstrap.md
+++ b/odd/ledger/e0007-handoff-bootstrap.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/ledger/e0007-handoff-bootstrap
+kind: odd
 title: "E0007 Handoff Bootstrap"
 audience: odd
 exposure: nav

--- a/odd/ledger/e0007-handoff-bootstrap.md
+++ b/odd/ledger/e0007-handoff-bootstrap.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/ledger/e0007-handoff-bootstrap
-kind: odd
+kind: journals
 title: "E0007 Handoff Bootstrap"
 audience: odd
 exposure: nav

--- a/odd/ledger/epistemic-ledger.md
+++ b/odd/ledger/epistemic-ledger.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/ledger/epistemic-ledger
+kind: odd
 title: "The Epistemic Ledger — Durable Artifacts That Survive Ephemeral Conversations"
 audience: canon
 exposure: nav

--- a/odd/ledger/epistemic-ledger.md
+++ b/odd/ledger/epistemic-ledger.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/ledger/epistemic-ledger
-kind: journals
+kind: canon
 title: "The Epistemic Ledger — Durable Artifacts That Survive Ephemeral Conversations"
 audience: canon
 exposure: nav

--- a/odd/ledger/epistemic-ledger.md
+++ b/odd/ledger/epistemic-ledger.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/ledger/epistemic-ledger
-kind: odd
+kind: journals
 title: "The Epistemic Ledger — Durable Artifacts That Survive Ephemeral Conversations"
 audience: canon
 exposure: nav

--- a/odd/ledger/journal/2026-04-17-pr100-rage-quit-handoff.md
+++ b/odd/ledger/journal/2026-04-17-pr100-rage-quit-handoff.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/ledger/journal/2026-04-17-pr100-rage-quit-handoff
+kind: odd
 title: "Session Journal — PR #100 Rage-Quit Handoff"
 audience: odd
 exposure: nav

--- a/odd/ledger/journal/2026-04-17-pr100-rage-quit-handoff.md
+++ b/odd/ledger/journal/2026-04-17-pr100-rage-quit-handoff.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/ledger/journal/2026-04-17-pr100-rage-quit-handoff
-kind: odd
+kind: journals
 title: "Session Journal — PR #100 Rage-Quit Handoff"
 audience: odd
 exposure: nav

--- a/odd/ledger/project-journal-best-practices.md
+++ b/odd/ledger/project-journal-best-practices.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/ledger/project-journal-best-practices
-kind: odd
+kind: journals
 title: "Project Journal Best Practices — Sizing, Timestamps, and Tradeoffs"
 audience: docs
 exposure: nav

--- a/odd/ledger/project-journal-best-practices.md
+++ b/odd/ledger/project-journal-best-practices.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/ledger/project-journal-best-practices
+kind: odd
 title: "Project Journal Best Practices — Sizing, Timestamps, and Tradeoffs"
 audience: docs
 exposure: nav

--- a/odd/manifesto.md
+++ b/odd/manifesto.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/manifesto
+kind: odd
 title: "ODD Manifesto — Extended"
 audience: canon
 exposure: nav

--- a/odd/manifesto.md
+++ b/odd/manifesto.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/manifesto
-kind: odd
+kind: canon
 title: "ODD Manifesto — Extended"
 audience: canon
 exposure: nav

--- a/odd/maturity.md
+++ b/odd/maturity.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/maturity
+kind: odd
 title: "Project Maturity & Progressive Governance"
 audience: canon
 exposure: nav

--- a/odd/maturity.md
+++ b/odd/maturity.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/maturity
-kind: odd
+kind: canon
 title: "Project Maturity & Progressive Governance"
 audience: canon
 exposure: nav

--- a/odd/misuse-patterns.md
+++ b/odd/misuse-patterns.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/misuse-patterns
+kind: odd
 title: "ODD Misuse Patterns"
 audience: canon
 exposure: nav

--- a/odd/misuse-patterns.md
+++ b/odd/misuse-patterns.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/misuse-patterns
-kind: odd
+kind: canon
 title: "ODD Misuse Patterns"
 audience: canon
 exposure: nav

--- a/odd/odd-compared.md
+++ b/odd/odd-compared.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/odd-compared
+kind: odd
 title: "Odd Compared"
 audience: odd
 exposure: nav

--- a/odd/odd-compared.md
+++ b/odd/odd-compared.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/odd-compared
-kind: odd
+kind: canon
 title: "Odd Compared"
 audience: odd
 exposure: nav

--- a/odd/orientation-map.md
+++ b/odd/orientation-map.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/orientation-map
-kind: odd
+kind: canon
 title: "ODD + Canon + Evidence — Orientation Map"
 audience: canon
 exposure: nav

--- a/odd/orientation-map.md
+++ b/odd/orientation-map.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/orientation-map
+kind: odd
 title: "ODD + Canon + Evidence — Orientation Map"
 audience: canon
 exposure: nav

--- a/odd/prompt-architecture.md
+++ b/odd/prompt-architecture.md
@@ -1,5 +1,6 @@
 ---
 uri: klappy://odd/prompt-architecture
+kind: odd
 title: "Prompt Architecture"
 audience: canon
 exposure: nav

--- a/odd/prompt-architecture.md
+++ b/odd/prompt-architecture.md
@@ -1,6 +1,6 @@
 ---
 uri: klappy://odd/prompt-architecture
-kind: odd
+kind: canon
 title: "Prompt Architecture"
 audience: canon
 exposure: nav

--- a/odd/terminology.md
+++ b/odd/terminology.md
@@ -1,7 +1,7 @@
 ---
 title: ODD Terminology & Glossary
 uri: klappy://odd/terminology
-kind: odd
+kind: canon
 slug: odd-terminology
 version: 0.1
 status: evolving

--- a/odd/terminology.md
+++ b/odd/terminology.md
@@ -1,6 +1,7 @@
 ---
 title: ODD Terminology & Glossary
 uri: klappy://odd/terminology
+kind: odd
 slug: odd-terminology
 version: 0.1
 status: evolving


### PR DESCRIPTION
## Handoff step 1 — frontmatter half

Pairs with klappy/oddkit#178. Adds `kind: odd` to the frontmatter of all 113 `odd/**/*.md` documents, inserted directly after `uri:`.

Per D0002 item 4 (kind from frontmatter only, path inference prohibited): with this declared, the kind travels with the documents through the step-4 bifurcation into `outcomes-driven-development`, and the worker's corrected `odd/` path fallback is purely transitional.

Verification: `scripts/validate-frontmatter.py` clean (44 scanned, 0 findings); validator smoke tests pass.

**Acceptance** (after #178 deploys): catalog with default filters + `path_prefix=odd/decisions/` → D0001 + D0002.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only frontmatter edits across markdown; no runtime or auth changes, with behavior depending on paired oddkit catalog/index work.
> 
> **Overview**
> Adds an explicit **`kind`** field in YAML frontmatter (immediately after **`uri:`**) across **`odd/**/*.md`**, classifying each file as **`canon`**, **`docs`**, or **`journals`** instead of relying on the default **`odd/` → journals** path mapping.
> 
> **`kind: canon`** covers durable ODD philosophy, contracts, decisions, challenge/encoding/gate governance, and most appendices. **`kind: docs`** marks templates, getting-started material, and backlog stubs. **`kind: journals`** marks handoffs and ledger/session journal files so they stay in the journals bucket even when the tree moves.
> 
> This is the frontmatter half of the D0002 storage-model work: document role for catalog **`include`/`exclude`** and bifurcation into **`outcomes-driven-development`** comes from declared metadata, not path inference.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 326731ece6db1bb0453ffd63bb654773e0edd5a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->