### PR TITLE
backlog: adjudication criteria for the undecided joint session

### DIFF
--- a/odd/backlog/2026-06-09-bifurcation-follow-ups.md
+++ b/odd/backlog/2026-06-09-bifurcation-follow-ups.md
@@ -31,6 +31,11 @@ Blocked by the defaults item. Delete the moved files (142 ODD + 75 oddkit md + s
 
 19 `target_repo: "undecided"` files + 3 forks (writing-vertical cluster; vodka/architecture principles split; AGENTS.md two-way split). Format: succinct per-file proposal + one-line why, timeboxed review with maintainer. AGENTS.md must split before either half moves.
 
+Adjudication criteria (maintainer calibration, recorded 2026-06-09):
+
+1. **Topic is not the routing criterion.** A doc is not pulled from core because of what it talks about; canon principles route on whether the principle itself is portable. Ruled in-session: `canon/principles/methodology-personification` and `canon/principles/voice-as-cognitive-load-shedding` are core despite being voice/communication-flavored.
+2. **Provisional found-frameworks stay overlay.** A framework the maintainer found and is still personally validating ("applied as working practice, retired when disconfirmed") does not ship to adopters as core canon until proven. Ruled in-session: `canon/methods/triangle-pass` returned to the overlay (klappy.dev #233, outcomes-driven-development #3) — it derives from `canon/meta/triangle-of-yaps` (undecided).
+
 ## P2 — Worker auth for private knowledge bases
 
 GitHub App or scoped-PAT worker secret so oddkit can read private repos. Enables flipping ODD private later if monetization positioning demands it.


### PR DESCRIPTION
Records the two maintainer calibrations from today so the joint session inherits them: (1) topic is not the routing criterion — principles route on portability of the principle itself (methodology-personification + voice-as-cognitive-load-shedding ruled core); (2) provisional found-frameworks under personal validation stay in the overlay until proven (triangle-pass returned).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Backlog documentation only; no runtime, schema, or routing behavior changes.
> 
> **Overview**
> Adds **adjudication criteria** to the bifurcation follow-ups backlog so the upcoming undecided joint session uses fixed maintainer rules instead of re-debating routing.
> 
> **Criterion 1:** routing is not by topic—canon principles are core when the *principle* is portable; `methodology-personification` and `voice-as-cognitive-load-shedding` are explicitly ruled core.
> 
> **Criterion 2:** frameworks still under personal validation stay in the overlay until proven; `triangle-pass` is ruled back to overlay (with linked PR/issue refs), tied to undecided `triangle-of-yaps`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72fd523602b24bff16ad10042423b02fcc04c505. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->