### PR TITLE
fix: oddkit is manuals-only — 7 docs retagged to outcomes-driven-development (criterion 4)

### DIFF
--- a/canon/constraints/audit-gates-are-spawned-agent-sessions.md
+++ b/canon/constraints/audit-gates-are-spawned-agent-sessions.md
@@ -13,7 +13,7 @@ derives_from: "canon/methods/governance-validation-via-agents.md, canon/methods/
 complements: "canon/constraints/borrow-evaluation-before-implementation.md, canon/constraints/no-irreversible-action-without-epistemic-justification.md, canon/methods/spawned-agent-session-substrate-options.md"
 governs: "Any merge-blocking validator that audits canon, documentation, code-vs-canon sync, cross-reference integrity, or any other governance surface where the check requires LLM-grade judgment. Mechanical scripts (regex, AST walkers, lint rules) MAY run as triggers, schedules, or pre-flight hints but MUST NOT serve as the gate. The gate is a spawned agent session that fetches canon at runtime and produces structured findings."
 status: active
-target_repo: "oddkit"
+target_repo: "outcomes-driven-development"
 ---
 
 # Audit Gates Are Spawned Agent Sessions, Not Pattern Matchers

--- a/canon/principles/async-by-default-for-long-running-tools.md
+++ b/canon/principles/async-by-default-for-long-running-tools.md
@@ -14,7 +14,7 @@ derives_from:
 complements:
   - klappy://canon/principles/partial-data-with-transparency-and-background-warm
 status: active
-target_repo: "oddkit"
+target_repo: "outcomes-driven-development"
 ---
 
 # Async by Default — Long-Running MCP Tools Return an Identifier, Never Block

--- a/canon/principles/cache-fetches-and-parses.md
+++ b/canon/principles/cache-fetches-and-parses.md
@@ -13,7 +13,7 @@ derives_from: "canon/principles/vodka-architecture.md, canon/principles/dry-cano
 complements: "canon/constraints/oddkit-prompt-pattern.md, canon/principles/ritual-is-a-smell.md"
 governs: "All caching decisions in oddkit and any oddkit-pattern MCP server — which derived values get cached, which get rebuilt per request"
 status: active
-target_repo: "oddkit"
+target_repo: "outcomes-driven-development"
 ---
 
 # Cache Fetches and Parses — Not Microsecond Derivations

--- a/canon/principles/consistency-same-pattern-every-time.md
+++ b/canon/principles/consistency-same-pattern-every-time.md
@@ -13,7 +13,7 @@ derives_from: "canon/principles/vodka-architecture.md, canon/values/axioms.md"
 complements: "docs/architecture/epistemic-os-layers.md, canon/principles/kiss-simplicity-is-the-ceiling.md"
 governs: "All MCP server interfaces and knowledge base serving patterns in this program"
 status: active
-target_repo: "oddkit"
+target_repo: "outcomes-driven-development"
 ---
 
 # Consistency — Same Pattern, Every Knowledge Base, Every Time

--- a/canon/principles/dry-canon-says-it-once.md
+++ b/canon/principles/dry-canon-says-it-once.md
@@ -13,7 +13,7 @@ derives_from: "canon/principles/vodka-architecture.md, canon/constraints/oddkit-
 complements: "canon/principles/prompt-over-code.md, canon/values/axioms.md"
 governs: "All governance rule placement decisions in this program"
 status: active
-target_repo: "oddkit"
+target_repo: "outcomes-driven-development"
 ---
 
 # DRY — The Canon Says It Once, the Server Never Repeats It

--- a/canon/principles/identity-resolved-by-protocol.md
+++ b/canon/principles/identity-resolved-by-protocol.md
@@ -17,7 +17,7 @@ governs: "All cross-document identity references in canon and consumers of canon
 complements:
   - "canon/principles/anti-cache-lying.md"
   - "docs/oddkit/specs/oddkit-resolve.md"
-target_repo: "oddkit"
+target_repo: "outcomes-driven-development"
 ---
 
 # Identity Is Resolved By The Protocol — Hardcoded References Are A Cached Lie

--- a/canon/principles/partial-data-with-transparency-and-background-warm.md
+++ b/canon/principles/partial-data-with-transparency-and-background-warm.md
@@ -13,7 +13,7 @@ derives_from: "canon/values/axioms.md, canon/principles/vodka-architecture.md, c
 complements: "canon/principles/cache-fetches-and-parses.md, canon/principles/type-contract-plus-adversarial-review.md"
 governs: "Any tool handler, MCP server endpoint, or user-facing operation whose natural shape is 'scan a corpus to produce complete data.' Binding on all oddkit-pattern MCP servers in this program when deciding where expensive work runs relative to the user-blocking path."
 status: active
-target_repo: "oddkit"
+target_repo: "outcomes-driven-development"
 ---
 
 # Partial Data With Transparency And Background Warm — Never Block The User On A Corpus Scan

--- a/odd/backlog/2026-06-09-bifurcation-follow-ups.md
+++ b/odd/backlog/2026-06-09-bifurcation-follow-ups.md
@@ -38,6 +38,8 @@ Adjudication criteria (maintainer calibration, recorded 2026-06-09):
 
 3. **Exposed tension without a ruling is core; the ruling itself is overlay.** When a principle, constraint, or method names a tension — "it could be this or this, with a range between" — and does not make the maintainer's judgment call about where on the range to land, that exposure is universal fodder for outcomes-driven-development. The test per doc: does it adjudicate, or does it only surface what you need to think through? Adjudication is klappy-specific; the tension travels.
 
+4. **oddkit the repo is a user manual and a maintenance manual — nothing else.** If a doc is not about creating, maintaining, or using oddkit specifically, it does not belong in the oddkit repo. Principles and methods that oddkit merely embodies are ODD core; the engine being the proof does not make the principle engine documentation. Ruled in-session: 7 docs moved oddkit → core (the principles cluster + audit-gates-are-spawned-agent-sessions). Open: some user-manual content may itself need a different home — review when the manuals are next touched.
+
 ## P2 — Worker auth for private knowledge bases
 
 GitHub App or scoped-PAT worker secret so oddkit can read private repos. Enables flipping ODD private later if monetization positioning demands it.


### PR DESCRIPTION
Maintainer ruling: oddkit repo = user + maintenance manual only; principles the engine embodies are ODD core. Retags 7 docs and records criterion 4 in the backlog. Pairs with removal PR in oddkit and addition PR in outcomes-driven-development. Flagged for separate ruling: envelope-time-fields (lean stays), canon-integration-audit (lean core), frontmatter-validation-before-merge (lean core).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only `target_repo` retags and backlog notes; no runtime or governance prose changes in this diff.
> 
> **Overview**
> Applies **bifurcation criterion 4**: the **oddkit** repo is only user + maintenance manuals; portable principles the engine exemplifies belong in **outcomes-driven-development** core.
> 
> **Seven** canon files retag frontmatter **`target_repo`** from `oddkit` → `outcomes-driven-development` (no body edits): `audit-gates-are-spawned-agent-sessions` plus six vodka/MCP principles (`async-by-default-for-long-running-tools`, `cache-fetches-and-parses`, `consistency-same-pattern-every-time`, `dry-canon-says-it-once`, `identity-resolved-by-protocol`, `partial-data-with-transparency-and-background-warm`).
> 
> **`odd/backlog/2026-06-09-bifurcation-follow-ups.md`** records the maintainer ruling and notes paired removal/addition PRs elsewhere; three other docs are flagged for separate adjudication.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07e83aebc85c7a670fab06f6d30029df60d9527b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->