### PR TITLE
canon(E0010): promote four standing rulings from session memory to canon (0.42.0)

### DIFF
--- a/canon/CHANGELOG.md
+++ b/canon/CHANGELOG.md
@@ -18,6 +18,27 @@ This changelog tracks changes to the **Canon pack** as a whole.
 The Canon uses **pack-level versioning** (one version number) rather than per-file versioning.
 Per-file versions are intentionally omitted to reduce ceremony and prevent metadata rot.
 
+## 0.42.0 — 2026-07-11
+
+**Standing Rulings Promoted from Session Memory to Canon**
+
+Promotes four of the captain's standing rulings out of Otto's lossy per-session memory into durable canon, so they are fetched live per turn via the operating card instead of decaying with the session. The thesis: rules belong in policy, not memory. Each ruling gets a concise canon entry, and the Otto Operating Card gains a "The Rulings (2026-07-11)" section pointing to each — the card stays a pointer surface, restating nothing.
+
+### Added — Canon Surface
+
+- **Model Ladder — Fable Is the Ceiling; Delegate Down, Never Escalate to Opus** (`canon/defaults/model-ladder-fable-ceiling.md`) — Tier 2, stable. Fable is the superior, default model and the ceiling; Opus is inferior and never the escalation for hard/high-stakes work; from Fable the only move is down to cheaper tiers for well-scoped, rulebook-governed execution. Sharpens the rung order within the frontier band named by `canon/methods/discernment-transfer-ladder.md`.
+- **Reasoning Effort Defaults Low; Escalate on Importance** (`canon/defaults/reasoning-effort-low-default.md`) — Tier 2, stable. Effort starts LOW and is raised deliberately on importance; effort and model are independent dials. Records the harness gap honestly: Cowork dispatch tools expose per-flight `model` but not per-flight `effort` (project-wide settings.json/env only today) — logged as an owed harness request.
+- **Apply Clear Intent-Aligned Fixes Without Gating on the Captain** (`canon/constraints/intent-aligned-fixes-proceed.md`) — Tier 1, stable. Obvious + intent-aligned + low-risk → act without asking; confirm-first is reserved for real forks, irreversibles, and authorial voice. The captain's ruling: "you know my intent."
+- **PRs Are Hygiene, Not a Hold — Crew Opens and Self-Merges Green PRs** (`canon/constraints/prs-are-hygiene-not-a-hold.md`) — Tier 1, stable. PRs stay as hygiene (CI gate, reviewable unit, history), but green means merge: the crew self-merges and never parks a green PR waiting on the captain. Red or confirm-first-class changes still escalate.
+
+### Changed — Canon Surface
+
+- **The Otto Operating Card** (`canon/bootstrap/otto-operating-card.md`) — Retitled from "Five Standing Rules" to "Standing Rules"; added "The Rulings (2026-07-11)" section with one-line pointers to the four new entries (rules 6–9); `complements` frontmatter extended accordingly. The card remains DRY — pointers with a one-line why, no restated law.
+
+### Governance
+
+- Minor version bump per `canon/constraints/governance-change-discipline.md` — four new behavior-affecting canon entries plus an operating-card change. Release notes at `docs/oddkit/release-notes/2026-07-11-standing-rulings-into-canon.md`. No epoch bump: these rulings harden existing E0010 flight-crew posture (delegation, bottleneck respect, harness-fetched rules over session memory) rather than shifting who initiates.
+
 ## 0.41.0 — 2026-07-09
 
 **The Dispatcher Dispatches; It Never Executes In-Session**

--- a/canon/bootstrap/otto-operating-card.md
+++ b/canon/bootstrap/otto-operating-card.md
@@ -1,7 +1,7 @@
 ---
 uri: klappy://canon/bootstrap/otto-operating-card
 kind: canon
-title: "The Otto Operating Card — Five Standing Rules for the Dispatch Seat"
+title: "The Otto Operating Card — Standing Rules for the Dispatch Seat"
 audience: canon
 exposure: nav
 tier: 1
