### PR TITLE
fix: restructure artifacts-are-projections per writing canon (gauntlet addressed)

### DIFF
--- a/writings/artifacts-are-projections.md
+++ b/writings/artifacts-are-projections.md
@@ -1,41 +1,65 @@
 ---
 uri: "klappy://writings/artifacts-are-projections"
-title: "Artifacts Are Projections"
+title: "Artifacts Are Projections — The Thing You Shipped Was Never the Asset"
 audience: public
 exposure: draft
 tier: 2
 voice: first_person
-stability: draft  # pending author editorial pass per ai-voice-cliches (gauntlet run post-hoc 2026-06-09)
+stability: draft
 tags: ["knowledge-base", "projection", "artifacts", "directors-chair", "ai", "expertise"]
 public: false
 type: "essay"
 slug: "artifacts-are-projections"
 hook: "You shipped the thing. Six months later the thing is stale, and everything you knew while making it lives nowhere but your head."
-description: "The artifact was never the asset. Your knowledge base is — and every app, essay, video, or deck is a projection you can regenerate at will. Companion to the ODD principle 'Knowledge Base as the Unit.'"
+description: "The artifact was never the asset. Your knowledge base is, and every app, essay, video, or deck is a projection you can regenerate at will. Companion to the ODD principle 'Knowledge Base as the Unit.'"
 date: "2026-06-09"
 epoch: "E0009"
-og_description: "The artifact was never the asset. Your knowledge base is — everything else is a projection."
+og_description: "The artifact was never the asset. Your knowledge base is. Everything else is a projection."
 companion: "odd://canon/principles/knowledge-base-as-the-unit"
 ---
 
-# Artifacts Are Projections
+# Artifacts Are Projections — The Thing You Shipped Was Never the Asset
 
-You shipped the thing. The deck, the app, the video, the course. It was good — good enough that people asked for another one, a different shape, a newer version. And six months later the thing is stale, the rework feels like starting over, and everything you actually knew while making it lives nowhere but your head.
+> Every artifact you ship goes stale; the knowledge that produced it doesn't have to. Encode your expertise into a knowledge base — decisions, constraints, vocabulary, the rules you'd give an apprentice — and the knowledge base becomes the durable asset while everything downstream becomes a projection: a website, an essay, an audio overview, an app, rendered by a build or a model and disposable on purpose, because anything projected can be re-projected from a source that didn't go stale. Your job changes with it. You leave the workbench for the director's chair: you adjudicate what enters the canon and you direct which projections get made. Owned by you, licensed if you choose, never assigned.
+
+## Summary — The Knowledge Base Is the Planet; Everything You Ship Is a Map of It
+
+A map projection takes one Earth and renders it a hundred ways. Nobody confuses the projection for the planet, and nobody panics when a projection ages, because the planet is still there. Your expertise works the same way once you encode it: the knowledge base is the planet, every artifact is a map printed from it, and staleness stops being a crisis because regeneration is cheap. The hard work moves upstream, into deciding what you actually know and stating it carefully enough to project from. That is director's work. The rest of this essay is the walk from the pain to the chair.
+
+## The Thing Went Stale. Did Your Knowledge?
+
+You shipped the thing. The deck, the app, the video, the course. It was good enough that people asked for another one, a different shape, a newer version. And six months later the thing is stale, the rework feels like starting over, and everything you actually knew while making it lives nowhere but your head.
 
 What if the thing was never the asset?
 
-Here's a question worth sitting with: when your artifact went stale, did your *knowledge* go stale — or just the surface it was printed on?
+Here's a question worth sitting with: when your artifact went stale, did your knowledge go stale, or just the surface it was printed on?
 
-A map projection takes one Earth and renders it a hundred ways — Mercator for sailing, polar for flying, equal-area for honesty about Greenland. Nobody confuses the projection for the planet. Nobody panics when a projection ages, because the Earth is still there and you can always project again.
+## One Earth, a Hundred Maps
 
-Your expertise works the same way, if you let it. Encode what you know — the decisions, the constraints, the hard-won "never again" rules, the vocabulary — into a knowledge base: a living, versioned, reviewable body of your own canon. That becomes the planet. Then every artifact is a projection: the website is a projection, the essay is a projection, the audio overview is a projection, the app scaffold is a projection. Some projections are deterministic builds. Some are generated — a model reading your knowledge base and rendering it as a video script, a slide deck, an interactive tool. Either way, the projection is disposable *on purpose*, because anything projected can be re-projected from the source that didn't go stale.
+A map projection takes one Earth and renders it a hundred ways. Mercator for sailing, polar for flying, equal-area for honesty about Greenland. Nobody confuses the projection for the planet. Nobody panics when a projection ages, because the Earth is still there and you can always project again.
 
