### PR TITLE
odd: bifurcation follow-ups backlog + D0002 status → ratified

### DIFF
--- a/odd/backlog/2026-06-09-bifurcation-follow-ups.md
+++ b/odd/backlog/2026-06-09-bifurcation-follow-ups.md
@@ -1,0 +1,56 @@
+---
+uri: klappy://odd/backlog/2026-06-09-bifurcation-follow-ups
+kind: docs
+title: "Backlog — Bifurcation Follow-Ups (Queued by Maintainer, 2026-06-09)"
+audience: odd
+exposure: nav
+tier: 3
+voice: neutral
+stability: stub
+tags: ["backlog", "bifurcation", "d0002", "oddkit", "outcomes-driven-development", "truthkit", "follow-up"]
+date: 2026-06-09
+epoch: E0009
+status: queued
+priority: ordered-below
+derives_from: "odd/decisions/D0002-canon-storage-model.md, odd/handoffs/2026-06-09-storage-model-execution.md, docs/repo-bifurcation-and-target-repo-routing.md"
+---
+
+# Backlog — Bifurcation Follow-Ups
+
+> Maintainer rulings recorded 2026-06-09: ODD repo is public for now; license deliberately undecided; no federation built today — clients make multiple calls per repo via `knowledge_base_url`; defaults and auth are queued, not built.
+
+## P1 — Multi-repo read defaults
+
+oddkit should default its read scope to `outcomes-driven-development` + `klappy.dev` until a caller overrides via `knowledge_base_url`. Interim contract (live now): one call per repo. Unblocks the removal pass below.
+
+## P1 — Removal pass in klappy.dev (4e)
+
+Blocked by the defaults item. Delete the moved files (142 ODD + 75 oddkit md + sidecar) from klappy.dev; in the same sweep retire `target_repo` from schema + validator, delete `canon/meta/scope-map.json`, and remove the transitional `odd/ → canon` PATH_KIND_MAP fallback in the worker. Dead-reference audit + read-model parity required in the PR body.
+
+## P1 — Undecided adjudication (joint session)
+
+21 `target_repo: "undecided"` files + 3 forks (writing-vertical cluster; vodka/architecture principles split; AGENTS.md two-way split). Format: succinct per-file proposal + one-line why, timeboxed review with maintainer. AGENTS.md must split before either half moves.
+
+## P2 — Worker auth for private knowledge bases
+
+GitHub App or scoped-PAT worker secret so oddkit can read private repos. Enables flipping ODD private later if monetization positioning demands it.
+
+## P2 — ODD repo license decision
+
+Open. No LICENSE file = all rights reserved (interim posture consistent with license-never-assign). Decide deliberately; the licensed artifact is the clonable repo (D0002 item 8).
+
+## P2 — Authority-as-column (D0002 item 3)
+
+Root doc per repo self-declares authority in frontmatter; peer pointers as canon declarations; build index ingests both. No registry file.
+
+## P2 — CI port to outcomes-driven-development
+
+Frontmatter validator + canon-quality workflow in the new repo (canonical scripts now live in oddkit per scope-map routing).
+
+## P3 — truthkit universality pass
+
+Read the ODD spine; tag the portable core `universal` vs `software`; that set seeds truthkit. Editorial, later.
+
+## P3 — Index-smell soft CI detector
+
+Soft signal flagging new static enumerations (sibling-file tables, Outline own-heading sections). Follow-up from the index-kill PR (#230).

--- a/odd/decisions/D0002-canon-storage-model.md
+++ b/odd/decisions/D0002-canon-storage-model.md
@@ -6,8 +6,8 @@ audience: canon
 exposure: nav
 tier: 1
 voice: neutral
-stability: draft
-status: proposed
+stability: stable
+status: ratified
 tags: ["odd", "architecture", "identity", "uri", "cqrs", "bifurcation", "read-model", "write-model"]
 relevance: decision
 execution_posture: governing
@@ -46,7 +46,7 @@ the decoupling.
 
 ## Status
 
-**Proposed.** Challenge battery passed 2026-06-09 (planning mode, no canon
+**Ratified** (PR #228 merged 2026-06-09; status flipped post-merge). Challenge battery passed 2026-06-09 (planning mode, no canon
 tensions, block_until_addressed false). Additionally pressure-tested across
 four adversarial maintainer review rounds (registry objection, static-index
 objection, discoverability objection, substrate thought experiment), each of


### PR DESCRIPTION
Records the 2026-06-09 maintainer rulings (ODD public for now, license open, no federation today — multi-call per repo, defaults + auth queued) as a backlog doc, and flips D0002 frontmatter to `status: ratified` / `stability: stable` per its own ratification clause (PR #228 merged).

Queued items: multi-repo read defaults (P1), removal pass 4e (P1, blocked on defaults), undecided joint session (P1), worker auth for private KBs (P2), ODD license (P2), authority-as-column (P2), ODD CI port (P2), truthkit universality pass (P3), index-smell detector (P3).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only: new backlog stub and decision metadata/status text; no runtime, auth, or schema changes in this diff.
> 
> **Overview**
> Adds **`odd/backlog/2026-06-09-bifurcation-follow-ups.md`**, a queued backlog that captures 2026-06-09 maintainer posture (ODD stays public for now, license undecided, no federation—multi-call per repo via `knowledge_base_url`) and orders follow-on work: **P1** multi-repo read defaults, klappy.dev removal pass (4e), undecided adjudication; **P2** worker auth, ODD license, authority-as-column, CI port; **P3** truthkit pass and index-smell detector.
> 
> Updates **`D0002-canon-storage-model.md`** to reflect post–PR #228 ratification: frontmatter **`stability: stable`** / **`status: ratified`**, and the Status section now states **Ratified** instead of **Proposed**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a89f68a220179e96f217af4aae326734d33992d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->