### PR TITLE
fix: triangle-pass target_repo core → undecided (joins writing-vertical cluster)

### DIFF
--- a/canon/methods/triangle-pass.md
+++ b/canon/methods/triangle-pass.md
@@ -13,7 +13,7 @@ derives_from: "canon/meta/triangle-of-yaps.md, canon/constraints/guide-posture.m
 complements: "canon/methods/choosing-the-right-narrative-container.md, canon/constraints/ai-voice-cliches.md, docs/audits/guide-posture-audit.md"
 governs: "How any topic is introduced and presented at the entry layer for klappy.dev — the weekly audio overview, the opening of an essay or section, a talk intro, a tool or onboarding intro. Governs the entry and the handoff, not the proof the handoff points to."
 constraint: "Subordinate to canon/meta/triangle-of-yaps.md, canon/constraints/guide-posture.md, canon/meta/writing-canon.md, and the axioms. Where any of those conflict with this method, they govern."
-target_repo: "outcomes-driven-development"
+target_repo: "undecided"
 ---
 
 # The Triangle Pass — Introduce a Topic as a Door Into the Proof, Not a Replacement for It


### PR DESCRIPTION
Maintainer ruling: the Triangle is a found framework under personal validation — it doesn't ship to ODD adopters. triangle-pass postdates the fork definition and bypassed the cluster lean; it derives from triangle-of-yaps (undecided). Retagged undecided pending the joint adjudication session. Pairs with outcomes-driven-development removal PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single metadata field in one canon doc; no runtime or content behavior changes.
> 
> **Overview**
> **Retags** `canon/methods/triangle-pass.md` so frontmatter `target_repo` moves from **`outcomes-driven-development`** to **`undecided`**, aligning the method with the writing-vertical / personal-validation cluster instead of ODD adopters.
> 
> No body or governance text changes—only the repo-routing metadata, pending joint adjudication and paired with the ODD-removal work described in the PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31c9c1a579cab1193f46db3e3f77ed02c729efa2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->