### PR TITLE
adjudicate: writing trio — guide-posture stays, dual-context + writing-canon → core

### DIFF
--- a/canon/constraints/dual-context-writing.md
+++ b/canon/constraints/dual-context-writing.md
@@ -19,7 +19,7 @@ date: 2026-04-09
 derives_from: "docs/book/governance.md, docs/planning/book-vs-website-distribution.md, canon/constraints/guide-posture.md"
 complements: "canon/meta/writing-canon.md, docs/book/how-to-read-this-book.md"
 governs: "All writings/ documents that also appear in the book chapter plan"
-target_repo: "undecided"
+target_repo: "outcomes-driven-development"
 ---
 
 # Constraint: Dual-Context Writing — One Document, Two Surfaces

--- a/canon/constraints/guide-posture.md
+++ b/canon/constraints/guide-posture.md
@@ -12,7 +12,6 @@ date: 2026-02-17
 derives_from: "canon/values/trust-kernel.md, canon/values/axioms.md"
 complements: "docs/oddkit/positioning.md, canon/meta/writing-canon.md"
 governs: "All public-facing content: websites (klappy.dev, odd.klappy.dev), voice agents, documentation with audience: public, tool descriptions, onboarding flows, and marketing copy"
-target_repo: "undecided"
 ---
 
 # Guide Posture — We Enter Their Story, Not the Other Way Around

--- a/canon/meta/writing-canon.md
+++ b/canon/meta/writing-canon.md
@@ -12,7 +12,7 @@ date: 2026-02-09
 complements: "canon/meta/TEMPLATE.md, docs/TEMPLATE.md, canon/meta/agent-executable-outline.md, canon/constraints/definition-of-done.md, canon/methods/self-audit.md, docs/oddkit/IMPL-writing-canon-gate.md"
 derives_from: "canon/values/axioms.md (Axiom 2 — A Claim Is a Debt)"
 governs: "All documents in canon/, odd/, and docs/ directories"
-target_repo: "undecided"
+target_repo: "outcomes-driven-development"
 ---
 
 # Writing Canon — Progressive Disclosure and Topographic Navigation

--- a/odd/backlog/2026-06-09-bifurcation-follow-ups.md
+++ b/odd/backlog/2026-06-09-bifurcation-follow-ups.md
@@ -29,14 +29,14 @@ Blocked by the defaults item. Delete the moved files (142 ODD + 75 oddkit md + s
 
 ## P1 — Undecided adjudication (joint session)
 
-19 `target_repo: "undecided"` files + 3 forks (writing-vertical cluster; vodka/architecture principles split; AGENTS.md two-way split). Format: succinct per-file proposal + one-line why, timeboxed review with maintainer. AGENTS.md must split before either half moves.
+17 `target_repo: "undecided"` files + 3 forks (writing-vertical cluster; vodka/architecture principles split; AGENTS.md two-way split). Format: succinct per-file proposal + one-line why, timeboxed review with maintainer. AGENTS.md must split before either half moves.
 
 Adjudication criteria (maintainer calibration, recorded 2026-06-09):
 
 1. **Topic is not the routing criterion.** A doc is not pulled from core because of what it talks about; canon principles route on whether the principle itself is portable. Ruled in-session: `canon/principles/methodology-personification` and `canon/principles/voice-as-cognitive-load-shedding` are core despite being voice/communication-flavored.
 2. **Provisional found-frameworks stay overlay.** A framework the maintainer found and is still personally validating ("applied as working practice, retired when disconfirmed") does not ship to adopters as core canon until proven. Ruled in-session: `canon/methods/triangle-pass` returned to the overlay (klappy.dev #233, outcomes-driven-development #3) — it derives from `canon/meta/triangle-of-yaps` (undecided).
 
-3. **Exposed tension without a ruling is core; the ruling itself is overlay.** When a principle, constraint, or method names a tension — "it could be this or this, with a range between" — and does not make the maintainer's judgment call about where on the range to land, that exposure is universal fodder for outcomes-driven-development. The test per doc: does it adjudicate, or does it only surface what you need to think through? Adjudication is klappy-specific; the tension travels.
+3. **Exposed tension without a ruling is core; the ruling itself is overlay.** When a principle, constraint, or method names a tension — "it could be this or this, with a range between" — and does not make the maintainer's judgment call about where on the range to land, that exposure is universal fodder for outcomes-driven-development. The test per doc: does it adjudicate, or does it only surface what you need to think through? Adjudication is klappy-specific; the tension travels. Ruled in-session: guide-posture stays in klappy.dev (externally proven but a chosen style — the choice is the adjudication); dual-context-writing and writing-canon are core (reusable authoring constraints; writing-canon is progressive-disclosure doctrine).
 
 4. **oddkit the repo is a user manual and a maintenance manual — nothing else.** If a doc is not about creating, maintaining, or using oddkit specifically, it does not belong in the oddkit repo. Principles and methods that oddkit merely embodies are ODD core; the engine being the proof does not make the principle engine documentation. Ruled in-session: 7 docs moved oddkit → core (the principles cluster + audit-gates-are-spawned-agent-sessions). Open: some user-manual content may itself need a different home — review when the manuals are next touched.
 


### PR DESCRIPTION
Maintainer rulings: guide-posture is a chosen style (the choice is the adjudication) → untagged, stays; dual-context-writing and writing-canon are reusable authoring constraints → core. Backlog count synced. Pairs with ODD addition PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Frontmatter and backlog metadata only; no substantive canon body edits or runtime behavior changes.
> 
> **Overview**
> Records maintainer **bifurcation routing** for the writing-vertical trio: **`dual-context-writing`** and **`writing-canon`** are tagged **`target_repo: "outcomes-driven-development"`** (portable authoring / progressive-disclosure doctrine → ODD core). **`guide-posture`** drops **`target_repo`** so it **stays on klappy.dev** — the ruling is a chosen public style, not universal canon.
> 
> **`odd/backlog/2026-06-09-bifurcation-follow-ups.md`** syncs the open **undecided** count (**19 → 17**) and documents the in-session ruling under criterion 3. Pairs with the companion PR that adds the same docs to the ODD repo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb7e7a9a887fd35405d63201bcc7aae68d78a6cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->