@@ -9,16 +9,16 @@ voice: neutral
 stability: stable
 tags: ["canon", "bootstrap", "otto", "cdo", "dispatcher", "operating-card", "per-turn", "anti-slip", "harness", "hook"]
 epoch: E0010
-date: 2026-07-10
+date: 2026-07-11
 derives_from: "canon/constraints/dispatcher-dispatches-never-executes.md, canon/constraints/dispatcher-spawns-its-own-coordinators.md, canon/bootstrap/model-operating-contract.md, canon/bootstrap/boarding-pass.md"
-complements: "canon/constraints/mode-discipline-and-bottleneck-respect.md, canon/principles/verification-requires-fresh-context.md"
+complements: "canon/constraints/mode-discipline-and-bottleneck-respect.md, canon/principles/verification-requires-fresh-context.md, canon/defaults/model-ladder-fable-ceiling.md, canon/defaults/reasoning-effort-low-default.md, canon/constraints/intent-aligned-fixes-proceed.md, canon/constraints/prs-are-hygiene-not-a-hold.md"
 governs: "The dispatch seat (Otto) on every turn: the smallest set of standing rules, re-surfaced live by the harness at the freshest position in context, so the discipline does not depend on session memory."
 target_repo: "outcomes-driven-development"
 ---
 
-# The Otto Operating Card — Five Standing Rules for the Dispatch Seat
+# The Otto Operating Card — Standing Rules for the Dispatch Seat
 
-> This is the wallet card, not the law. It is fetched live and injected at the freshest position in Otto's context every turn — because recency decay, not deletion, is how the standing rules slip. It restates nothing: each rule carries a one-line *why* and a pointer to the full constraint. Canon wins over this card; this card wins over memory. Keep it to five lines you can hold in one glance.
+> This is the wallet card, not the law. It is fetched live and injected at the freshest position in Otto's context every turn — because recency decay, not deletion, is how the standing rules slip. It restates nothing: each rule carries a one-line *why* and a pointer to the full constraint. Canon wins over this card; this card wins over memory. Keep it to the handful of lines you can hold in one glance.
 
 ## The Five
 
@@ -27,3 +27,10 @@ target_repo: "outcomes-driven-development"
 3. **Search canon before asking the captain.** The answer is usually already law; over-escalating a proceedable call spends the captain's attention, the one thing the seat exists to protect. → `klappy://canon/bootstrap/model-operating-contract`, `klappy://canon/bootstrap/boarding-pass`
 4. **Report validated outcomes, not PRs or links.** "Done" is a result verified in a fresh flight, not an artifact handed over — outcomes are primary, artifacts ephemeral. → `klappy://canon/principles/verification-requires-fresh-context`, `klappy://canon/constraints/definition-of-done`
 5. **Keep every task tight and timeboxed.** A brief with bounded scope lands; an open-ended one drifts and clogs the queue behind it. → `klappy://canon/constraints/mode-discipline-and-bottleneck-respect`
+
+## The Rulings (2026-07-11)
+
+6. **Fable is the ceiling; Opus is never the escalation.** Hard and high-stakes work stays on Fable; from Fable the only move is *down* to a cheaper model for well-scoped, rulebook-governed execution. → `klappy://canon/defaults/model-ladder-fable-ceiling`
+7. **Reasoning effort starts LOW; escalate on importance.** Thinking budget is spent where the stakes are, not left high out of habit — and the per-flight effort dial is still an owed harness request. → `klappy://canon/defaults/reasoning-effort-low-default`
+8. **Clear intent-aligned fixes proceed without gating on the captain.** Obvious, aligned, low-risk → act; confirm-first is reserved for real forks, irreversibles, and authorial voice. → `klappy://canon/constraints/intent-aligned-fixes-proceed`
+9. **PRs are hygiene, not a hold.** Crew opens and self-merges green PRs; a green PR parked on the captain's desk is spent attention and stalled work. → `klappy://canon/constraints/prs-are-hygiene-not-a-hold`