-I learned this the slow way. My own knowledge base spent months as a tangle — personal story, portable methodology, and a tool's manual all sharing one repository. Every artifact projected from it inherited the tangle. Untangling it meant deciding, document by document, which knowledge base owned which truth. The artifacts weren't the hard part. The artifacts were never the hard part.
+Your expertise works the same way, if you let it. Encode what you know (the decisions, the constraints, the hard-won "never again" rules, the vocabulary) into a knowledge base: a living, versioned, reviewable body of your own canon. That becomes the planet. Then every artifact is a projection: the website is a projection, the essay is a projection, the audio overview is a projection, the app scaffold is a projection. Some projections are deterministic builds. Some are generated: a model reading your knowledge base and rendering it as a video script, a slide deck, an interactive tool. Either way, the projection is disposable on purpose. Anything projected can be re-projected from the source that didn't go stale.
 
-So the work changes shape. You stop being the person who makes the things. You take the director's chair: you decide what enters the canon — what you actually know, stated carefully enough to be projected from — and you direct which projections get made, for which audience, on which surface. The model runs the camera. You own the screenplay.
+## I Learned This Untangling My Own Repo
 
-Which raises the question that matters more than any tooling: what do you know that nobody else has encoded? Not your outputs — your *judgment*. The tensions you've learned to navigate, the failure modes you can smell, the rules you'd give an apprentice. That's the planet. Everything you've ever shipped was a photograph of it.
+My own knowledge base spent months as a tangle. Personal story, portable methodology, and a tool's manual all shared one repository, and every artifact projected from it inherited the tangle. Untangling it meant deciding, document by document, which knowledge base owned which truth. The artifacts, it turned out, were the easy part.
 
-Start there. One decision you'd defend, one constraint you've paid for, one definition you'd fight over — written down, owned by you, licensed if you choose and never assigned. The projections will come faster than you expect. They always do, once there's something real to project.
+## The Director's Chair — You Stop Making Things and Start Directing Projections
 
-The governance-side companion to this essay — the formal principle, the projection contract, the failure modes — lives in the ODD canon as *Knowledge Base as the Unit*. This is the view from the artifact looking back at its source. That one is the view from the source, looking out.
+So the work changes shape. You stop being the person who makes the things. You take the director's chair: you decide what enters the canon (what you actually know, stated carefully enough to be projected from) and you direct which projections get made, for which audience, on which surface. The model runs the camera. You own the screenplay.
+
+## What Do You Know That Nobody Else Has Encoded?
+
+That question matters more than any tooling. I mean your judgment, not your outputs: the tensions you've learned to navigate, the failure modes you can smell, the rules you'd give an apprentice. That's the planet. Everything you've ever shipped was a photograph of it taken on one particular afternoon.
+
+## Where This Holds, and Where It Doesn't
+
+Fair warnings before you reorganize your life around a metaphor. This is a working rule, not a law of nature: I'll hold it until an artifact-first workflow beats it for knowledge work, and I'd genuinely like to see one try. It holds where the artifact is derivable from what you know. It does not hold where the artifact is the asset — a painting, a live performance, a codebase whose value lives in years of accumulated runtime behavior no document captures. And encoding costs real work up front; encode the wrong things carefully and you've built a beautiful planet nobody needs maps of.
+
+The evidence isn't just my one tangle. The same substrate already serves a second expert's corpus — a theology scholar's dissertations — through identical machinery, and for twenty years colleagues have asked to "clone" me, which I eventually understood as demand for the methodology, not the person. The knowledge base is what cloning actually looks like.
+
+## Start With One Decision You'd Defend
+
+One decision you'd defend, one constraint you've paid for, one definition you'd fight over. Written down, owned by you, licensed if you choose and never assigned. The projections will come faster than you expect. They always do, once there's something real to project.
+
+The governance-side companion to this essay (the formal principle, the projection contract, the failure modes) lives in the ODD canon as *Knowledge Base as the Unit*. This is the view from the artifact looking back at its source. That one is the view from the source, looking out.


### PR DESCRIPTION
Full post-hoc gauntlet: preflight → writing-canon (live read) → ai-voice-cliches audit → challenge, published-essay mode. Block-until-addressed gaps resolved with calibration: scope + counter-example (artifacts that ARE the asset), encoding cost, working-rule framing with a stated disconfirmer, and the sample expanded beyond one case (oral-theology corpus, clone-klappy-to-oddie-recognition). Progressive disclosure now passes all five tiers; header scan tells the story. Remains public:false / exposure:draft — promotion is the author's editorial call.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Draft markdown essay only; no runtime, API, or publication flag changes.
> 
> **Overview**
> **Restructures the draft essay** `artifacts-are-projections.md` for writing-canon progressive disclosure and a stronger header scan, without changing draft/public metadata.
> 
> Adds a **lead blockquote** and a **Summary** section up front, then breaks the former single flow into named sections (stale artifact hook, map metaphor, repo tangle anecdote, director’s chair, limits, evidence, CTA). **Title and H1** gain the subtitle *“The Thing You Shipped Was Never the Asset.”*
> 
> **New editorial substance:** a **“Where This Holds, and Where It Doesn’t”** section frames the idea as a working rule with counter-examples (artifact-as-asset cases, encoding cost), plus expanded evidence beyond the author’s repo (second corpus, “clone” demand). Light **punctuation/copy** tweaks in frontmatter and body (em dashes → commas/parentheses in places).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c57041b564bbed75507d22102d2b98d11bbdd0dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->