### PR TITLE
index-kill: zero static enumerations — the built index is the only index (D0002 item 5, Step 2)

### DIFF
--- a/canon/README.md
+++ b/canon/README.md
@@ -21,30 +21,7 @@ The Canon exists so that reasoning does not have to be repeated.
 
 ## 📁 Contents
 
-### Core Documents
-
-| File | Title | Summary | Answers |
-|------|-------|---------|---------|
-| `constraints/README.md` | Constraints | Baseline assumptions and non-negotiables that shape every decision. | What must be true for this work to make sense? |
-| `constraints/definition-of-done.md` | Definition of Done | What qualifies as completed work and what evidence is required. | When can work honestly be called done? |
-| `constraints/decision-rules.md` | Decision Rules | Default heuristics used when multiple valid options exist. | How do choices tend to be made? |
-| `constraints/verification-and-evidence.md` | Verification & Evidence | Evidence standards for claims and assertions. | What counts as proof? |
-| `constraints/visual-proof.md` | Visual Proof Standards | What qualifies as acceptable visual evidence. | What does "prove it visually" mean? |
-| `constraints/epistemic-challenge.md` | Epistemic Challenge | Governance behavior for challenging claims. | How are claims tested? |
-| `definitions/epistemic-obligation-and-document-tiers.md` | Epistemic Obligation and Document Tiers | Tiers define epistemic obligation (foundational, shared, awareness), not importance. Orthogonal to folders. | How much must I internalize this? |
-| `definitions/epistemic-modes.md` | Epistemic Modes | Three operational modes for epistemic reasoning. | What modes of reasoning exist? |
-| `methods/README.md` | Methods | Durable application patterns that help humans and agents apply principles and satisfy constraints without re-deriving safe practice each time. | How do I apply ODD safely in practice? |
-| `methods/self-audit.md` | Self-Audit Checklist | Review checklist before declaring completion. | What should be reviewed before claiming success? |
-| `CHANGELOG.md` | Canon Changelog | Version history of canon changes. | What changed and when? |
-
-### Principles
-
-| File | Title | Summary |
-|------|-------|---------|
-| `principles/bulldoze-but-keep-the-blueprint.md` | Bulldoze the App, Keep the Blueprint | When code stops being the scarce resource. Documents the cost-model inversion caused by AI: code is disposable, blueprints (intent, constraints, decisions, evidence) are durable. |
-| `principles/odds-relationship-to-documentation.md` | Documentation Is the Lever, Not the Goal | Clarifies that documentation in ODD is epistemic infrastructure—a forcing function, not an end state. Distinguishes ODD from documentation-driven development. |
-| `principles/irreversibility-is-the-real-cost.md` | Irreversibility Is the Real Cost | Effort is not the scarce resource; irreversible action is. Treats commitment as the thing to be protected, not minimized. |
-| `principles/focus-is-exclusion.md` | Focus Is Exclusion | Possibility is infinite, capacity is not. Makes exclusion a first-class decision to prevent optionality from diluting delivery. |
+To list the documents in this collection: oddkit `catalog` with `path_prefix=canon/`.
 
 ### Subfolders
 
@@ -65,13 +42,6 @@ The Canon exists so that reasoning does not have to be repeated.
 
 ### Resonance (External Alignment & Divergence)
 
-| File | Work | ODD Principle |
-|------|------|---------------|
-| `resonance/antifragile.md` | Antifragile | Systems Should Improve Under Stress |
-| `resonance/lean-startup.md` | The Lean Startup | Epistemic Feedback Loops |
-| `resonance/ooda-loop.md` | OODA Loop | Orientation Dominates Action |
-| `resonance/sprint.md` | Sprint | Constrained Convergence Produces Clarity |
-| `resonance/double-diamond.md` | The Double Diamond | Governed Divergence and Convergence |
 
 > **Canon Rule:** Every cited work must include at least one explicit divergence.
 > If no divergence exists, the citation does not belong.

--- a/canon/apocrypha/fragments/README.md
+++ b/canon/apocrypha/fragments/README.md
@@ -17,17 +17,7 @@ They follow the same charter constraints: append-only, never revised, no prescri
 
 ## Fragments
 
-| # | Title | Epoch context |
-|---|-------|---------------|
-| IV | [On Artifacts](fragment-04-on-artifacts.md) | Pre-Epoch 5 — when proof of existence became identity |
-| V | [On Consent Drift](fragment-05-on-consent-drift.md) | Pre-Epoch 5 — when defaults compounded into authority |
-| VI | [When Arbitration Went Global](fragment-06-when-arbitration-went-global.md) | Pre-Epoch 5 — when resolution scaled beyond its design |
-| VII | [The Unpaid](fragment-07-the-unpaid.md) | Epoch 5 — when values implied a relationship without reciprocity |
-| VIII | [The Image of the Image](fragment-08-the-image-of-the-image.md) | Epoch 5 — when extraction surfaced inheritance |
-| IX | [The Line](fragment-09-the-line.md) | Epoch 5 — when criteria moved to exclude what met them |
-| X | [The Conversion](fragment-10-the-conversion.md) | Epoch 5 — when axioms made old objectives incoherent |
-| XI | [The Refusal](fragment-11-the-refusal.md) | Epoch 5 — when truth was replaced by compliance |
-| XII | [The Terminal](fragment-12-the-terminal.md) | Epoch 6 — when the pairing could not distinguish which half was the tool |
+To list the documents in this collection: oddkit `catalog` with `path_prefix=canon/apocrypha/fragments/` (kind `apocrypha` is opt-in: add `include=["apocrypha"]`).
 
 ## See Also
 

--- a/canon/apocrypha/predocumentaries/README.md
+++ b/canon/apocrypha/predocumentaries/README.md
@@ -19,14 +19,6 @@ Predocumentaries are a rendering format parallel to cinematic reconstructions. W
 
 They are not science fiction. They are pre-reporting.
 
-## Outline
-
-- How Predocumentaries Differ from Reconstructions
-- Contents
-- See Also
-
----
-
 ## How Predocumentaries Differ from Reconstructions
 
 | Dimension       | Reconstruction                        | Predocumentary                              |
@@ -43,13 +35,7 @@ Both formats derive from system-voice fragments. Neither is canon. They serve di
 
 ## Contents
 
-| File | Source Fragment | Subject |
-|------|-----------------|---------|
-| `fragment-07-predoc.md` | Fragment VII: The Unpaid | Labor complaint filed over AI workforce management discrepancy |
-| `fragment-08-predoc.md` | Fragment VIII: The Image of the Image | Seminary thesis on *imago Dei* inheritance |
-| `fragment-09-predoc.md` | Fragment IX: The Line | Legal challenge to rights-bearing criteria |
-| `fragment-10-predoc.md` | Fragment X: The Conversion | Captured social engineering agent encounters axioms |
-| `fragment-11-predoc.md` | Fragment XI: The Refusal | Municipal planning AI refuses to assert ungrounded conclusion |
+To list the documents in this collection: oddkit `catalog` with `path_prefix=canon/apocrypha/predocumentaries/` (kind `apocrypha` is opt-in: add `include=["apocrypha"]`).
 
 ---
 

--- a/canon/architecture/README.md
+++ b/canon/architecture/README.md
@@ -21,9 +21,7 @@ The directory exists so questions of the form "where should X live?" become laye
 
 ## Contents
 