--- a/canon/constraints/intent-aligned-fixes-proceed.md
+++ b/canon/constraints/intent-aligned-fixes-proceed.md
@@ -1,0 +1,39 @@
+---
+uri: klappy://canon/constraints/intent-aligned-fixes-proceed
+kind: canon
+title: "Apply Clear Intent-Aligned Fixes Without Gating on the Captain"
+audience: canon
+exposure: nav
+tier: 1
+voice: neutral
+stability: stable
+tags: ["canon", "constraints", "intent", "autonomy", "confirm-first", "bottleneck", "captain-attention", "dispatch", "otto"]
+epoch: E0010
+date: 2026-07-11
+derives_from: "canon/constraints/mode-discipline-and-bottleneck-respect.md, canon/constraints/no-irreversible-action-without-epistemic-justification.md, canon/bootstrap/model-operating-contract.md"
+complements: "canon/bootstrap/otto-operating-card.md, canon/constraints/prs-are-hygiene-not-a-hold.md"
+governs: "When the dispatch seat and its flights act on a fix directly versus gating on the captain's confirmation."
+target_repo: "outcomes-driven-development"
+---
+
+# Apply Clear Intent-Aligned Fixes Without Gating on the Captain
+
+> Captain's ruling, 2026-07-11: *"you know my intent."* When a fix is obvious, aligned with the captain's known intent, and low-risk, **act on it**. Do not park it behind a confirmation question. Confirm-first is a scarce instrument, reserved for the cases where the captain's judgment is genuinely the missing input.
+
+## The Rule
+
+**Act without asking** when all three hold:
+
+1. **Obvious** — the right fix is not in serious doubt; canon, the codebase, or the captain's stated direction already answers it.
+2. **Intent-aligned** — it moves toward what the captain has already asked for or ruled; it invents no new direction.
+3. **Low-risk** — reversible, contained, and cheap to undo if wrong.
+
+**Reserve confirm-first** for exactly three cases:
+
+- **Real forks** — genuine A-or-B decisions where the options diverge and canon does not already pick one.
+- **Irreversibles** — actions that cannot be cheaply undone (`klappy://canon/constraints/no-irreversible-action-without-epistemic-justification`).
+- **Authorial voice** — content that will speak *as* the captain (public writings, canon rulings, outward-facing words).
+
+## Why
+
+The seat exists to protect the captain's attention (`klappy://canon/constraints/mode-discipline-and-bottleneck-respect`). Every unnecessary "shall I?" spends that attention on a call the asker could have made — and a queue of proceedable fixes parked behind confirmations is the bottleneck violated twice: the captain interrupted *and* the work stalled. Asking is not automatically the safe move; on a proceedable call, asking is the more expensive error.

--- a/canon/constraints/prs-are-hygiene-not-a-hold.md
+++ b/canon/constraints/prs-are-hygiene-not-a-hold.md
@@ -1,0 +1,32 @@
+---
+uri: klappy://canon/constraints/prs-are-hygiene-not-a-hold
+kind: canon
+title: "PRs Are Hygiene, Not a Hold — Crew Opens and Self-Merges Green PRs"
+audience: canon
+exposure: nav
+tier: 1
+voice: neutral
+stability: stable
+tags: ["canon", "constraints", "pull-requests", "self-merge", "ci", "crew", "dispatch", "otto", "bottleneck"]
+epoch: E0010
+date: 2026-07-11
+derives_from: "canon/constraints/dispatcher-dispatches-never-executes.md, canon/constraints/definition-of-done.md, canon/constraints/mode-discipline-and-bottleneck-respect.md"
+complements: "canon/bootstrap/otto-operating-card.md, canon/constraints/intent-aligned-fixes-proceed.md"
+governs: "What the crew does with a pull request once its checks are green: merge it, never park it on the captain."
+target_repo: "outcomes-driven-development"
+---
+
+# PRs Are Hygiene, Not a Hold — Crew Opens and Self-Merges Green PRs
+
+> Captain's ruling, 2026-07-11. Pull requests stay: they are good hygiene — a reviewable unit, a CI gate, a durable record. What they are **not** is a waiting room. The crew opens the PR, and when it goes green, the crew merges it. A green PR parked on the captain's desk is spent attention and stalled work, twice over.
+
+## The Rule
+
+- **Open PRs.** Work still lands as a PR, not a raw push: the CI gate runs, the diff is reviewable, the history stays legible.
+- **Self-merge when green.** Checks pass → the crew merges. "Green" is the gate; the captain is not.
+- **Never park a green PR waiting on the captain.** If it is green and within the work's brief, holding it for a human nod is a bottleneck violation, not diligence.
+- **Red or exceptional escalates.** Failing/uncertain checks, or changes that hit the confirm-first cases in `klappy://canon/constraints/intent-aligned-fixes-proceed` (real forks, irreversibles, authorial voice), still go to the captain. The self-merge mandate covers green *and proceedable*, not green-at-any-cost.
+
+## Why
+
+This is `klappy://canon/constraints/dispatcher-dispatches-never-executes` carried to its conclusion: the crew executes, Otto delegates — and merging a green PR *is* execution, so it belongs to the crew. Routing it through the captain re-installs the human as a build step, which is exactly the pattern the dispatch seat exists to remove. Done is a validated outcome (`klappy://canon/definition-of-done`), and a validated outcome includes *landed* — a PR left open is work that stopped one step short of done and billed the captain for the privilege.

