### PR TITLE
fix: demote artifacts-are-projections pending author editorial pass

### DIFF
--- a/writings/artifacts-are-projections.md
+++ b/writings/artifacts-are-projections.md
@@ -2,12 +2,12 @@
 uri: "klappy://writings/artifacts-are-projections"
 title: "Artifacts Are Projections"
 audience: public
-exposure: public
+exposure: draft
 tier: 2
 voice: first_person
-stability: draft
+stability: draft  # pending author editorial pass per ai-voice-cliches (gauntlet run post-hoc 2026-06-09)
 tags: ["knowledge-base", "projection", "artifacts", "directors-chair", "ai", "expertise"]
-public: true
+public: false
 type: "essay"
 slug: "artifacts-are-projections"
 hook: "You shipped the thing. Six months later the thing is stale, and everything you knew while making it lives nowhere but your head."


### PR DESCRIPTION
The essay shipped without the publish gauntlet. Post-hoc run: preflight done, ai-voice-cliches audit found clustering (13 em dashes / 3 clustered paragraphs, 1 negation parallelism, repeated closer). The constraint requires an author editing pass when patterns cluster — demoting to draft until that pass happens. Revised candidate text delivered to maintainer alongside.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only visibility change on a single essay; no runtime or security impact.
> 
> **Overview**
> **Demotes** the essay `artifacts-are-projections` from public to **draft** by updating frontmatter only (`exposure: draft`, `public: false`).
> 
> Adds a `stability: draft` note that an **author editorial pass** is still required after a post-hoc **ai-voice-cliches** gauntlet (clustered em dashes, negation parallelism, repeated closer). Essay body is unchanged in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cd33dd849d1dff49c402211192ec93c5a35b17b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->