### PR TITLE
adjudicate: oddkit-boundary trio → core

### DIFF
--- a/canon/constraints/canon-integration-audit.md
+++ b/canon/constraints/canon-integration-audit.md
@@ -13,7 +13,7 @@ derives_from: "canon/values/axioms.md, canon/meta/frontmatter-schema.md, canon/p
 complements: "canon/methods/revision-lens-sequence.md, canon/constraints/frontmatter-validation-before-merge.md, canon/principles/dream-house-principle.md, canon/principles/discernment-layer.md"
 governs: "Any doc-producing workflow that produces content intended to be merged into the knowledge base — essays, canon docs, observations, constraints, methods, principles"
 status: active
-target_repo: "oddkit"
+target_repo: "outcomes-driven-development"
 ---
 
 # Canon-Integration Audit — Three Checks Between Authoring and Merge

--- a/canon/constraints/frontmatter-validation-before-merge.md
+++ b/canon/constraints/frontmatter-validation-before-merge.md
@@ -12,7 +12,7 @@ date: 2026-04-09
 derives_from: "canon/meta/frontmatter-schema.md, canon/values/axioms.md"
 complements: "canon/meta/writing-canon.md, canon/constraints/definition-of-done.md"
 governs: "All PRs that add or modify files in writings/, canon/, odd/, or docs/"
-target_repo: "oddkit"
+target_repo: "outcomes-driven-development"
 ---
 
 # Frontmatter Validation Before Merge — No Exceptions

--- a/canon/principles/envelope-time-fields.md
+++ b/canon/principles/envelope-time-fields.md
@@ -13,7 +13,7 @@ derives_from: "odd/constraint/anti-cache-lying.md, canon/principles/cache-fetche
 complements: "docs/appendices/epoch-8-2.md, canon/constraints/core-governance-baseline.md"
 governs: "Semantics of time fields in the oddkit response envelope and any oddkit-pattern MCP server envelope — what each field means, which MUST be present, and which are forbidden"
 status: draft
-target_repo: "oddkit"
+target_repo: "outcomes-driven-development"
 ---
 
 # Envelope Time Fields — Request Time vs Content Provenance

--- a/odd/backlog/2026-06-09-bifurcation-follow-ups.md
+++ b/odd/backlog/2026-06-09-bifurcation-follow-ups.md
@@ -31,7 +31,7 @@ Blocked by the defaults item. Delete the moved files (142 ODD + 75 oddkit md + s
 
 All 19 (+triangle-pass) undecided markdown docs adjudicated live against the four criteria. Overlay (untagged, stay): ai-voice-cliches, author-identity-language, harness-disambiguation, relational-sensitivity, guide-posture, triangle-of-yaps, triangle-pass, writing-apocrypha-fragments, writing-predocumentaries. Core (shipped): writing-canon, dual-context-writing, prompt-over-code, antifragile-failures-grow-canon, using-ease-and-resistance-as-signals, revision-lens-sequence, choosing-the-right-narrative-container, vodka-architecture, kiss-simplicity-is-the-ceiling, maintainability-one-person-indefinitely, doing-less-enables-more.
 
-Remaining: **AGENTS.md two-way split** (creed/axioms half → core; oddkit-MCP-integration half → oddkit) — still scope-map "undecided". Also pending ruling: three oddkit-boundary docs (envelope-time-fields lean stays; canon-integration-audit, frontmatter-validation-before-merge lean core).
+Remaining: **AGENTS.md two-way split** (creed/axioms half → core; oddkit-MCP-integration half → oddkit) — still scope-map "undecided". Oddkit-boundary trio ruled core 2026-06-09: envelope-time-fields (the principle — request time vs content provenance — travels; oddkit field names are the worked example), canon-integration-audit, frontmatter-validation-before-merge.
 
 
 ## P2 — Worker auth for private knowledge bases


### PR DESCRIPTION
Maintainer rulings: all three core. envelope-time-fields' principle (request time ≠ content provenance; ambiguity is the failure) travels with its derivation chain, which is already core; canon-integration-audit and frontmatter-validation-before-merge are generic KB governance. Pairs with oddkit removal + ODD addition.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Frontmatter and backlog-only changes with no runtime, auth, or validator behavior in this diff.
> 
> **Overview**
> **Adjudicates the oddkit-boundary trio as core ODD canon** and retags their frontmatter `target_repo` from `oddkit` to `outcomes-driven-development`, aligning with the bifurcation plan to host portable KB governance and envelope semantics in the ODD repo rather than oddkit-only scope.
> 
> The three docs are **`canon-integration-audit`**, **`frontmatter-validation-before-merge`**, and **`envelope-time-fields`** (request time vs content provenance; oddkit field names remain the worked example). **`odd/backlog/2026-06-09-bifurcation-follow-ups.md`** is updated to mark this ruling resolved and to drop the “pending ruling” wording for that trio; **AGENTS.md split** stays undecided.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6fa5eaa6042bae3746e5e41de151a591a397a52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->