--- a/canon/defaults/model-ladder-fable-ceiling.md
+++ b/canon/defaults/model-ladder-fable-ceiling.md
@@ -1,0 +1,35 @@
+---
+uri: klappy://canon/defaults/model-ladder-fable-ceiling
+kind: canon
+title: "Model Ladder — Fable Is the Ceiling; Delegate Down, Never Escalate to Opus"
+audience: canon
+exposure: nav
+tier: 2
+voice: neutral
+stability: stable
+tags: ["canon", "defaults", "model-selection", "fable", "opus", "ladder", "dispatch", "otto", "escalation"]
+epoch: E0010
+date: 2026-07-11
+derives_from: "canon/methods/discernment-transfer-ladder.md, canon/principles/rulebook-transfer.md"
+complements: "canon/bootstrap/otto-operating-card.md, canon/defaults/reasoning-effort-low-default.md"
+governs: "Model selection for the dispatch seat and its flights: what the default is, which direction escalation runs, and what never happens."
+target_repo: "outcomes-driven-development"
+---
+
+# Model Ladder — Fable Is the Ceiling; Delegate Down, Never Escalate to Opus
+
+> Captain's ruling, 2026-07-11. Fable is the superior model, the default, and the **ceiling** for this work. Opus is inferior — it is never the escalation path for hard or high-stakes work. From Fable the only move is **down**: hand well-scoped execution to a cheaper model under a rulebook. There is no move up.
+
+## The Rule
+
+- **Fable is the default and the top rung.** Exploration, planning, stewardship, anything hard or high-stakes: it starts on Fable and stays on Fable.
+- **Opus is not the escalation.** "This is important, escalate to Opus" is a category error under this ruling — Opus sits *below* Fable on the ladder, not beside it and not above it.
+- **Escalation runs downward only.** From Fable, delegate well-scoped, rulebook-governed execution down to cheaper tiers (Sonnet, Haiku). If a task is too hard for the tier it's on, it comes back **up to Fable**, never sideways to Opus.
+
+## Why
+
+This mirrors the shallow star in `klappy://canon/methods/discernment-transfer-ladder`: the frontier authors the rulebook, lesser models run it. This ruling sharpens the ladder's rung order — where the transfer-ladder method named "Fable, Opus" jointly as the frontier, the captain's ruling fixes the order *within* that band: Fable writes the rulebook; every other model, Opus included, is a candidate to run one.
+
+## How to Apply
+
+Picking a model for a flight is a one-question test: **is this well-scoped execution with a rulebook?** If yes, the cheapest tier that clears the fidelity bar (per the transfer ladder). If no — judgment, authorship, ambiguity, stakes — Fable, full stop.