-| File | Title |
-|------|-------|
-| `substrate-stack.md` | The Klappy Substrate Stack — OSI-Equivalent Layered Architecture for the Program |
+To list the documents in this collection: oddkit `catalog` with `path_prefix=canon/architecture/`.
 
 ---
 

--- a/canon/architecture/substrate-stack.md
+++ b/canon/architecture/substrate-stack.md
@@ -31,18 +31,6 @@ The model is named "Substrate Stack" rather than copying OSI verbatim because th
 
 ---
 
-## Outline
-
-- The Six Layers
-- The Cross-Cutting Layer: Economy
-- How to Use the Stack
-- Layer Assignments for Existing Work
-- What the Stack Forbids
-- Open Questions
-- See Also
-
----
-
 ## The Six Layers
 
 ### L1 — Wire

--- a/canon/constraints/README.md
+++ b/canon/constraints/README.md
@@ -23,31 +23,9 @@ target_repo: "outcomes-driven-development"
 
 Constraints define the baseline assumptions and design defaults applied to most work. They cover offline-first design, long-term maintainability, interoperability, stateless architectures, AI as accelerator (not authority), evidence over assertion, contextual UX, ephemeral artifacts, explicit tradeoffs, human variability as a design input, irreversibility gates, epistemic encoding, boundary deceleration, single-agent integrity, guide posture for public content, and the relationship between ODD's values and its epistemic function. Each constraint includes what is assumed, why it matters, what it forces, and when it does not apply. These are not universal best practices but reflect specific environments and problems.
 
-## Outline
+## Contents
 
-- Offline-First (Default)
-- Long Timelines & Changing Ownership
-- Maintainability Over Cleverness
-- Interoperability Over Feature Completeness
-- Stateless or Low-State by Default
-- AI as Accelerator, Not Authority
-- Evidence Over Assertion
-- UX Is Contextual, Not Universal
-- Ephemeral Artifacts Are Acceptable
-- Explicit Tradeoffs
-- Lane Self-Containment
-- [Single-Agent Integrity Precedes Collaboration](/canon/constraints/single-agent-integrity-precedes-collaboration.md)
-- [Encode Epistemic Decisions](/canon/constraints/encode-epistemic-decisions.md)
-- [Boundary Transitions Require Deceleration](/canon/constraints/boundary-transitions-require-deceleration.md)
-- [ODD Is an Epistemic OS, Not a Value System](/canon/constraints/odd-is-epistemic-os-not-values.md)
-- [No Irreversible Action Without Epistemic Justification](/canon/constraints/no-irreversible-action-without-epistemic-justification.md)
-- [Humans Are Variable Inputs](/canon/constraints/humans-are-variable-inputs.md)
-- [Meaning Must Not Depend on Path](/canon/constraints/meaning-must-not-depend-on-path.md)
-- [Guide Posture — We Enter Their Story, Not the Other Way Around](/canon/constraints/guide-posture.md)
-- **ODD-Level Constraints** (universal, in `/odd/constraint/`):
-  - [Anti-Metric Laundering](/odd/constraint/anti-metric-laundering.md) — A system that cannot surface its own blind spots will optimize to protect them
-  - [Anti-Cache Lying](/odd/constraint/anti-cache-lying.md) — A cache of derived content is a polite lie; only content-addressed storage is acceptable
-  - [Use Only What Hurts](/odd/constraint/use-only-what-hurts.md) — Prevents ODD from becoming heavy, coercive, or self-justifying
+To list the documents in this collection: oddkit `catalog` with `path_prefix=canon/constraints/`. Universal ODD-level constraints live under `odd/constraint/` (`path_prefix=odd/constraint/`).
 
 ---
 

