### PR TITLE
backlog: adjudication criterion 3 — exposed tension is core, the ruling is overlay

### DIFF
--- a/odd/backlog/2026-06-09-bifurcation-follow-ups.md
+++ b/odd/backlog/2026-06-09-bifurcation-follow-ups.md
@@ -36,6 +36,8 @@ Adjudication criteria (maintainer calibration, recorded 2026-06-09):
 1. **Topic is not the routing criterion.** A doc is not pulled from core because of what it talks about; canon principles route on whether the principle itself is portable. Ruled in-session: `canon/principles/methodology-personification` and `canon/principles/voice-as-cognitive-load-shedding` are core despite being voice/communication-flavored.
 2. **Provisional found-frameworks stay overlay.** A framework the maintainer found and is still personally validating ("applied as working practice, retired when disconfirmed") does not ship to adopters as core canon until proven. Ruled in-session: `canon/methods/triangle-pass` returned to the overlay (klappy.dev #233, outcomes-driven-development #3) — it derives from `canon/meta/triangle-of-yaps` (undecided).
 
+3. **Exposed tension without a ruling is core; the ruling itself is overlay.** When a principle, constraint, or method names a tension — "it could be this or this, with a range between" — and does not make the maintainer's judgment call about where on the range to land, that exposure is universal fodder for outcomes-driven-development. The test per doc: does it adjudicate, or does it only surface what you need to think through? Adjudication is klappy-specific; the tension travels.
+
 ## P2 — Worker auth for private knowledge bases
 
 GitHub App or scoped-PAT worker secret so oddkit can read private repos. Enables flipping ODD private later if monetization positioning demands it.


### PR DESCRIPTION
Maintainer calibration: docs that expose a tension/range without making the klappy-specific judgment call are universal (core ODD); docs that adjudicate where on the range to land are overlay. Per-doc test: does it adjudicate, or only surface what you need to think through?

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only backlog calibration with no runtime, schema, or auth changes.
> 
> **Overview**
> Adds **maintainer adjudication criterion #3** to the P1 undecided-doc routing rules in `odd/backlog/2026-06-09-bifurcation-follow-ups.md`.
> 
> Docs that **only expose a tension or range** (without the maintainer’s call on where to land) route to **core ODD**; docs that **adjudicate** that range route to the **klappy overlay**. The per-doc test is whether the piece adjudicates or only surfaces what adopters must think through.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c647b5772c29ad4a81ae0eb29d874eb078ba39d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->