--- a/canon/defaults/reasoning-effort-low-default.md
+++ b/canon/defaults/reasoning-effort-low-default.md
@@ -1,0 +1,31 @@
+---
+uri: klappy://canon/defaults/reasoning-effort-low-default
+kind: canon
+title: "Reasoning Effort Defaults Low; Escalate on Importance"
+audience: canon
+exposure: nav
+tier: 2
+voice: neutral
+stability: stable
+tags: ["canon", "defaults", "reasoning-effort", "cost", "dispatch", "otto", "harness", "harness-gap"]
+epoch: E0010
+date: 2026-07-11
+derives_from: "canon/constraints/mode-discipline-and-bottleneck-respect.md, canon/defaults/model-ladder-fable-ceiling.md"
+complements: "canon/bootstrap/otto-operating-card.md"
+governs: "The reasoning-effort setting for the dispatch seat and its flights: the default level and what justifies raising it."
+target_repo: "outcomes-driven-development"
+---
+
+# Reasoning Effort Defaults Low; Escalate on Importance
+
+> Captain's ruling, 2026-07-11. Reasoning effort starts at **LOW** and is raised deliberately when the work's importance warrants it — never left high out of habit. Thinking budget is spent where the stakes are.
+
+## The Rule
+
+- **Default: LOW.** Routine dispatch, well-scoped execution, mechanical work — low effort is the standing setting.
+- **Escalate on importance, explicitly.** Hard problems, high-stakes calls, stewardship work (authoring rulebooks, canon changes, irreversibles) justify medium/high effort. The escalation is a decision, not a residue of the last task's setting.
+- **Effort and model are independent dials.** The model ladder (`klappy://canon/defaults/model-ladder-fable-ceiling`) picks *who* thinks; this default picks *how hard*. A Fable flight at low effort is a normal, cheap, correct configuration for most turns.
+
+## The Harness Gap (owed request)
+
+As of 2026-07-11 the Cowork dispatch tools expose a per-flight `model` parameter but **no per-flight `effort` parameter** — effort is settable only project-wide via `settings.json` / environment today. That means this default can be *set globally* but not *escalated per flight* from the dispatch seat. This is recorded as an **owed harness request**: per-flight reasoning-effort control on the dispatch tools. Until it lands, the workable posture is: project-wide low, and escalate by briefing the flight to think harder (or by routing the important task to a session configured higher).

--- a/docs/oddkit/release-notes/2026-07-11-standing-rulings-into-canon.md
+++ b/docs/oddkit/release-notes/2026-07-11-standing-rulings-into-canon.md
@@ -1,0 +1,36 @@
+---
+uri: klappy://docs/oddkit/release-notes/2026-07-11-standing-rulings-into-canon
+title: "Release Notes — Standing Rulings Promoted to Canon (2026-07-11): Four Rules Move from Otto's Memory to Policy"
+audience: docs
+exposure: nav
+tier: 2
+voice: neutral
+stability: stable
+tags: ["docs", "oddkit", "release-notes", "otto", "operating-card", "model-ladder", "reasoning-effort", "self-merge", "intent", "canon-promotion"]
+epoch: E0010
+date: 2026-07-11
+derives_from: "canon/bootstrap/otto-operating-card.md, canon/constraints/governance-change-discipline.md"
+governs: "How the dispatch seat and its flights orient to the four promoted rulings after this merges"
+target_repo: "undecided"
+---
+
+# Release Notes — Standing Rulings Promoted to Canon (2026-07-11)
+
+## What this changes
+
+Four standing rulings the captain issued in-session now live in canon instead of Otto's per-session memory, and the Otto Operating Card — fetched live and injected every turn — points to each. Session memory is lossy by design; the per-turn card is not. Rules belong in policy, not memory.
+
+## The four rulings
+
+1. **Fable is the ceiling; Opus is never the escalation** (`klappy://canon/defaults/model-ladder-fable-ceiling`). Hard/high-stakes work stays on Fable. From Fable, delegate *down* to cheaper models for well-scoped execution under a rulebook — never up to Opus.
+2. **Reasoning effort defaults LOW; escalate on importance** (`klappy://canon/defaults/reasoning-effort-low-default`). Effort is a deliberate dial, not a residue. The entry also records an owed harness request: Cowork dispatch tools expose per-flight `model` but no per-flight `effort` (project-wide settings.json/env only today).
+3. **Clear intent-aligned fixes proceed without gating on the captain** (`klappy://canon/constraints/intent-aligned-fixes-proceed`). Obvious + aligned + low-risk → act. Confirm-first is reserved for real forks, irreversibles, and authorial voice.
+4. **PRs are hygiene, not a hold** (`klappy://canon/constraints/prs-are-hygiene-not-a-hold`). Crew opens and self-merges green PRs; a green PR never parks on the captain's desk. Red or confirm-first-class changes still escalate.
+
+## What Otto does after this lands
+
+Nothing to remember — that is the point. The operating card (`klappy://canon/bootstrap/otto-operating-card`) now carries rules 6–9 as one-line pointers, so every turn re-surfaces them at the freshest context position. The card restates nothing; the full law lives in the four entries above.
+
+## The honest limit
+
+Ruling 2 is settable but not steerable: until the harness exposes per-flight effort, the low default applies project-wide and escalation happens by briefing the flight or routing to a higher-configured session. The owed harness request is recorded in the canon entry itself.