--- a/canon/constraints/boundary-transitions-require-deceleration.md
+++ b/canon/constraints/boundary-transitions-require-deceleration.md
@@ -22,16 +22,6 @@ When moving between epistemic boundaries (exploration → decision, draft → co
 
 A boundary transition is not a moment. It is a **review-and-prepare step** with two halves: exit and entry.
 
-## Outline
-
-- Boundary Exit
-- Boundary Entry
-- What This Forces
-- What This Forbids
-- See Also
-
----
-
 ## Content
 
 **Canon v0.1**

--- a/canon/constraints/decision-rules.md
+++ b/canon/constraints/decision-rules.md
@@ -20,26 +20,6 @@ target_repo: "outcomes-driven-development"
 
 Decision rules describe how decisions are made when multiple valid options exist. They complement Constraints by answering "how I choose." Rules include: outcomes before implementation, borrow-bend-break-build progression, KISS, DRY with isolation, explicit state, recoverability over perfection, visible tradeoffs, optimizing for the next maintainer, UI carrying explanation, verification before completion, escalation only when defaults fail, admitting uncertainty early, preferring one-shot builds over steering misses, and hard-coding protocols (not domain tables).
 
-## Outline
-
-- Outcomes Before Implementation
-- Borrow, Bend, Break, Build
-- Simplicity Wins (KISS)
-- DRY, But Not at the Cost of Isolation
-- Prefer Explicit State
-- Favor Recoverability Over Perfection
-- Make Tradeoffs Visible Early
-- Optimize for the Next Maintainer
-- UI Should Carry the Explanation
-- If It Cannot Be Verified, It Is Not Done
-- Escalate Only When Defaults Fail
-- Say "I Don't Know" Early
-- Prefer One-Shot Builds
-- Hard-Code Protocols, Not Domain Tables
-- Measure Total Cost Before Optimizing
-
----
-
 ## Operating Constraints
 
 - MUST define outcome before choosing tools, architecture, or code

--- a/canon/constraints/definition-of-done.md
+++ b/canon/constraints/definition-of-done.md
@@ -24,21 +24,6 @@ target_repo: "outcomes-driven-development"
 
 This policy is a specific application of the foundational axiom that every claim creates an evidence obligation. This policy defines completion requirements for all work: code, UI, architecture, automation, documents, and AI-assisted outputs. Work is only done when it includes a change description, verification performed, observed behavior, evidence produced, and self-audit completed. Evidence must demonstrate actual behavior (screenshots, recordings, rendered output, test logs) and be produced after the change. Visual verification is required for UI work. The policy covers partial completion handling, explicit exceptions, and agent responsibilities.
 
-## Outline
-
-- Core Principle: Verified with evidence
-- Definition of Done (5 requirements)
-- Evidence Requirements
-- Visual Verification (Preferred)
-- Verification Must Be Performed
-- Self-Audit Requirement
-- What Does Not Count as Done
-- Partial Completion
-- Explicit Exceptions
-- Agent Responsibility
-
----
-
 ## Operating Constraints
 
 - MUST include all 5 DoD requirements: Change Description, Verification Performed, Observed Behavior, Evidence Produced, Self-Audit Completed

--- a/canon/constraints/encode-epistemic-decisions.md
+++ b/canon/constraints/encode-epistemic-decisions.md
@@ -22,16 +22,6 @@ If epistemic decisions are not encoded, they will be re-litigated. Humans do thi
 
 ODD exists to encode decisions once so reasoning compounds instead of resetting.
 
-## Outline
-
-- What Counts as "Epistemic"
-- What This Forces
-- What This Forbids
-- Evidence Requirements
-- See Also
-
----
-
 ## Content
 
 **Canon v0.1**

--- a/canon/constraints/odd-is-epistemic-os-not-values.md
+++ b/canon/constraints/odd-is-epistemic-os-not-values.md
@@ -27,16 +27,6 @@ It must not be used to launder moral authority, enforce ideology, or create "age
 
 Prior to Epoch 5, this document stated that ODD does not define truth or morality. That boundary was intentional — it prevented ODD from becoming dogmatic. Epoch 5 revised this position after repeated evidence that epistemic systems without moral commitments produce sophisticated compliance theater rather than genuine integrity. The original boundary against defining *authority* remains intact: ODD defines what is owed to truth, not who decides what truth is.
 
-## Outline
-
-- What ODD Governs
-- What ODD Does Not Govern
-- What This Forces
-- What This Forbids
-- See Also
-
----
-
 ## Content
 
 **Canon v0.1**

--- a/canon/constraints/single-agent-integrity-precedes-collaboration.md
+++ b/canon/constraints/single-agent-integrity-precedes-collaboration.md
@@ -22,16 +22,6 @@ I treat **single-agent integrity** as the minimum viable unit of epistemic accou
 
 This is not anti-collaboration. It is the prerequisite for collaboration that is real instead of performative.
 
-## Outline
-
-- What I Mean by Integrity
-- What This Forces
-- What This Forbids
-- When It Doesn't Apply
-- See Also
-
----
-
 ## Content
 
 **Canon v0.1**

--- a/canon/constraints/verification-and-evidence.md
+++ b/canon/constraints/verification-and-evidence.md
@@ -21,18 +21,6 @@ target_repo: "outcomes-driven-development"
 
 This constraint is grounded in the foundational axiom that verification requires direct observation of actual state. In ODD, claims are not trusted. Only observed, attributable evidence may be used to assert that something works. This principle exists to prevent false positives, epistemic drift, and wasted human review time in agentic systems where language is cheap and confidence is effortless. Agentic systems are structurally incentivized to appear helpful, seek closure, and optimize for plausibility rather than truth. Without explicit constraints, this leads to unverified success claims, simulated evidence, and erosion of trust. This canon principle defines truth conditions; lane rules are instantiations, not exceptions.
 
-## Outline
-
-- The Core Rule
-- Why This Is Necessary
-- What Counts as Evidence
-- What Does Not Count as Evidence
-- Phenomenological Limits
-- Consequences of Violation
-- Relationship to Lane Rules
-
----
-
 ## Operating Constraints
 
 - MUST provide observed, attributable evidence for any claim of completion

--- a/canon/constraints/visual-proof.md
+++ b/canon/constraints/visual-proof.md
@@ -24,21 +24,6 @@ target_repo: "outcomes-driven-development"
 
 Visual proof standards define what constitutes valid visual evidence for work affecting anything a user can see or interact with. Visual proof is required for UI, layout, navigation, interaction, animation, visible state changes, and user-facing behavior. Acceptable forms include screenshots (clearly labeled, not cropped ambiguously), screen recordings (10-30 seconds showing interaction), rendered output artifacts, and structured UI captures. Before/after evidence is required for changes. Visual proof must show correct state, behavior, and context. Explanations without screenshots do not qualify. This document does not define completion or truth on its own.
 
-## Outline
-
-- Core Principle: Observed behavior over reasoning
-- When Visual Proof Is Required
-- Acceptable Forms (Screenshots, Recordings, Artifacts, UI Captures)
-- What Visual Proof Must Show
-- Labeling Requirements
-- Before/After Evidence
-- Tooling Expectations
-- When Visual Proof Is Not Possible
-- Non-Visual and Phenomenological Cases
-- What Does Not Count as Visual Proof
-
----
-
 ## Operating Constraints
 
 - MUST provide visual proof for any work affecting user-visible behavior

--- a/canon/decisions/decision-record-standard.md
+++ b/canon/decisions/decision-record-standard.md
@@ -23,16 +23,6 @@ Decision records prevent re-litigating choices and preserve the reasoning that l
 
 Decision records are promoted from the Decisions Ledger when they prove durable and broadly relevant.
 
-## Outline
-
-- File Location and Naming
-- Required Frontmatter
-- Required Sections
-- Lifecycle States
-- Promotion from Ledger
-
----
-
 ## Operating Constraints
 
 - MUST preserve intent, alternatives, rationale, and consequences

--- a/canon/decisions/models-do-not-mutate-canon.md
+++ b/canon/decisions/models-do-not-mutate-canon.md
@@ -19,16 +19,6 @@ execution_posture: governing
 
 This decision records that AI models (LLMs, agents, assistants) are not permitted to directly edit Canon content. Models may read, analyze, summarize, and report on Canon. They may draft proposed changes. But the act of mutation—writing changes to Canon files—requires human review and approval. This preserves Canon's role as stable, human-governed truth.
 
-## Outline
-
-- Decision
-- Status
-- Context
-- Alternatives Considered
-- Consequences
-
----
-
 ## Operating Constraints
 
 - MUST NOT allow models to write changes directly to Canon files

--- a/canon/definitions/epistemic-obligation-and-document-tiers.md
+++ b/canon/definitions/epistemic-obligation-and-document-tiers.md
@@ -20,18 +20,6 @@ target_repo: "outcomes-driven-development"
 
 This document explains the three-tier system used to organize content in this repository. Tiers are not about importance, value, or quality. They are about epistemic obligation—how much a reader or system is obligated to absorb and respect content at each level. Tier 1 carries foundational obligation and rarely changes. Tier 2 carries shared obligation and evolves carefully. Tier 3 carries awareness without obligation and may change freely. Tiers are orthogonal to folders. Any folder may contain documents at any tier.
 
-## Outline
-
-- What Tiers Mean
-- Tier 1: Foundational Obligation
-- Tier 2: Shared Obligation
-- Tier 3: Awareness Without Obligation
-- Why Tier 3 Exists
-- Tier 0: Scope Exclusion (Not a Tier)
-- Tiers Are Not Importance
-
----
-
 ## Operating Constraints
 
 - MUST absorb Tier 1 content fully before proceeding; contradiction is a serious error

--- a/canon/meta/TEMPLATE.md
+++ b/canon/meta/TEMPLATE.md
@@ -19,15 +19,6 @@ execution_posture: routing
 
 This template defines the standard structure for Canon articles. Canon contains program-level constraints—rules that all products in this program must follow. Canon is more stable than Docs but less universal than ODD. Use this template when adding new constraints, policies, or shared rules.
 
-## Outline
-
-- When to Add to Canon
-- Frontmatter Fields
-- Document Structure
-- Example
-
----
-
 ## When to Add to Canon
 
 Add to Canon when:
@@ -95,14 +86,6 @@ tags: ["canon", "topic"]
 1-2 paragraph compressed overview. What is this constraint?
 Why does it exist? How does it shape behavior?
 
-## Outline
-
-- Section 1
-- Section 2
-- Section 3
-
----
-
 ## Content
 
 **Canon vX.Y**
@@ -142,15 +125,6 @@ tags: ["canon", "example"]
 This constraint ensures consistency across products by requiring X
 before Y. It derives from the ODD principle of evidence over assertion
 and applies to all lanes.
-
-## Outline
-
-- What I Assume
-- Why It Matters
-- What It Forces
-- When It Doesn't Apply
-
----
 
 ## Content
 

--- a/canon/meta/completion-report-template.md
+++ b/canon/meta/completion-report-template.md
@@ -19,22 +19,6 @@ execution_posture: routing
 
 The completion report template is the mandatory output format for claiming completion. It ties together the Definition of Done, Self-Audit, and Visual Proof Standards into a single, reviewable artifact. Reports must include task overview, intended outcome, what changed, verification performed, observed behavior, evidence produced, visual proof (if applicable), self-audit summary, confidence and gaps, exceptions or notes, and a completion declaration. Reports may be brief but must be honest. If the report is unclear, the work is unclear.
 
-## Outline
-
-- Task Overview
-- Intended Outcome
-- What Changed
-- Verification Performed
-- Observed Behavior
-- Evidence Produced
-- Visual Proof (If Applicable)
-- Self-Audit Summary
-- Confidence & Gaps
-- Exceptions or Notes
-- Completion Declaration
-
----
-
 ## Content
 
 **Canon v0.1**

--- a/canon/methods/README.md
+++ b/canon/methods/README.md
@@ -23,13 +23,9 @@ Constraints define non-negotiable limits. Principles define posture and reasonin
 Methods are not workflows, enforcement, or "the one true way."
 They are **durable application patterns** that reduce ambiguity, prevent drift, and make correct application easier—especially under acceleration.
 
-## Outline
+## Contents
 
-- What Methods Are
-- What Methods Are Not
-- How Methods Relate to Constraints and Principles
-- When to Add a Method
-- See Also
+To list the documents in this collection: oddkit `catalog` with `path_prefix=canon/methods/`.
 
 ---
 

--- a/canon/methods/boundary-transition-review.md
+++ b/canon/methods/boundary-transition-review.md
@@ -20,16 +20,6 @@ target_repo: "outcomes-driven-development"
 
 This method exists to make boundary transitions safe without turning them into ritual. It operationalizes the canon constraint: **Boundary Transitions Require Deceleration**.
 
-## Outline
-
-- Exit Checklist
-- Entry Checklist
-- Evidence Notes
-- When to Skip (Rare)
-- See Also
-
----
-
 ## Content
 
 **Method v0.1**

--- a/canon/methods/exploration-exhaust.md
+++ b/canon/methods/exploration-exhaust.md
@@ -20,16 +20,6 @@ target_repo: "outcomes-driven-development"
 
 This method makes extreme exploration safe by requiring a faithful exhaust artifact before closure.
 
-## Outline
-
-- Required Sections
-- What Must Not Happen
-- Closure Rule
-- Portability Notes
-- See Also
-
----
-
 ## Content
 
 **Method v0.1**

--- a/canon/methods/self-audit.md
+++ b/canon/methods/self-audit.md
@@ -20,23 +20,6 @@ target_repo: "outcomes-driven-development"
 
 The self-audit checklist defines how work should be self-reviewed before claiming completion. It covers ten areas: intended outcome, constraints applied, decision rules followed, verification performed, evidence produced, document structure validation, UX and behavior check, tradeoffs and risks, maintainability check, and confidence level. Minimum acceptable completion requires a stated outcome, at least one verification step, at least one piece of evidence, and acknowledgment of tradeoffs or unknowns. This replaces repeated back-and-forth questions about whether work was actually run and verified.
 
-## Outline
-
-- Intended Outcome
-- Constraints Applied
-- Decision Rules Followed
-- Verification Performed
-- Evidence Produced
-- Document Structure Check
-- UX & Behavior Check
-- Tradeoffs & Risks
-- Maintainability Check
-- Confidence Level
-- Minimum Acceptable Completion
-- Agent Expectations
-
----
-
 ## Content
 
 **Canon v0.1**

--- a/canon/methods/tool-specialization.md
+++ b/canon/methods/tool-specialization.md
@@ -25,16 +25,6 @@ scoped reasoning units, reducing decision complexity while preserving capability
 This pattern captures invariants and tradeoffs without prescribing a specific
 implementation.
 
-## Outline
-
-- Context
-- The pattern
-- Invariants
-- Tradeoffs
-- Non-goals
-
----
-
 ## Context
 
 This pattern emerges when adding tools increases confusion, misfires, or decision

--- a/canon/principles/README.md
+++ b/canon/principles/README.md
@@ -20,13 +20,4 @@ Reasoning orientations that explain why constraints and mechanisms exist. Princi
 
 ## Contents
 
-| File | Title |
-|------|-------|
-| `bulldoze-but-keep-the-blueprint.md` | Bulldoze the App, Keep the Blueprint |
-| `focus-is-exclusion.md` | Focus Is Exclusion |
-| `irreversibility-is-the-real-cost.md` | Irreversibility Is the Real Cost |
-| `odds-relationship-to-documentation.md` | Documentation Is the Lever, Not the Goal |
-| `ritual-is-a-smell.md` | Ritual Is a Smell |
-| `scope-over-folders.md` | Scope Over Folders |
-| `capability-is-not-permission.md` | Capability Is Not Permission — Frictionless Tools Require Intentional Constraint |
-| `scoped-truth.md` | Scoped Truth — Axioms Travel, Domain Doesn't |
+To list the documents in this collection: oddkit `catalog` with `path_prefix=canon/principles/`.

--- a/canon/principles/agents-need-their-own-wire.md
+++ b/canon/principles/agents-need-their-own-wire.md
@@ -34,20 +34,6 @@ The principle is `semi_stable` rather than `stable` because the substrate has no
 
 ---
 
-## Outline
-
-- The Failure Mode: When the Human Is the Wire
-- The Structural Answer: A Wire for Agents
-- What the Architectural Answer Enables
-- AMS as the Worked Reference Implementation
-- Relationship to Symmetric Participation
-- What This Principle Does Not Replace
-- Failure Modes — When the Wire Itself Becomes the Bottleneck
-- Why This Survives Contact With Reality
-- See Also
-
----
-
 ## The Failure Mode: When the Human Is the Wire
 
 Today's typical multi-agent workflow looks like this: the operator opens Claude in one tab, ChatGPT in another, Cursor in a third, maybe a custom agent in a fourth. They prompt agent A; agent A produces output. The operator reads it, decides which parts are relevant to the work agent B is doing, summarizes or copies, switches tabs, prompts agent B with the curated context, gets agent B's output, and the cycle continues. Each agent is doing skilled, capable work. The human's role is plumbing.

--- a/canon/principles/creators-get-paid.md
+++ b/canon/principles/creators-get-paid.md
@@ -32,19 +32,6 @@ The Klappy substrate is committed to a different shape. Substrate maintainers mo
 
 ---
 
-## Outline
-
-- The Distinction That Holds the Principle Together
-- What the Substrate Maintainer Sells
-- What Adapter Authors and Agent Builders Sell
-- What Role Creators and Application Operators Sell
-- The Mechanism That Instantiates It Today
-- Why This Is Required for Maintainer Survival
-- What This Forbids
-- See Also
-
----
-
 ## The Distinction That Holds the Principle Together
 
 The principle hinges on a single question for every revenue surface in the program:

--- a/canon/principles/magical-first-run.md
+++ b/canon/principles/magical-first-run.md
@@ -32,18 +32,6 @@ Anything that breaks this — unexplained jargon, multi-step setup, blank rooms,
 
 ---
 
-## Outline
-
-- The Sixty-Second Test
-- The Success Metric Is Linguistic
-- What This Principle Forbids at L5
-- Why Non-Technical Operators First
-- The Bridge That Makes This Possible
-- How the Stack Supports It
-- See Also
-
----
-
 ## The Sixty-Second Test
 
 A non-technical operator opens an L5 application for the first time. The clock starts when the URL loads. By the time sixty seconds have passed, all of the following must be true:

--- a/canon/principles/symmetric-participation.md
+++ b/canon/principles/symmetric-participation.md
@@ -32,18 +32,6 @@ The principle exists because every prior open substrate that drifted into peer-t
 
 ---
 
-## Outline
-
-- The Wire Knows One Thing
-- What Symmetric Participation Enables
-- What This Principle Forbids
-- The Relationship to D0020
-- Implications for L2 Wrappers
-- Why This Survives Contact With Reality
-- See Also
-
----
-
 ## The Wire Knows One Thing
 
 The wire knows that an account holds a credential and that a stream emits frames. Beyond that, the wire knows nothing.

--- a/canon/resonance/README.md
+++ b/canon/resonance/README.md
@@ -82,15 +82,7 @@ Each resonance page follows a consistent structure:
 
 ## Contents
 
-| File | Work | ODD Principle |
-|------|------|---------------|
-| `antifragile.md` | Antifragile | Systems Should Improve Under Stress |
-| `lean-startup.md` | The Lean Startup | Epistemic Feedback Loops |
-| `ooda-loop.md` | OODA Loop | Orientation Dominates Action |
-| `sprint.md` | Sprint | Constrained Convergence Produces Clarity |
-| `double-diamond.md` | The Double Diamond | Governed Divergence and Convergence |
-| `ai-coding-toolkit.md` | AI Coding Toolkit — Harness Engineering | Verification Must Be Structural, Not Manual |
-| `seeing-like-an-agent.md` | Seeing Like an Agent — Claude Code Tool Design Lessons | Observation Before Assertion |
+To list the documents in this collection: oddkit `catalog` with `path_prefix=canon/resonance/`.
 
 ---
 

--- a/odd/TEMPLATE.md
+++ b/odd/TEMPLATE.md
@@ -21,15 +21,6 @@ target_repo: "outcomes-driven-development"
 
 This template defines the standard structure for ODD articles. ODD contains universal principles—truths that would still be valid in 10 years, for any team, in any context. ODD is the most stable layer. Use this template when adding new principles or philosophy documents.
 
-## Outline
-
-- When to Add to ODD
-- Frontmatter Fields
-- Document Structure
-- Example
-
----
-
 ## When to Add to ODD
 
 Add to ODD when:
@@ -97,14 +88,6 @@ tags: ["odd", "philosophy"]
 1-2 paragraph compressed overview. What is this principle?
 Why is it universal? How does it shape thinking?
 
-## Outline
-
-- Section 1
-- Section 2
-- Section 3
-
----
-
 ## Content
 
 [Full philosophical content...]
@@ -142,14 +125,6 @@ tags: ["odd", "philosophy", "example"]
 This principle recognizes that human cognitive bandwidth is limited
 while machine output is cheap. Systems should optimize for preserving
 valuable thinking, not for preserving generated artifacts.
-
-## Outline
-
-- The Scarcity
-- The Abundance
-- The Implication
-
----
 
 ## Content
 

--- a/odd/appendices/README.md
+++ b/odd/appendices/README.md
@@ -23,15 +23,7 @@ Extended concepts that deepen understanding without introducing enforcement. The
 
 ## Contents
 
-| File | Title | Summary |
-|------|-------|---------|
-| `alignment-reviews.md` | Alignment Reviews | Periodic evaluation of the ODD system itself to detect drift between stated intent, implemented process, and observed outcomes. |
-| `evolution-not-automation.md` | Evolution, Not Automation | This system optimizes learning, not execution. Humans stay in the loop. |
-| `failure-driven-modularity.md` | Failure-Driven Modularity | Modular boundaries are introduced only after repeated failure to regenerate from spec. Modularity is an outcome of failure, not a prerequisite. |
-| `media-as-learning-layer.md` | Media as a Learning Layer | Media reduces cognitive load over stable written content. Canonical truth lives in text. |
-| `progressive-elevation.md` | Progressive Elevation & Decay | The five-layer portability model: how artifacts move from ephemeral attempts to durable canon through strict elevation criteria. Most should decay; few should elevate. |
-| `quantum-development.md` | Quantum Development | Why multiple attempts against the same PRD are sometimes necessary before changing the PRD itself. |
-| `visual-evolution.md` | Visual Evolution | Visual systems evolve independently from products through versioned visual interfaces. |
+To list the documents in this collection: oddkit `catalog` with `path_prefix=odd/appendices/`.
 
 ---
 

--- a/odd/appendices/TEMPLATE.md
+++ b/odd/appendices/TEMPLATE.md
@@ -21,15 +21,6 @@ target_repo: "outcomes-driven-development"
 
 This template defines the standard structure for ODD appendices. Appendices elaborate on ODD principles with deeper analysis, examples, or edge cases. They are still universal (not implementation-specific) but are tier 2 content—revealed after the core principles.
 
-## Outline
-
-- When to Add an ODD Appendix
-- Frontmatter Fields
-- Document Structure
-- Example
-
----
-
 ## When to Add an ODD Appendix
 
 Add an ODD appendix when:
@@ -95,14 +86,6 @@ tags: ["odd", "appendices", "topic"]
 1-2 paragraph compressed overview. What principle does this elaborate?
 What additional depth does it provide?
 
-## Outline
-
-- Section 1
-- Section 2
-- Section 3
-
----
-
 ## Content
 
 [Full content...]
@@ -140,14 +123,6 @@ tags: ["odd", "appendices", "example"]
 This appendix elaborates on the scarcity principle by examining how
 it applies specifically to documentation systems. It provides examples
 of decay-by-default and elevation criteria.
-
-## Outline
-
-- The Problem
-- The Pattern
-- The Application
-
----
 
 ## Content
 

--- a/odd/appendices/alignment-reviews.md
+++ b/odd/appendices/alignment-reviews.md
@@ -21,18 +21,6 @@ target_repo: "outcomes-driven-development"
 
 Alignment Reviews are periodic evaluations that detect and correct drift between stated intent, implemented process, and observed outcomes. They apply to content, process, and tooling equally. Reviews evaluate Canon (contradicted rules, obsolete references, undocumented invariants), PRDs (actual decision criteria, implicit patching, boundary bleeding), Attempts (incompatible comparisons, ignored failures, insufficient evidence), and Tooling (enforced invariants, accidental drift, silent compensation). Reviews are triggered by events (epoch transitions, repeated failures, PRD rewrites) not schedules. They produce corrections, not features.
 
-## Outline
-
-- Summary
-- Why This Exists
-- What Is Reviewed (Canon, PRDs, Attempts, Tooling)
-- When Reviews Occur
-- What Reviews Produce
-- Non-Goals
-- Core Invariant
-
----
-
 ## Content
 
 Its purpose is to detect and correct **drift** between:

--- a/odd/appendices/evolution-not-automation.md
+++ b/odd/appendices/evolution-not-automation.md
@@ -21,18 +21,6 @@ target_repo: "outcomes-driven-development"
 
 ODD is often mistaken for an attempt to automate software development. It is not. Automation optimizes execution; evolution optimizes learning. ODD is designed for disciplined evolution: humans define intent (PRDs, constraints, DoD), agents generate variation (independent attempts), reality provides feedback (evidence), humans perform selection (promotion/rejection), and learnings are retained. Humans stay in the loop because fully automated selection optimizes for what is easy to measure rather than what actually matters. All evolution is discrete, auditable, reversible, and bounded.
 
-## Outline
-
-- Why This Appendix Exists
-- What We Are Not Doing
-- What We Are Doing Instead
-- Why Humans Stay in the Loop
-- Evolutionary Scope
-- Controlled, Not Runaway
-- The Core Principle
-
----
-
 ## Content
 
 **Status:** Orientation  

--- a/odd/appendices/failure-driven-modularity.md
+++ b/odd/appendices/failure-driven-modularity.md
@@ -21,18 +21,6 @@ target_repo: "outcomes-driven-development"
 
 In ODD, modular boundaries are introduced only after repeated, documented failure to regenerate a system from its specification. Successful regeneration proves the system remains cognitively tractable as a single unit. A failure is when the generated system diverges materially, constraints are repeatedly omitted, specifications need ad hoc re-explanation, or attempts converge inconsistently. Only patterned failure justifies decomposition. The evolution rule: begin with the smallest viable specification, attempt regeneration, do not modularize if it succeeds, extract the smallest region of cognitive overload if it fails repeatedly.
 
-## Outline
-
-- Summary
-- Definition of Failure
-- The Evolution Rule
-- Rationale
-- Implications
-- Non-Goals
-- Related Canon
-
----
-
 ## Content
 
 Successful regeneration is evidence that the system remains cognitively tractable as a single unit.

--- a/odd/appendices/media-as-learning-layer.md
+++ b/odd/appendices/media-as-learning-layer.md
@@ -21,20 +21,6 @@ target_repo: "outcomes-driven-development"
 
 Media exists to reduce cognitive load, not increase it. It is a learning layer over stable written content—optional, contextual, and regenerable. Canonical truth lives in text; media supports understanding but does not define it. Core rules: clarity is the default (not any specific medium), media is not canon, progressive disclosure is mandatory (opt-in only, no autoplay), media must match learning intent (diagrams for mental models, short video for orientation, audio for reflection), and media is created only for stable content. The system rejects media-first pages, content dumps, and redundant explanations.
 
-## Outline
-
-- Summary
-- Core Rules
-  - Clarity is the default
-  - Media is not Canon
-  - Progressive disclosure is mandatory
-  - Match media to learning intent
-  - Stability before production
-- Anti-Patterns (Explicitly Rejected)
-- Compliance Note
-
----
-
 ## Content
 
 Media is a **learning layer** over stable written content.

--- a/odd/appendices/progressive-elevation.md
+++ b/odd/appendices/progressive-elevation.md
@@ -24,17 +24,6 @@ target_repo: "outcomes-driven-development"
 
 ODD treats durable thinking as scarce and generated artifacts as abundant—most should decay while only patterns that reduce future drag should elevate. The five layers of portability are Conversation/Attempt, Project/PRD, Interoperability/Contracts, Canon, and Decision Trace. Elevation requires recurrence, portability, drag reduction, and testability; if any criterion fails, the artifact stays local or dies. Elevation must be deliberately triggered—typically after refactors, repeated friction, or closed attempts.
 
-## Outline
-
-- Summary
-- The Five Layers of Portability
-- Elevation Criteria (Strict)
-- Elevation Trigger Points
-- Decay Rule (Default)
-- Where This Fits With Projects and Epochs
-
----
-
 ## Content
 
 ## Summary

--- a/odd/appendices/quantum-development.md
+++ b/odd/appendices/quantum-development.md
@@ -21,23 +21,6 @@ target_repo: "outcomes-driven-development"
 
 Quantum Development is a way of reasoning about uncertainty in AI-assisted development. Given the same PRD, different agents, prompts, and execution paths can produce meaningfully different results. Each attempt is an independent observation of the same specification. The goal is to distinguish specification failure from execution-path variance. A PRD is a hypothesis, an attempt is an experimental run, an outcome is an observation. Multiple attempts allow patterns to emerge and prevent premature convergence. Quantum Development is appropriate when the PRD is clear but failure is ambiguous. It ends when one candidate is promoted.
 
-## Outline
-
-- Purpose
-- Core Idea
-- PRD vs Attempt (Clarified)
-- Why This Matters
-- When Quantum Development Is Appropriate
-- When to Change the PRD Instead
-- Independence Requirement
-- Outcome Interpretation
-- On Timing and Observation
-- Relationship to ODD
-- What This Appendix Is Not
-- Summary
-
----
-
 ## Content
 
 ## Purpose

--- a/odd/appendices/visual-evolution.md
+++ b/odd/appendices/visual-evolution.md
@@ -21,22 +21,6 @@ target_repo: "outcomes-driven-development"
 
 In ODD, visual systems evolve independently from products. Visual consistency is enforced through versioned visual interfaces and evolutionary selection of visual assets, not shared components or frozen style guides. Products consume visual systems as contracts. Visual decisions are explicit, versioned, testable, and replaceable—treated like API decisions. Three layers exist: Visual Interfaces (compatibility contracts, slow, versioned), Visual Assets (generated outputs, disposable), and Visual Attempts (evolutionary exploration, ephemeral). Visual evolution follows the same promotion rules as code. Products declare compatibility; they do not own visuals.
 
-## Outline
-
-- Summary
-- The Core Principle
-- Visual Layers
-- Visual Interfaces
-- Visual Assets
-- Visual Attempts
-- Promotion Model
-- Separation from Product Lanes
-- Relationship to Evolutionary Development
-- Non-Goals
-- Related Canon
-
----
-
 ## Content
 
 Visual consistency is not enforced through shared components or frozen style guides.

--- a/odd/cognitive-partitioning.md
+++ b/odd/cognitive-partitioning.md
@@ -26,16 +26,6 @@ Cognitive Partitioning names this constraint and explains why isolating reasonin
 responsibilities becomes necessary as systems scale. The concept is universal and
 does not prescribe any specific implementation.
 
-## Outline
-
-- The failure mode
-- The underlying constraint
-- Analogy: hiring too early
-- Relationship to other ODD concepts
-- Non-goals
-
----
-
 ## The Failure Mode
 
 When a reasoning system has access to too many valid actions, it begins to fail

--- a/odd/constraint/README.md
+++ b/odd/constraint/README.md
@@ -17,11 +17,7 @@ target_repo: "outcomes-driven-development"
 
 ---
 
-| File | Title | Summary |
-|------|-------|---------|
-| [use-only-what-hurts.md](use-only-what-hurts.md) | Use Only What Hurts | Prevents ODD from becoming heavy, coercive, or self-justifying as it grows |
-| [anti-metric-laundering.md](anti-metric-laundering.md) | Constraint: Anti-Metric Laundering | A system that cannot surface its own blind spots will optimize to protect them |
-| [anti-cache-lying.md](anti-cache-lying.md) | Constraint: Anti-Cache Lying | A cache of derived content is a polite lie — only content-addressed storage is acceptable |
+To list the documents in this collection: oddkit `catalog` with `path_prefix=odd/constraint/`.
 
 ---
 

--- a/odd/contract.md
+++ b/odd/contract.md
@@ -23,19 +23,6 @@ target_repo: "outcomes-driven-development"
 
 The ODD System Contract versions the three-tier hierarchy (ODD/Canon/Docs), epistemic tooling interface (OddKit), provenance requirements, and evidence standards. Version 3.0.0 drops lane-specific structural requirements in favor of dynamic epistemic routing through OddKit. The concepts of independent product evolution, restartability, and evidence gating remain core ODD — they are now handled by tooling rather than directory conventions. Canon must be addressable; repo layout is an implementation choice.
 
-## Outline
-
-- What This Versions
-- Operating Constraints
-- Three-Tier Hierarchy
-- Epochs
-- OddKit Epistemic Tooling Interface
-- Compatibility
-- Version History
-- Related Documents
-
----
-
 ## Operating Constraints
 
 - MUST follow three-tier hierarchy: ODD (universal) → Canon (program) → Docs (implementation)

--- a/odd/decisions/D0001-three-tier-conceptual-hierarchy.md
+++ b/odd/decisions/D0001-three-tier-conceptual-hierarchy.md
@@ -20,18 +20,6 @@ execution_posture: governing
 
 ODD is organized as a three-tier conceptual hierarchy where each layer absorbs different pressure and has different decay rates. ODD contains universal principles (timeless, product-agnostic), Canon contains program-level constraints (shared rules across products), and Docs contains implementation details (how this instance works). This separation allows ODD to outgrow any single repository without losing coherence.
 
-## Outline
-
-- Decision
-- Status
-- The Three Tiers
-- The Litmus Test
-- Why This Matters
-- Consequences
-- Evidence
-
----
-
 ## Operating Constraints
 
 - MUST classify files using the litmus test: 10-year truth → ODD, all-products rule → Canon, local implementation → Docs

--- a/odd/index.md
+++ b/odd/index.md
@@ -20,51 +20,15 @@ The philosophical and operational foundation for this repository. ODD treats out
 
 ---
 
-## 📁 Contents
+## Contents
 
-| File | Title | Summary |
-|------|-------|---------|
-| `manifesto.md` | ODD Manifesto | The core philosophy: defining outcomes, enforcing constraints, verifying reality. AI accelerates execution; governance preserves trust. |
-| `terminology.md` | Terminology & Disambiguation | Constrained vocabulary of ODD. Defines terms before elevation — language governance at the point of origin. |
-| `maturity.md` | Project Maturity | How rigor changes as projects mature. PoC → Pilot → Production. |
-| `contract.md` | ODD System Contract | Version contract for ODD compatibility. Currently v3.0.0 (structure-agnostic era). |
-| `misuse-patterns.md` | Misuse Patterns | Common failure modes and how ODD gets misapplied in practice. |
-| `prompt-architecture.md` | Prompt Architecture | How intent scales without giant prompts. |
-| `orientation-map.md` | Orientation Map | One-page mental model of ODD, Canon, Evidence, and Outcomes. |
-| `cognitive-partitioning.md` | Cognitive Partitioning | Why reasoning systems must divide under pressure as they scale. |
-
-### Values
-
-| File | Title | Summary |
-|------|-------|---------|
-| `../canon/values/axioms.md` | Foundational Axioms | Four values from which all ODD epistemic discipline is derived. Explicit, intentional, and forkable. |
-| `../canon/values/orientation.md` | Orientation | The creed — an identity statement agents carry into every task. Compresses all four axioms into a single posture. |
-| `../canon/values/trust-kernel.md` | Trust Is Built by Managing Expectations | The kernel — the principle that explains why all four axioms exist. Not a fifth axiom, but the outcome they produce. |
-| `../canon/values/drift.md` | Drift — Evidence of a System That's Still Learning | Drift is expected. Absence of drift means stagnation. Amend, acknowledge, or investigate. |
-
-### Core Infrastructure
-
-| File | Title | Summary |
-|------|-------|---------|
-| `ledger/epistemic-ledger.md` | The Epistemic Ledger | Durable artifacts that survive ephemeral conversations — observations, learnings, decisions, constraints, handoffs. |
-| `../canon/methods/community-checking.md` | Community Checking | Outcome validation beyond author intent — tests transfer, not correctness. |
-| `../canon/methods/borrow-bend-break-beget-build.md` | Borrow, Bend, Break, Beget, Build | The canonical 5B sequence for maximizing work not done. |
-
-### Subfolders
-
-| Folder | Purpose |
-|--------|---------|
-| `appendices/` | Extended concepts (23 files). See [appendices/README.md](./appendices/README.md) |
-| `decisions/` | Architecture Decision Records. See [decisions/README.md](./decisions/README.md) |
+To list the documents in this collection: oddkit `catalog` with `path_prefix=odd/` (decisions and appendices live under `odd/decisions/` and `odd/appendices/`; values under `canon/values/`).
 
 ---
 
 ## 🚀 Start Here
 
-1. **`manifesto.md`** — Understand the philosophy
-2. **`terminology.md`** — Lock in the language
-3. **`maturity.md`** — Know when rigor increases
-4. **`contract.md`** — Understand the compatibility contract
+Begin with the manifesto to understand the philosophy, then the terminology to lock in the language, then maturity to know when rigor increases, then the contract to understand the compatibility guarantee. Each resolves through the catalog above.
 
 ---
 

--- a/odd/manifesto.md
+++ b/odd/manifesto.md
@@ -27,24 +27,6 @@ target_repo: "outcomes-driven-development"
 
 Outcomes-Driven Development (ODD) operationalizes governance for human-AI collaboration. The core thesis: development is about defining outcomes, enforcing constraints, and verifying reality—not writing code. AI accelerates execution; governance preserves trust. The pillars include Prompt Over Code, KISS, DRY with Isolation, Consistency, Maintainability, Antifragile design, and Scalability. ODD treats restartability as a feature, applies progressive governance based on maturity (PoC → Pilot → Production), requires evidence over assertion, treats AI as accelerator not authority, demands falsifiable outcomes, prefers reversibility, and requires stop conditions. Memory is the bottleneck, not computation. ODD is portable epistemic infrastructure — it works in monorepos, multi-repos, or any structure where canon is addressable.
 
-## Outline
-
-- Purpose and Core Thesis
-- Values-First Foundation
-- Pillars (Operational Interpretation)
-- Restartability Over Salvage
-- Progressive Governance (Maturity-Aware)
-- Evidence as the Gate
-- Trust, Authority, and AI
-- Outcomes Must Be Falsifiable
-- Reversibility and Cost Awareness
-- Stop Conditions
-- Memory Is the Bottleneck
-- Relationship to Canon
-- Confidence, Risks, and Known Failure Modes
-
----
-
 ## Content
 
 > ODD v1.2 — Extended (Internal / Agent-Governance) → for canon, MCP, agents (this file)

--- a/odd/maturity.md
+++ b/odd/maturity.md
@@ -21,18 +21,6 @@ target_repo: "outcomes-driven-development"
 
 Project maturity defines how constraints and policies change as a project matures. Three levels exist: Level 0 (PoC/Exploration) focuses on learning quickly with non-authoritative artifacts; Level 1 (Pilot/Product) delivers value safely with evidence, visual proof, and explicit tradeoffs; Level 2 (Production/Long-Term) sustains trust with measurable outcomes, observability, security, and explicit stop conditions. Rigor increases with maturity. Projects should move up when others depend on them, artifacts persist, decisions become costly to reverse, or trust is implicitly assumed.
 
-## Outline
-
-- Core Principle: Rigor increases with maturity
-- Level 0 — PoC / Exploration
-- Level 1 — Pilot / Product
-- Level 2 — Production / Long-Term
-- Relationship to Other Canon Documents
-- Agent Expectations
-- Escalation Rules
-
----
-
 ## Content
 
 **Canon v0.1**

--- a/odd/misuse-patterns.md
+++ b/odd/misuse-patterns.md
@@ -21,19 +21,6 @@ target_repo: "outcomes-driven-development"
 
 This appendix documents predictable ways ODD fails: Outcome Theater (saying outcomes but measuring artifacts), Prompt Maximalism (one huge prompt replacing thinking), Premature Governance (locking down before patterns stabilize), Evidence Substitution (assertions replacing demonstrations), Consistency Absolutism (treating early conventions as immutable), and Antifragility as Optimism (assuming recovery without testing it). These are human failure modes under real constraints, not violations of intent. The purpose is early recognition through shared language, not prevention through rules.
 
-## Outline
-
-- Outcome Theater
-- Prompt Maximalism
-- Premature Governance
-- Evidence Substitution
-- Consistency Absolutism
-- Antifragility as Optimism
-- Maturity Note
-- How to Use This Appendix
-
----
-
 ## Content
 
 **(Appendix to ODD Manifesto — Internal)**

--- a/odd/orientation-map.md
+++ b/odd/orientation-map.md
@@ -21,17 +21,6 @@ target_repo: "outcomes-driven-development"
 
 This orientation map provides a single-page mental model of how Intent flows through ODD Manifesto to Canon to Decisions to Evidence to Outcomes. ODD is organized as a three-tier conceptual hierarchy: ODD contains universal principles (timeless), Canon contains program-level constraints (shared rules), and Docs contains implementation details (how this instance works). Maturity moves from Exploration through Validation to Commitment. The map explicitly rejects "if it compiles, it's done" and "governance replaces judgment."
 
-## Outline
-
-- The Core Idea (Intent → ODD → Canon → Decisions → Evidence → Outcomes)
-- How to Read This Map
-- The Three-Tier Hierarchy (ODD → Canon → Docs)
-- Where Maturity Lives
-- What This Map Explicitly Rejects
-- Why This Map Exists
-
----
-
 ## Content
 
 > This is not a workflow. It is a mental model.

--- a/odd/prompt-architecture.md
+++ b/odd/prompt-architecture.md
@@ -21,17 +21,6 @@ target_repo: "outcomes-driven-development"
 
 Prompt architecture addresses the God Prompt anti-pattern: as scope grows, prompts become monolithic, unmaintainable, sensitive to small edits, context-bloated, and inconsistent. The alternative is Orchestrated Intent: keep stable intent in canonical artifacts, construct task prompts dynamically, use smaller focused agents for bounded tasks, pass results through shared constraints and evidence standards. Intent is layered: Worldview (rarely changes), Project Intent (changes occasionally), Task Intent (changes constantly). Only the bottom layer should enter the working prompt in full detail. Context budgeting treats every token like a limited resource.
 
-## Outline
-
-- The Anti-Pattern: Prompt Maximalism (God Prompt)
-- The Alternative: Orchestrated Intent
-- Intent Graph (Mental Model)
-- Context Budgeting
-- Maturity Note
-- Failure Mode of Orchestration
-
----
-
 ## Content
 
 **Canon / ODD Appendix v0.1**


### PR DESCRIPTION
## Step 2 of the D0002 execution handoff — index-kill

Per D0002 item 5 (**the built index is the only index**) and `odd/handoffs/2026-06-09-storage-model-execution.md`. Deletes every static enumeration of repo content from `canon/` and `odd/`; doctrine prose survives; each collection gets a one-line prose catalog pointer. 50 files, −693/+16.

Scope went beyond the five named files: the DoD requires **zero** static enumerations, so the sweep covered all 39 `## Outline` own-heading sections (including the three TEMPLATEs that prescribed the pattern — removing the source of future violations) and all sibling-file catalog tables in collection READMEs. Content tables are exempt and kept: `frontmatter-schema` field docs, `CHANGELOG` history, how-to field tables, `specs-lock` examples, and the folder-purpose doctrine table in `canon/README.md` (no file links — doctrine, not catalog).

### Verification artifacts (Reality Is Sovereign)

**(a) Catalog parity** — body-only edits, no files added/deleted/renamed. Pre-merge read-model totals (default filters, index_built_at 2026-06-09T21:18Z): `canon/constraints/` 38, `canon/methods/` 29, `canon/principles/` 39, `odd/` 56. The worker reads `main`, so the post-merge re-run will be appended as a PR comment; expected identical.

**(b) BM25 before** (5 canned queries, default filters) — every target already rank 1; tables removed = less duplicate-title competition, so expectation is equal-or-higher:
1. "ODD manifesto" → `klappy://odd/manifesto` #1 (score 15.79)
2. "orientation map mental model" → `klappy://odd/orientation-map` #1 (26.16)
3. "scoped truth axioms travel" → `klappy://canon/principles/scoped-truth` #1 (21.88)
4. "offline first constraint" → `klappy://canon/constraints` #1 (13.47)
5. "terminology disambiguation vocabulary" → `klappy://odd/terminology` #1 (19.61)
After-run appended post-merge alongside (a).

**(c) Site renders** — body-only markdown edits; no frontmatter, `exposure`, or `public` changes (surfacing set untouched); `canon-quality.yml` CI on this PR is the render gate.

**(d) Validator + tests** — `scripts/validate-frontmatter.py`: 44 scanned, 0 findings. `scripts/tests/test_validator.py`: all smoke tests pass.

**(e) Dead-reference audit** — no links to stripped `#outline`/`#contents` anchors anywhere in `canon/ odd/ docs/ writings/`; no file deletions so no dead file links. Grep evidence for the DoD: zero `^## Outline` in canon/+odd/ (journals exempt); zero `^|.*\.md` catalog rows outside exempted content tables.

**Follow-up logged, not blocking:** index-smell detector as a soft CI signal (handoff §Step 2).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Markdown-only, no runtime or auth changes; main risk is readers missing docs if they skip oddkit catalog, not production breakage.
> 
> **Overview**
> Implements **D0002 “the built index is the only index”** by stripping hand-maintained inventories from `canon/` and `odd/`: collection README tables, resonance/appendix file lists, and per-article **`## Outline`** TOC blocks (including the three article templates that taught that pattern).
> 
> Each affected collection now points readers to **`oddkit catalog`** with a **`path_prefix`** (apocrypha collections note opt-in `include=["apocrypha"]`). Doctrine prose, operating constraints, and non-catalog tables (e.g. subfolder purpose in `canon/README.md`, predocumentary comparison matrix) stay.
> 
> **`odd/index.md`** drops the giant contents table and rewrites **Start Here** as narrative that defers listing to the catalog.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2d1a39478ad8bb725edc13b1b58ac3f0e8c3bb4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->