### PR TITLE
fix(backlog): undecided count 21 → 19

### DIFF
--- a/odd/backlog/2026-06-09-bifurcation-follow-ups.md
+++ b/odd/backlog/2026-06-09-bifurcation-follow-ups.md
@@ -29,7 +29,7 @@ Blocked by the defaults item. Delete the moved files (142 ODD + 75 oddkit md + s
 
 ## P1 — Undecided adjudication (joint session)
 
-21 `target_repo: "undecided"` files + 3 forks (writing-vertical cluster; vodka/architecture principles split; AGENTS.md two-way split). Format: succinct per-file proposal + one-line why, timeboxed review with maintainer. AGENTS.md must split before either half moves.
+19 `target_repo: "undecided"` files + 3 forks (writing-vertical cluster; vodka/architecture principles split; AGENTS.md two-way split). Format: succinct per-file proposal + one-line why, timeboxed review with maintainer. AGENTS.md must split before either half moves.
 
 ## P2 — Worker auth for private knowledge bases
 


### PR DESCRIPTION
Frontmatter-only parse gives 19 undecided movers; the prior 21 was a body-text grep over-count (same root cause as the stowaway fix in outcomes-driven-development#2 / oddkit#183).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only correction in a backlog stub; no runtime, schema, or validation behavior changes.
> 
> **Overview**
> Corrects the **P1 — Undecided adjudication** backlog line so it reports **19** `target_repo: "undecided"` files instead of **21**, matching a frontmatter-only count (the old number came from a body-text grep over-count, same class of issue as prior stowaway fixes elsewhere).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb34173d7f8be7502f7d6e541579307a3b84f14e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->