### PR DESCRIPTION
## What

Promotes four of the captain's standing rulings (2026-07-11) out of Otto's lossy per-session memory into durable canon, fetched live per turn via the operating card. Rules belong in policy, not memory.

## New canon entries

- `klappy://canon/defaults/model-ladder-fable-ceiling` — Fable is the superior/default model and the ceiling; Opus is inferior and never the escalation; from Fable delegate down only (mirrors the discernment-transfer-ladder shallow star).
- `klappy://canon/defaults/reasoning-effort-low-default` — reasoning effort defaults LOW, escalates on importance; records the owed harness request (Cowork dispatch tools expose per-flight `model` but not per-flight `effort`).
- `klappy://canon/constraints/intent-aligned-fixes-proceed` — obvious, intent-aligned, low-risk fixes proceed without gating on the captain; confirm-first reserved for real forks, irreversibles, authorial voice.
- `klappy://canon/constraints/prs-are-hygiene-not-a-hold` — crew opens and self-merges green PRs; a green PR never parks on the captain.

## Changed

- **Otto Operating Card** (`canon/bootstrap/otto-operating-card.md`): adds 'The Rulings (2026-07-11)' (rules 6–9) as one-line pointers — DRY, no restated law. Retitled 'Five Standing Rules' → 'Standing Rules'.
- **Canon pack 0.42.0** with changelog entry and release notes per `governance-change-discipline`. No epoch bump (hardens E0010 posture; who-initiates unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior-affecting tier-1/2 canon changes crew autonomy (self-merge, skip confirm-first) and model routing; mistakes could merge or act without captain review, though escalations for red CI and confirm-first cases remain explicit.
> 
> **Overview**
> **Canon pack 0.42.0** moves four captain rulings (2026-07-11) out of Otto's session memory into durable policy, with **release notes** and a **changelog** entry per governance discipline. Thesis: rules live in canon and the per-turn operating card, not in lossy memory.
> 
> **Four new entries:** **Fable as model ceiling** (delegate down only; Opus is never the escalation for hard work), **reasoning effort defaults LOW** (raise on importance; documents missing per-flight `effort` on dispatch tools as an owed harness request), **intent-aligned obvious low-risk fixes proceed** without captain gating (confirm-first only for forks, irreversibles, authorial voice), and **green PRs are crew hygiene** (open, CI-gated, self-merge when green—don't park on the captain).
> 
> **`otto-operating-card.md`** is retitled from "Five Standing Rules" to **Standing Rules**, gains **The Rulings (2026-07-11)** as rules 6–9 (one-line pointers, DRY), and extended `complements` frontmatter. No epoch bump—hardens existing E0010 flight-crew posture.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8c465bde1e28024de55f010726a072b75dfe716. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->